### PR TITLE
fix: remove whitespace from gcloud substitutions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,16 +77,7 @@ jobs:
         run: |
           gcloud builds submit \
             --config=cloudbuild.yaml \
-            --substitutions="\
-              _IMAGE_NAME=gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ env.FRONTEND_SERVICE }},\
-              _TAG=${{ github.sha }},\
-              _VITE_FIREBASE_API_KEY=${{ secrets.VITE_FIREBASE_API_KEY }},\
-              _VITE_FIREBASE_AUTH_DOMAIN=${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }},\
-              _VITE_FIREBASE_PROJECT_ID=${{ secrets.VITE_FIREBASE_PROJECT_ID }},\
-              _VITE_FIREBASE_STORAGE_BUCKET=${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }},\
-              _VITE_FIREBASE_MESSAGING_SENDER_ID=${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }},\
-              _VITE_FIREBASE_APP_ID=${{ secrets.VITE_FIREBASE_APP_ID }},\
-              _VITE_ALIGNMENT_SERVICE_URL=${{ secrets.ALIGNMENT_SERVICE_URL }}" \
+            --substitutions="_IMAGE_NAME=gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ env.FRONTEND_SERVICE }},_TAG=${{ github.sha }},_VITE_FIREBASE_API_KEY=${{ secrets.VITE_FIREBASE_API_KEY }},_VITE_FIREBASE_AUTH_DOMAIN=${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }},_VITE_FIREBASE_PROJECT_ID=${{ secrets.VITE_FIREBASE_PROJECT_ID }},_VITE_FIREBASE_STORAGE_BUCKET=${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }},_VITE_FIREBASE_MESSAGING_SENDER_ID=${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }},_VITE_FIREBASE_APP_ID=${{ secrets.VITE_FIREBASE_APP_ID }},_VITE_ALIGNMENT_SERVICE_URL=${{ secrets.ALIGNMENT_SERVICE_URL }}" \
             --quiet
 
       # -----------------------------------------------------------------------


### PR DESCRIPTION
The multi-line substitutions had leading spaces that were being included in the key names, causing Cloud Build to fail with 'key not matched in template' errors.