### PR TITLE
fix: use GCP_PROJECT_ID secret for Firebase deploy

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -9,6 +9,7 @@
 #   - Manual dispatch (for ad-hoc deployments)
 #
 # Required GitHub Secrets:
+#   - GCP_PROJECT_ID: Firebase/GCP project ID (same as Cloud Run deploy)
 #   - FIREBASE_SERVICE_ACCOUNT: JSON key for Firebase service account
 #   - GEMINI_API_KEY: API key for Gemini transcription analysis
 #   - REPLICATE_API_TOKEN: API token for WhisperX transcription
@@ -45,7 +46,8 @@ on:
           - functions-only
 
 env:
-  FIREBASE_PROJECT_ID: audio-transcript-app-67465
+  # Uses the same GCP_PROJECT_ID secret as Cloud Run deploy (single-project architecture)
+  FIREBASE_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

Fixes Firebase deploy failing because the workflow had the old project ID (`audio-transcript-app-67465`) hardcoded instead of using the `GCP_PROJECT_ID` secret.

## Changes

- Use `${{ secrets.GCP_PROJECT_ID }}` instead of hardcoded project ID
- Add `GCP_PROJECT_ID` to the documented required secrets list
- Consistent with Cloud Run deploy workflow (single-project architecture)

## Required Before Merge

Ensure GitHub Secret is set:
| Secret | Value |
|--------|-------|
| `GCP_PROJECT_ID` | `audio-transcript-analyzer-01` |

## Test plan

- [ ] Verify `GCP_PROJECT_ID` secret is set correctly
- [ ] Merge and confirm Firebase deploy workflow succeeds