### PR TITLE
feat: interactive Firebase Storage setup with Console instructions

### DIFF
--- a/scripts/gcp-setup.sh
+++ b/scripts/gcp-setup.sh
@@ -419,17 +419,34 @@ else
     # Firebase Storage provisioning MUST be done via Firebase Console for new projects.
     # This is a Firebase platform limitation - there is no CLI or API to create the initial bucket.
     BUCKET=""
-    log_info ""
-    log_info "Firebase Storage requires one-time setup via Firebase Console."
-    log_info ""
-    log_info "Please enable Firebase Storage:"
-    log_info "  1. Go to: https://console.firebase.google.com/project/$PROJECT_ID/storage"
-    log_info "  2. Click 'Get started'"
-    log_info "  3. Select 'Start in production mode'"
-    log_info "  4. Choose location: $STORAGE_REGION"
-    log_info "  5. Click 'Done'"
-    log_info ""
-    log_info "After setup, re-run this script to configure bucket permissions and CORS."
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════════════════════════╗"
+    echo "║  Firebase Storage requires one-time setup via Firebase Console               ║"
+    echo "╚══════════════════════════════════════════════════════════════════════════════╝"
+    echo ""
+    echo "  Please complete these steps:"
+    echo ""
+    echo "  1. Open: https://console.firebase.google.com/project/$PROJECT_ID/storage"
+    echo "  2. Click 'Get started'"
+    echo "  3. Select 'Start in production mode'"
+    echo "  4. Choose location: $STORAGE_REGION"
+    echo "  5. Click 'Done'"
+    echo ""
+    read -p "  Press ENTER when you've completed the Firebase Storage setup... " </dev/tty
+    echo ""
+
+    # Re-check for bucket after user confirms setup
+    log_info "Checking for Storage bucket..."
+    if gsutil ls "$BUCKET_FIREBASE" &>/dev/null; then
+        BUCKET="$BUCKET_FIREBASE"
+        log_success "Storage bucket found: $BUCKET"
+    elif gsutil ls "$BUCKET_APPSPOT" &>/dev/null; then
+        BUCKET="$BUCKET_APPSPOT"
+        log_success "Storage bucket found: $BUCKET"
+    else
+        log_error "Storage bucket still not found. Please verify setup completed successfully."
+        log_info "You can re-run this script after confirming Storage is enabled in Firebase Console."
+    fi
 fi
 
 if [[ -n "$BUCKET" ]]; then


### PR DESCRIPTION
## Summary

Simplifies Firebase Storage setup in `gcp-setup.sh` by accepting the platform limitation and providing a smooth interactive experience.

## The Problem

Firebase Storage bucket creation for new projects **cannot be done programmatically** - it requires Firebase Console setup. We tried multiple approaches:
- `gcloud storage buckets create` - fails due to `.firebasestorage.app` domain ownership
- `gsutil mb` - same domain ownership issue
- `firebase init storage` - only creates config files, not buckets
- REST APIs - no endpoint to create initial bucket

## The Solution

Instead of fighting the platform, embrace it:

1. Script checks if bucket exists (`.firebasestorage.app` or `.appspot.com`)
2. If not found, displays clear instructions in a formatted box
3. **Pauses and waits** for user to complete Console setup
4. Re-checks for bucket after user presses ENTER
5. Continues with permission/CORS configuration

```
╔══════════════════════════════════════════════════════════════════════════════╗
║  Firebase Storage requires one-time setup via Firebase Console               ║
╚══════════════════════════════════════════════════════════════════════════════╝

  Please complete these steps:

  1. Open: https://console.firebase.google.com/project/PROJECT_ID/storage
  2. Click 'Get started'
  3. Select 'Start in production mode'
  4. Choose location: us-central1
  5. Click 'Done'

  Press ENTER when you've completed the Firebase Storage setup...
```

## Benefits

- No more failed automation attempts cluttering output
- User doesn't lose their place in the script
- Clear, actionable instructions
- Script continues automatically after setup

## Test plan

- [x] Tested on project without Storage bucket
- [x] Instructions display correctly
- [x] Script pauses and waits for input
- [x] Re-check finds bucket after Console setup
- [x] Permissions and CORS configured successfully