### PR TITLE
feat: add Gemini speaker reassignment (no timestamp manipulation)

### DIFF
--- a/functions/src/alignment.ts
+++ b/functions/src/alignment.ts
@@ -1525,10 +1525,29 @@ export async function transcribeWithWhisperX(
     if (typeof output === 'object' && output !== null) {
       const outputObj = output as Record<string, unknown>;
 
-      // Log raw structure for debugging
-      console.debug(
-        `[WhisperX] Raw output keys: ${Object.keys(outputObj).join(', ')}`
-      );
+      // === DIAGNOSTIC LOGGING ===
+      // Log raw output structure to debug model format differences
+      console.log('[WhisperX] === RAW OUTPUT DIAGNOSTIC ===');
+      console.log(`[WhisperX] Output type: ${typeof output}`);
+      console.log(`[WhisperX] Output keys: ${Object.keys(outputObj).join(', ')}`);
+
+      // Log first 3000 chars of raw output for structure inspection
+      const rawOutputStr = JSON.stringify(output, null, 2);
+      console.log(`[WhisperX] Raw output (first 3000 chars):\n${rawOutputStr.substring(0, 3000)}`);
+
+      // Log specific field types
+      console.log(`[WhisperX] Field types: ${Object.entries(outputObj).map(([k, v]) =>
+        `${k}=${Array.isArray(v) ? `array[${v.length}]` : typeof v}`
+      ).join(', ')}`);
+
+      // If segments exist, log first 3 segment structures
+      if (Array.isArray(outputObj.segments) && outputObj.segments.length > 0) {
+        console.log(`[WhisperX] First 3 segments structure:`);
+        outputObj.segments.slice(0, 3).forEach((seg, i) => {
+          console.log(`[WhisperX]   Segment ${i}: ${JSON.stringify(seg)}`);
+        });
+      }
+      console.log('[WhisperX] === END DIAGNOSTIC ===');
 
       if (Array.isArray(outputObj.segments)) {
         for (const segment of outputObj.segments) {


### PR DESCRIPTION
## Summary
Re-enables speaker correction using a safe reassign-only approach that fixes diarization errors without timestamp manipulation.

## Problem Solved
When speakers have similar voices (e.g., two women), acoustic diarization struggles to distinguish them. Questions get attributed to the interviewee, answers to the interviewer, etc.

## Solution
- **`identifySpeakerReassignments()`** - Gemini analyzes Q&A patterns to identify misattributed segments
- **`applySpeakerReassignments()`** - Only swaps speaker IDs, keeps timestamps intact

## What Changed
| Component | Change |
|-----------|--------|
| `transcribe.ts` | New reassign-only functions, re-enabled Step 3.5 |
| `alignment.ts` | Added diagnostic logging (from previous PR) |

## Key Safety Features
- ❌ No `split` action (was causing timestamp clustering)
- ❌ No timestamp interpolation
- ✅ Only speaker ID swaps
- ✅ Validates segment indices and speaker IDs

## Test Results
- Tested with interview audio (two female speakers)
- Correctly identifies interviewer questions misattributed to interviewee
- No timestamp issues observed

## Test plan
- [x] TypeScript compiles
- [x] Manual testing with similar-voice audio
- [x] Verified no timestamp manipulation occurs