### PR TITLE
Add Secret Manager Secret Accessor role to docs

### DIFF
--- a/.agent_process/requirements/backend-integration-plan.md
+++ b/.agent_process/requirements/backend-integration-plan.md
@@ -753,6 +753,8 @@ These steps must be done once per environment and cannot be fully automated:
      - **Service Account User** - Allow functions to run as service account
      - **Cloud Datastore User** - Read/write Firestore data
      - **Storage Admin** - Manage Firebase Storage
+     - **Firebase Admin** - Access Firebase Extensions API
+     - **Secret Manager Secret Accessor** - Read secrets during deployment
 
    Or via CLI:
    ```bash
@@ -764,6 +766,8 @@ These steps must be done once per environment and cannot be fully automated:
    gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$SA_EMAIL" --role="roles/iam.serviceAccountUser"
    gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$SA_EMAIL" --role="roles/datastore.user"
    gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$SA_EMAIL" --role="roles/storage.admin"
+   gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$SA_EMAIL" --role="roles/firebase.admin"
+   gcloud projects add-iam-policy-binding $PROJECT --member="serviceAccount:$SA_EMAIL" --role="roles/secretmanager.secretAccessor"
    ```
 
 7. **Add GitHub Secrets**

--- a/docs/how-to/firebase-setup.md
+++ b/docs/how-to/firebase-setup.md
@@ -168,6 +168,7 @@ The service account needs these roles in [Google Cloud IAM](https://console.clou
 | **Cloud Datastore User** | Read/write Firestore data |
 | **Storage Admin** | Manage Firebase Storage |
 | **Firebase Admin** | Access Firebase Extensions API (required for deployments) |
+| **Secret Manager Secret Accessor** | Read secrets (like GEMINI_API_KEY) during deployment |
 
 Via CLI:
 
@@ -198,6 +199,10 @@ gcloud projects add-iam-policy-binding $PROJECT \
 gcloud projects add-iam-policy-binding $PROJECT \
   --member="serviceAccount:$SA_EMAIL" \
   --role="roles/firebase.admin"
+
+gcloud projects add-iam-policy-binding $PROJECT \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/secretmanager.secretAccessor"
 ```
 
 ### 3. Add GitHub Secrets


### PR DESCRIPTION
## Summary
Add missing IAM role for secret access during Cloud Functions deployment.

## Problem
Firebase deploy was failing with:
```
Permission 'secretmanager.secrets.get' denied for resource 'projects/.../secrets/GEMINI_API_KEY'
```

## Solution
Document that the service account needs **Secret Manager Secret Accessor** role to read secrets during deployment.

## Changes
- Updated `docs/how-to/firebase-setup.md` with the new role
- Updated `.agent_process/requirements/backend-integration-plan.md`