### PR TITLE
feat: single-project architecture with self-healing CI/CD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@
 VITE_FIREBASE_API_KEY=your_firebase_api_key_here
 VITE_FIREBASE_AUTH_DOMAIN=your-project-id.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=your-project-id
-VITE_FIREBASE_STORAGE_BUCKET=your-project-id.appspot.com
+VITE_FIREBASE_STORAGE_BUCKET=your-project-id.firebasestorage.app
 VITE_FIREBASE_MESSAGING_SENDER_ID=123456789012
 VITE_FIREBASE_APP_ID=1:123456789012:web:abcdef1234567890
 
@@ -31,8 +31,10 @@ VITE_FIREBASE_APP_ID=1:123456789012:web:abcdef1234567890
 # -----------------------------------------------------------------------------
 
 # The Gemini API key is stored as a Firebase secret, NOT in this file.
-# Set it once via: npx firebase functions:secrets:set GEMINI_API_KEY
-# Get your key at: https://makersuite.google.com/app/apikey
+# The setup script (gcp-setup.sh) can create this automatically, or create manually:
+#   1. GCP Console: APIs & Services → Credentials → Create API Key
+#   2. Restrict to "Generative Language API" for security
+#   3. Store in Firebase: npx firebase functions:secrets:set GEMINI_API_KEY
 
 # -----------------------------------------------------------------------------
 # Development Configuration
@@ -46,7 +48,9 @@ VITE_USE_FIREBASE_EMULATORS=false
 # -----------------------------------------------------------------------------
 
 # Google Cloud Project ID (required)
-GCP_PROJECT_ID=your-gcp-project-id
+# IMPORTANT: Use the SAME project ID as your Firebase project above.
+# This app uses a single project for both Cloud Run (frontend) and Firebase (backend).
+GCP_PROJECT_ID=your-project-id
 
 # Cloud Run region (optional, defaults to us-west1)
 GCP_REGION=us-west1

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -94,6 +94,52 @@ jobs:
         working-directory: functions
         run: npm run build
 
+      # Configure service agent IAM bindings (required for Cloud Functions v2 with Storage triggers)
+      # These service agents are created lazily, so we configure them on every deploy to ensure they exist
+      - name: Configure Service Agent IAM Bindings
+        if: github.event.inputs.deploy_target != 'rules-only'
+        run: |
+          echo "Configuring service agent IAM bindings..."
+          PROJECT_ID="${{ env.FIREBASE_PROJECT_ID }}"
+          PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format="value(projectNumber)")
+
+          # Helper function to add binding if SA exists
+          add_binding_if_exists() {
+            local sa_email="$1"
+            local role="$2"
+            local desc="$3"
+
+            if gcloud iam service-accounts describe "$sa_email" --project="$PROJECT_ID" &>/dev/null; then
+              gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+                --member="serviceAccount:$sa_email" \
+                --role="$role" \
+                --condition=None \
+                --quiet > /dev/null 2>&1 || true
+              echo "  ✓ $desc"
+            else
+              echo "  ⊘ $desc (service agent not yet created)"
+            fi
+          }
+
+          # Runtime service account → Secret accessor
+          RUNTIME_SA="${PROJECT_ID}@appspot.gserviceaccount.com"
+          add_binding_if_exists "$RUNTIME_SA" "roles/secretmanager.secretAccessor" "Runtime SA → Secret Accessor"
+
+          # Storage service agent → Pub/Sub publisher (for storage triggers)
+          STORAGE_SA="service-${PROJECT_NUMBER}@gs-project-accounts.iam.gserviceaccount.com"
+          add_binding_if_exists "$STORAGE_SA" "roles/pubsub.publisher" "Storage Agent → Pub/Sub Publisher"
+
+          # Pub/Sub service agent → Token creator (for authenticated push)
+          PUBSUB_SA="service-${PROJECT_NUMBER}@gcp-sa-pubsub.iam.gserviceaccount.com"
+          add_binding_if_exists "$PUBSUB_SA" "roles/iam.serviceAccountTokenCreator" "Pub/Sub Agent → Token Creator"
+
+          # Compute service agent → Cloud Run invoker + event receiver
+          COMPUTE_SA="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+          add_binding_if_exists "$COMPUTE_SA" "roles/run.invoker" "Compute Agent → Run Invoker"
+          add_binding_if_exists "$COMPUTE_SA" "roles/eventarc.eventReceiver" "Compute Agent → Event Receiver"
+
+          echo "✅ Service agent bindings configured"
+
       # Set Firebase Function Secrets (only when deploying functions)
       # Note: Using printf instead of echo to avoid trailing newlines in secrets
       # Only sets secrets that are non-empty to avoid "Secret Payload cannot be empty" errors

--- a/docs/how-to/deploy.md
+++ b/docs/how-to/deploy.md
@@ -12,11 +12,37 @@ Deploy the Audio Transcript Analysis App to production.
 
 **Note:** Frontend and Firebase Functions deploy in parallel on merge to main (~3-4 min total).
 
+## Single Project Architecture
+
+This app uses a **single GCP/Firebase project** for all components:
+
+- **Frontend**: Cloud Run (static React app served via nginx)
+- **Backend**: Firebase Cloud Functions (transcription processing)
+- **Database**: Cloud Firestore
+- **Storage**: Firebase Storage (audio files)
+- **Auth**: Firebase Authentication
+
+Using one project simplifies billing, IAM, and service integration. The same project ID is used for both `gcloud` (Cloud Run) and `firebase` (Functions, Firestore, Storage) commands.
+
 ## Prerequisites
 
 - Firebase project set up ([Firebase Setup Guide](firebase-setup.md))
 - GitHub repository with Actions enabled
 - Required secrets configured
+
+### Quick Setup with Automated Script
+
+The easiest way to set up everything (including Workload Identity for Cloud Run) is the automated script:
+
+```bash
+# Full setup with GitHub CI/CD integration
+./scripts/gcp-setup.sh <project-id> <billing-account-id> <github-org/repo>
+
+# Example:
+./scripts/gcp-setup.sh my-app-12345 01A2B3-C4D5E6-F7G8H9 myorg/my-repo
+```
+
+This configures both Firebase and Cloud Run deployment in a single project. See [Firebase Setup Guide](firebase-setup.md) for details.
 
 ## Automatic Deployment (CI/CD)
 
@@ -37,20 +63,29 @@ Triggered when Firebase files change:
 - `firestore.indexes.json`
 - `firebase.json`
 
+The workflow automatically configures required service agent IAM bindings before each deployment, so you don't need to manually run any setup scripts after the initial project creation.
+
 ## GitHub Secrets Required
 
 Configure in **Settings → Secrets and variables → Actions**:
 
-### For Cloud Run Deployment
+### Project Configuration
 
 | Secret | Description |
 |--------|-------------|
-| `GCP_PROJECT_ID` | Your GCP project ID |
-| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity provider |
-| `GCP_SERVICE_ACCOUNT` | Service account email |
+| `GCP_PROJECT_ID` | Your Firebase/GCP project ID (same for frontend and backend) |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity Federation provider (see setup below) |
+| `GCP_SERVICE_ACCOUNT` | Service account email for GitHub Actions |
+
+> **Important**: `GCP_PROJECT_ID` must be the **same project** as your Firebase project. This ensures Cloud Run, Cloud Functions, Firestore, and Storage all share the same billing and IAM configuration.
+
+### Firebase Config (Frontend Build)
+
+| Secret | Description |
+|--------|-------------|
 | `VITE_FIREBASE_API_KEY` | Firebase API key (from `firebase apps:sdkconfig`) |
 | `VITE_FIREBASE_AUTH_DOMAIN` | Firebase auth domain (e.g., `project-id.firebaseapp.com`) |
-| `VITE_FIREBASE_PROJECT_ID` | Firebase project ID |
+| `VITE_FIREBASE_PROJECT_ID` | Firebase project ID (same as `GCP_PROJECT_ID`) |
 | `VITE_FIREBASE_STORAGE_BUCKET` | Storage bucket (e.g., `project-id.firebasestorage.app`) |
 | `VITE_FIREBASE_MESSAGING_SENDER_ID` | Messaging sender ID (project number) |
 | `VITE_FIREBASE_APP_ID` | Firebase app ID |
@@ -63,11 +98,21 @@ These secrets are stored in Firebase Secret Manager, not GitHub:
 
 | Secret | Description | Setup Command |
 |--------|-------------|---------------|
-| `GEMINI_API_KEY` | Google AI Studio API key | `npx firebase functions:secrets:set GEMINI_API_KEY` |
+| `GEMINI_API_KEY` | Gemini API key (create in GCP project) | `npx firebase functions:secrets:set GEMINI_API_KEY` |
 | `REPLICATE_API_TOKEN` | Replicate API token for WhisperX | `npx firebase functions:secrets:set REPLICATE_API_TOKEN` |
 
-**Important:** Set these secrets before the first deployment:
+**Important:** The setup script (`gcp-setup.sh`) can create the Gemini API key automatically within your project. If setting manually:
+
 ```bash
+PROJECT_ID="your-project-id"
+
+# Create Gemini API key in your project
+gcloud services api-keys create \
+  --project=$PROJECT_ID \
+  --display-name="gemini-api-key" \
+  --api-target=service=generativelanguage.googleapis.com
+
+# Store in Firebase secrets
 npx firebase functions:secrets:set GEMINI_API_KEY
 npx firebase functions:secrets:set REPLICATE_API_TOKEN
 ```
@@ -83,13 +128,120 @@ firebase apps:sdkconfig WEB --project=your-project-id
 |--------|-------------|
 | `FIREBASE_SERVICE_ACCOUNT` | Firebase service account JSON |
 
+## Workload Identity Federation Setup
+
+Cloud Run deployment uses Workload Identity Federation for secure, keyless authentication from GitHub Actions. This must be configured in the **same project** as your Firebase backend.
+
+> **Tip**: The automated setup script handles all of this:
+> ```bash
+> ./scripts/gcp-setup.sh <project-id> <billing-account-id> <github-org/repo>
+> ```
+> Only follow the manual steps below if you need to set up Workload Identity separately.
+
+### Enable Required APIs
+
+```bash
+PROJECT_ID="your-project-id"
+
+gcloud services enable run.googleapis.com --project=$PROJECT_ID
+gcloud services enable cloudbuild.googleapis.com --project=$PROJECT_ID
+gcloud services enable containerregistry.googleapis.com --project=$PROJECT_ID
+gcloud services enable artifactregistry.googleapis.com --project=$PROJECT_ID
+gcloud services enable iamcredentials.googleapis.com --project=$PROJECT_ID
+```
+
+### Create Workload Identity Pool
+
+```bash
+PROJECT_ID="your-project-id"
+
+# Create the identity pool
+gcloud iam workload-identity-pools create "github-pool" \
+  --project=$PROJECT_ID \
+  --location="global" \
+  --display-name="GitHub Actions Pool"
+
+# Create OIDC provider for GitHub
+# GITHUB_ORG should be your GitHub organization or username (e.g., "myorg" from "myorg/repo")
+GITHUB_ORG="your-github-org"
+
+gcloud iam workload-identity-pools providers create-oidc "github-provider" \
+  --project=$PROJECT_ID \
+  --location="global" \
+  --workload-identity-pool="github-pool" \
+  --display-name="GitHub Provider" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+  --attribute-condition="assertion.repository_owner=='${GITHUB_ORG}'" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+```
+
+> **Security Note**: The `--attribute-condition` restricts which GitHub repositories can authenticate. Only repos owned by `GITHUB_ORG` can use this Workload Identity Pool.
+
+### Create Service Account for GitHub Actions
+
+```bash
+PROJECT_ID="your-project-id"
+
+# Create service account
+gcloud iam service-accounts create github-actions \
+  --project=$PROJECT_ID \
+  --display-name="GitHub Actions CI/CD"
+
+SA_EMAIL="github-actions@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# Grant Cloud Run deployment permissions
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/run.admin"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/cloudbuild.builds.builder"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/storage.admin"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/iam.serviceAccountUser"
+```
+
+### Allow GitHub to Impersonate Service Account
+
+```bash
+PROJECT_ID="your-project-id"
+GITHUB_REPO="your-org/your-repo"
+
+PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)")
+SA_EMAIL="github-actions@${PROJECT_ID}.iam.gserviceaccount.com"
+
+gcloud iam service-accounts add-iam-policy-binding $SA_EMAIL \
+  --project=$PROJECT_ID \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github-pool/attribute.repository/${GITHUB_REPO}"
+```
+
+### Get Values for GitHub Secrets
+
+```bash
+PROJECT_ID="your-project-id"
+PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)")
+
+echo "GCP_PROJECT_ID: $PROJECT_ID"
+echo "GCP_SERVICE_ACCOUNT: github-actions@${PROJECT_ID}.iam.gserviceaccount.com"
+echo "GCP_WORKLOAD_IDENTITY_PROVIDER: projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+```
+
 ## Manual Deployment
 
 ### Deploy Everything
 
 ```bash
+PROJECT_ID="your-project-id"
+
 # Deploy Firebase (rules + functions)
-npx firebase deploy
+npx firebase deploy --project=$PROJECT_ID
 
 # Deploy frontend to Cloud Run
 ./deploy.sh
@@ -98,16 +250,20 @@ npx firebase deploy
 ### Deploy Specific Components
 
 ```bash
+PROJECT_ID="your-project-id"
+REGION="us-west1"
+
 # Security rules only
-npx firebase deploy --only firestore:rules,storage:rules
+npx firebase deploy --only firestore:rules,storage:rules --project=$PROJECT_ID
 
 # Cloud Functions only
-npx firebase deploy --only functions
+npx firebase deploy --only functions --project=$PROJECT_ID
 
-# Frontend only
+# Frontend only (to the same project as Firebase)
 gcloud run deploy audio-transcript-app \
+  --project=$PROJECT_ID \
+  --region=$REGION \
   --source . \
-  --region us-west1 \
   --allow-unauthenticated
 ```
 
@@ -135,33 +291,41 @@ gcloud run deploy audio-transcript-app \
 ### Check Cloud Run
 
 ```bash
+PROJECT_ID="your-project-id"
+REGION="us-west1"
+
 # List services
-gcloud run services list
+gcloud run services list --project=$PROJECT_ID
 
 # Get service URL
 gcloud run services describe audio-transcript-app \
-  --region us-west1 \
+  --project=$PROJECT_ID \
+  --region=$REGION \
   --format="value(status.url)"
 ```
 
 ### Check Firebase Functions
 
 ```bash
+PROJECT_ID="your-project-id"
+
 # List deployed functions
-npx firebase functions:list
+npx firebase functions:list --project=$PROJECT_ID
 
 # View function logs
-npx firebase functions:log
+npx firebase functions:log --project=$PROJECT_ID
 ```
 
 ### Health Checks
 
 ```bash
+PROJECT_ID="your-project-id"
+
 # Frontend
 curl https://your-app-url.run.app/health
 
 # Functions (check logs after upload)
-npx firebase functions:log --only transcribeAudio
+npx firebase functions:log --only transcribeAudio --project=$PROJECT_ID
 ```
 
 ## Rollback
@@ -169,11 +333,19 @@ npx firebase functions:log --only transcribeAudio
 ### Cloud Run
 
 ```bash
+PROJECT_ID="your-project-id"
+REGION="us-west1"
+
 # List revisions
-gcloud run revisions list --service audio-transcript-app
+gcloud run revisions list \
+  --service audio-transcript-app \
+  --project=$PROJECT_ID \
+  --region=$REGION
 
 # Rollback to previous revision
 gcloud run services update-traffic audio-transcript-app \
+  --project=$PROJECT_ID \
+  --region=$REGION \
   --to-revisions=REVISION_NAME=100
 ```
 
@@ -182,8 +354,10 @@ gcloud run services update-traffic audio-transcript-app \
 Firebase keeps previous versions. Redeploy from a previous commit:
 
 ```bash
+PROJECT_ID="your-project-id"
+
 git checkout <previous-commit>
-npx firebase deploy --only functions
+npx firebase deploy --only functions --project=$PROJECT_ID
 ```
 
 ## Cost Optimization
@@ -287,5 +461,11 @@ Firebase Auth only allows sign-in from pre-approved domains. After deploying to 
 
 > **Tip**: Get your Cloud Run URL with:
 > ```bash
-> gcloud run services describe audio-transcript-app --region=us-west1 --format="value(status.url)"
+> PROJECT_ID="your-project-id"
+> REGION="us-west1"
+>
+> gcloud run services describe audio-transcript-app \
+>   --project=$PROJECT_ID \
+>   --region=$REGION \
+>   --format="value(status.url)"
 > ```

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -34,6 +34,23 @@ cd functions && npm install && cd ..
 
 ## Step 3: Set Up Firebase
 
+**Option A: Automated Setup (Recommended)**
+
+Use the setup script to configure everything in one command:
+
+```bash
+# Find your billing account ID
+gcloud billing accounts list
+
+# Run setup (optionally include GitHub repo for CI/CD)
+./scripts/gcp-setup.sh <project-id> <billing-account-id> [github-org/repo]
+
+# Example:
+./scripts/gcp-setup.sh my-app-12345 01A2B3-C4D5E6-F7G8H9 myorg/my-repo
+```
+
+**Option B: Manual Setup**
+
 Follow the complete [Firebase Setup Guide](../how-to/firebase-setup.md) to:
 
 1. Create a Firebase project
@@ -43,7 +60,7 @@ Follow the complete [Firebase Setup Guide](../how-to/firebase-setup.md) to:
 5. Register your web app
 6. Configure environment variables
 
-**Quick summary:**
+**After setup (both options):**
 
 ```bash
 # Copy environment template
@@ -51,18 +68,29 @@ cp .env.example .env
 
 # Edit .env with your Firebase config
 # (Get values from Firebase Console → Project Settings → Your apps)
+# IMPORTANT: Set GCP_PROJECT_ID to the same value as VITE_FIREBASE_PROJECT_ID
 ```
 
 ## Step 4: Configure Gemini API
 
-1. Get a Gemini API key from [Google AI Studio](https://makersuite.google.com/app/apikey)
-2. Set it as a Firebase secret:
+If you ran the automated setup script (`gcp-setup.sh`) with "y" when prompted, the Gemini API key was created automatically. Otherwise, create one in your GCP project:
 
 ```bash
+PROJECT_ID="your-project-id"
+
+# Create API key restricted to Gemini
+gcloud services api-keys create \
+  --project=$PROJECT_ID \
+  --display-name="gemini-api-key" \
+  --api-target=service=generativelanguage.googleapis.com
+
+# Store in Firebase secrets
 npx firebase login
-npx firebase use your-project-id
+npx firebase use $PROJECT_ID
 npx firebase functions:secrets:set GEMINI_API_KEY
 ```
+
+Or via Console: [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials) → **Create Credentials** → **API key**
 
 ## Step 5: Deploy Firebase Backend
 


### PR DESCRIPTION
## Summary

- **Single-project architecture**: Consolidate Cloud Run frontend and Firebase backend into one GCP project for simpler billing, IAM, and service integration
- **Self-healing CI/CD**: GitHub workflow auto-configures service agent IAM bindings on each deploy
- **In-project Gemini API key**: Create API keys within the project instead of via Google AI Studio

## Changes

### Setup Script (`gcp-setup.sh`)
- Add Workload Identity Federation setup for GitHub Actions (keyless auth)
- Create Gemini API key in-project with `generativelanguage.googleapis.com` restriction
- Add service account propagation waits (handles GCP eventual consistency)
- Add `--attribute-condition` for OIDC provider security
- Enable `generativelanguage.googleapis.com` and `apikeys.googleapis.com` APIs

### CI/CD (`firebase-deploy.yml`)
- Auto-configure service agent IAM bindings before each deploy
- Handles lazy service agent creation gracefully

### Documentation
- Single-project architecture guidance across all setup docs
- In-project Gemini API key creation instructions
- Updated API tables and CLI commands with explicit `--project` flags

## Test plan

- [ ] Run `gcp-setup.sh` on a fresh project to verify full setup flow
- [ ] Verify GitHub Actions workflow deploys successfully
- [ ] Confirm Gemini API key is created and stored in Secret Manager
- [ ] Test Workload Identity Federation auth from GitHub Actions