### PR TITLE
fix: use correct Vite env var pattern for alignment service URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,13 +31,14 @@ ARG VITE_ALIGNMENT_SERVICE_URL
 
 # Create .env file for Vite to read during build
 # Vite automatically exposes VITE_* prefixed vars to the client
+# IMPORTANT: All client-accessible vars MUST have VITE_ prefix
 RUN echo "VITE_FIREBASE_API_KEY=${VITE_FIREBASE_API_KEY}" > .env && \
     echo "VITE_FIREBASE_AUTH_DOMAIN=${VITE_FIREBASE_AUTH_DOMAIN}" >> .env && \
     echo "VITE_FIREBASE_PROJECT_ID=${VITE_FIREBASE_PROJECT_ID}" >> .env && \
     echo "VITE_FIREBASE_STORAGE_BUCKET=${VITE_FIREBASE_STORAGE_BUCKET}" >> .env && \
     echo "VITE_FIREBASE_MESSAGING_SENDER_ID=${VITE_FIREBASE_MESSAGING_SENDER_ID}" >> .env && \
     echo "VITE_FIREBASE_APP_ID=${VITE_FIREBASE_APP_ID}" >> .env && \
-    echo "ALIGNMENT_SERVICE_URL=${VITE_ALIGNMENT_SERVICE_URL}" >> .env
+    echo "VITE_ALIGNMENT_SERVICE_URL=${VITE_ALIGNMENT_SERVICE_URL}" >> .env
 
 # Build the application
 RUN npm run build

--- a/services/alignmentService.ts
+++ b/services/alignmentService.ts
@@ -2,20 +2,17 @@ import { Conversation, Segment } from '../types';
 
 /**
  * Configuration for the alignment service
- * Uses process.env which is defined by Vite at build time
+ * Vite exposes env vars with VITE_ prefix via import.meta.env
  */
-declare const process: { env: { ALIGNMENT_SERVICE_URL?: string } };
-
-// Empty string is falsy in JS, so we need explicit check
-const configuredUrl = process.env.ALIGNMENT_SERVICE_URL;
+const configuredUrl = import.meta.env.VITE_ALIGNMENT_SERVICE_URL;
 const ALIGNMENT_SERVICE_URL = (configuredUrl && configuredUrl.trim() !== '')
   ? configuredUrl
   : 'http://localhost:8080';
 
-// Debug logging in production to help diagnose deployment issues
+// Debug logging to help diagnose deployment issues
 if (typeof window !== 'undefined') {
   console.log('[AlignmentService] Configured URL:', ALIGNMENT_SERVICE_URL);
-  console.log('[AlignmentService] Raw env value:', JSON.stringify(process.env.ALIGNMENT_SERVICE_URL));
+  console.log('[AlignmentService] Raw env value:', JSON.stringify(configuredUrl));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixed alignment service URL not propagating to client code after Cloud Run migration
- Dockerfile now writes `VITE_ALIGNMENT_SERVICE_URL` (was missing `VITE_` prefix)
- alignmentService.ts now uses `import.meta.env` instead of `process.env`

## Root Cause
Vite only exposes environment variables with the `VITE_` prefix to client bundles. The Dockerfile was writing `ALIGNMENT_SERVICE_URL` without the prefix, and the client code was using Node.js-style `process.env` instead of Vite's `import.meta.env`.

Result: The alignment service URL always fell back to `localhost:8080` in production, breaking the "Improve Timestamps" feature.

## Test plan
- [ ] Deploy to Cloud Run
- [ ] Open browser console and verify `[AlignmentService] Configured URL:` shows the production URL (not localhost)
- [ ] Test "Improve Timestamps" button on a conversation