### PR TITLE
fix: use printf to avoid newlines in Firebase secrets

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -95,13 +95,14 @@ jobs:
         run: npm run build
 
       # Set Firebase Function Secrets (only when deploying functions)
+      # Note: Using printf instead of echo to avoid trailing newlines in secrets
       - name: Set Firebase Function Secrets
         if: github.event.inputs.deploy_target != 'rules-only'
         run: |  # pragma: allowlist secret
           echo "Setting Firebase Function secrets..."
-          echo "${{ secrets.GEMINI_API_KEY }}" | firebase functions:secrets:set GEMINI_API_KEY --force
-          echo "${{ secrets.REPLICATE_API_TOKEN }}" | firebase functions:secrets:set REPLICATE_API_TOKEN --force
-          echo "${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}" | firebase functions:secrets:set HUGGINGFACE_ACCESS_TOKEN --force
+          printf '%s' "${{ secrets.GEMINI_API_KEY }}" | firebase functions:secrets:set GEMINI_API_KEY --force
+          printf '%s' "${{ secrets.REPLICATE_API_TOKEN }}" | firebase functions:secrets:set REPLICATE_API_TOKEN --force
+          printf '%s' "${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}" | firebase functions:secrets:set HUGGINGFACE_ACCESS_TOKEN --force
           echo "✅ Firebase secrets configured"
 
       # Deploy based on target


### PR DESCRIPTION
## Summary

Fixes the `Invalid header value b'Bearer \n'` error in WhisperX API calls.

**Problem:** The `echo` command adds a trailing newline when piping secrets to Firebase, corrupting the API token.

**Fix:** Use `printf '%s'` instead, which outputs exactly what you give it without adding newlines.

### Changes

```diff
- echo "${{ secrets.REPLICATE_API_TOKEN }}" | firebase functions:secrets:set ...
+ printf '%s' "${{ secrets.REPLICATE_API_TOKEN }}" | firebase functions:secrets:set ...
```

## Test Plan

- [ ] Merge and let firebase-deploy workflow run
- [ ] Upload audio file
- [ ] Verify WhisperX call succeeds (no auth errors)
- [ ] Verify speaker correction runs
