### PR TITLE
feat: add admin dashboard with observability metrics

### DIFF
--- a/.local_docs/ux_design/comprehensive-ux-analysis.md
+++ b/.local_docs/ux_design/comprehensive-ux-analysis.md
@@ -1,0 +1,1574 @@
+# Comprehensive UX Design: Audio Transcript Analysis App
+
+**Date:** 2025-12-23
+**Prepared by:** UX Designer (Claude Code - Ux Designer Persona)
+**Document Version:** 1.0
+
+---
+
+## Executive Summary
+
+This document provides a comprehensive UX analysis and design strategy for expanding the Audio Transcript Analysis App from a personal transcription tool into a collaborative platform with AI-powered insights. The analysis covers:
+
+1. **UX Audit** - Critical evaluation of existing Library and Viewer features
+2. **Feature Designs** - Detailed UX patterns for 5 new capabilities
+3. **Information Architecture** - Navigation and mental model redesign
+4. **Design System** - Consistent patterns for expanded functionality
+5. **Accessibility & Usability** - WCAG compliance and cognitive load optimization
+
+**Key Finding:** The current app has a strong foundation with minimal cognitive load and clear information hierarchy, but requires careful navigation redesign to prevent feature sprawl as new capabilities are added.
+
+---
+
+## Part 1: UX Audit of Existing Features
+
+### 1.1 Library Page - Current State Analysis
+
+#### **What Users Are Trying to Accomplish:**
+- Quickly scan and find past conversations
+- Upload new audio files for transcription
+- Monitor processing status of recent uploads
+- Understand cloud sync state
+
+#### **Cognitive Load Assessment: ✅ LOW**
+
+**Strengths:**
+- **Scannable table layout** with clear visual hierarchy
+- **Status indicators** use color + icon + text (multi-modal feedback)
+- **Processing progress** shows real-time feedback with granular steps
+- **Empty state** provides clear call-to-action for new users
+- **Sync status badge** is persistent but unobtrusive
+
+**Usability Issues Identified:**
+
+| Issue | Severity | User Impact | Recommendation |
+|-------|----------|-------------|----------------|
+| No search/filter functionality | **HIGH** | Users with 50+ conversations will struggle to find specific items | Add search bar above table with filters for date, speaker count, status |
+| Table column headers not clickable | **MEDIUM** | Users expect sorting by clicking "Name", "Date", "Duration" | Add sort indicators and click handlers |
+| Mobile responsiveness hides key data | **MEDIUM** | Status column hidden on mobile removes important feedback | Consider progressive disclosure or cards on mobile |
+| Deletion confirmation uses browser `confirm()` | **LOW** | Not branded, jarring modal | Replace with styled modal matching app aesthetic |
+| No bulk operations | **LOW** | Power users can't delete/tag multiple conversations | Add checkbox selection + bulk action toolbar |
+
+#### **Mental Model Analysis:**
+
+**Current Model:** "Personal library of recordings"
+**Desired Model (with new features):** "Collaborative knowledge base"
+
+The Library currently signals **ownership** (your recordings) but will need to evolve to show:
+- Shared conversations (from others)
+- Cross-conversation insights
+- Search across all accessible content
+
+---
+
+### 1.2 Viewer Page - Current State Analysis
+
+#### **What Users Are Trying to Accomplish:**
+- Read transcript while listening to audio
+- Jump to specific topics or speaker turns
+- Look up unfamiliar terms mentioned in conversation
+- Track people mentioned in the discussion
+- Correct speaker attribution errors
+
+#### **Cognitive Load Assessment: ✅ MEDIUM-LOW**
+
+**Strengths:**
+- **Two-way sync** (click transcript → audio jumps; audio plays → transcript highlights)
+- **Sidebar context** provides definitions without interrupting reading flow
+- **Visual rhythm** uses speaker avatars + topic markers for scannable structure
+- **Inline editing** for speaker names reduces friction
+- **Real-time audio sync** with drift correction
+
+**Usability Issues Identified:**
+
+| Issue | Severity | User Impact | Recommendation |
+|-------|----------|-------------|----------------|
+| Sidebar only visible on desktop (lg+ breakpoint) | **HIGH** | Mobile users lose access to terms/people context | Add bottom sheet or tabs for mobile |
+| No keyboard shortcuts | **MEDIUM** | Power users can't navigate efficiently | Add space=play/pause, ←/→ skip, J/K jump segments |
+| Person mentions navigation counter is subtle | **MEDIUM** | Users may not notice the mention tracking feature | Consider highlighting mentions in transcript with same visual treatment as terms |
+| No way to ask questions about content | **HIGH** | Users must manually search/reread to find information | **→ NEW FEATURE: Conversation chatbot** |
+| No export or sharing functionality | **HIGH** | Users can't collaborate or share insights | **→ NEW FEATURE: Sharing** |
+
+#### **Mental Model Analysis:**
+
+**Current Model:** "Interactive document viewer with multimedia sync"
+**User Expectation:** "Intelligent assistant that can answer questions about the conversation"
+
+The Viewer is well-designed for **passive consumption** but lacks **active inquiry**. Users need to:
+1. Ask questions ("What did they say about the budget?")
+2. Get summarized answers with timestamps
+3. Share specific insights with collaborators
+
+---
+
+### 1.3 Upload Modal - Current State Analysis
+
+#### **Cognitive Load Assessment: ✅ LOW**
+
+**Strengths:**
+- **Drag-and-drop + click** (dual input methods)
+- **Visual state feedback** (dragging, selected, uploading, error)
+- **Progressive disclosure** (shows file info only after selection)
+- **Clear error messaging**
+
+**Usability Issues Identified:**
+
+| Issue | Severity | User Impact | Recommendation |
+|-------|----------|-------------|----------------|
+| "Max 100MB" shown in placeholder, but code doesn't enforce it | **HIGH** | Users experience cryptic upload failures | Add client-side validation with file size check |
+| Upload blocks UI until complete | **MEDIUM** | Users can't browse library during upload | Make upload non-blocking with notification |
+| No metadata capture during upload | **LOW** | Users can't add title/description before processing | Add optional metadata form |
+| "Max 100MB" insufficient for long meetings | **HIGH** | Enterprise users need 2+ hour recordings | **→ NEW FEATURE: Large file support** |
+
+---
+
+## Part 2: User Journey Maps for New Features
+
+### 2.1 Feature: Conversation Chatbot (Single Conversation Q&A)
+
+#### **User Journey: Finance Team Manager**
+
+**Persona:** Sarah, Finance Manager
+**Goal:** Review quarterly planning meeting to extract budget commitments
+**Context:** 2-hour meeting recording, needs to pull specific numbers for board deck
+
+**Journey Stages:**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 1. DISCOVER                                                     │
+│ Sarah opens conversation in Viewer                              │
+│ • Sees new "Ask About This Conversation" panel in sidebar       │
+│ • Recognizes it as a Q&A interface (chat bubble icon)           │
+│ 🎯 Expectation: "I can ask questions about this recording"      │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 2. ENGAGE                                                       │
+│ Sarah types: "What budget numbers were mentioned?"              │
+│ • Chat interface shows typing indicator                         │
+│ • Response appears in ~3-5 seconds                              │
+│ 🎯 Mental model: "This is like asking a colleague who          │
+│    attended the meeting"                                        │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 3. EVALUATE                                                     │
+│ Response shows:                                                 │
+│ • "Here are the budget figures mentioned:                       │
+│   • Q1: $2.4M (at 34:12)                                       │
+│   • Q2: $2.7M (at 42:56)                                       │
+│   • Annual: $11M (at 51:30)"                                   │
+│ • Each timestamp is a clickable link                            │
+│ 🎯 Affordance discovery: "I can jump to context"                │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 4. VERIFY                                                       │
+│ Sarah clicks timestamp "34:12"                                  │
+│ • Audio jumps to that moment                                    │
+│ • Transcript scrolls and highlights the segment                 │
+│ • She hears: "...so Q1 came in at 2.4 million..."             │
+│ 🎯 Trust building: "The AI got this right"                      │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 5. REFINE                                                       │
+│ Sarah follows up: "What concerns did Lisa raise?"               │
+│ • Chat maintains context (knows this is same conversation)      │
+│ • Response: "Lisa raised 3 concerns: [list with timestamps]"   │
+│ 🎯 Natural dialogue: "This remembers what we're talking about"  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Pain Points to Address:**
+1. **Hallucination risk** - AI must cite sources (timestamps) for every claim
+2. **Context limits** - Long conversations (2+ hours) may exceed token limits
+3. **Ambiguity** - User questions like "What did they say?" need clarification prompts
+
+---
+
+### 2.2 Feature: Search Across Conversations
+
+#### **User Journey: Product Manager**
+
+**Persona:** Marcus, Product Manager
+**Goal:** Find all mentions of "user authentication" across 3 months of customer interviews
+**Context:** 15 recorded interviews, needs to compile requirements
+
+**Journey Stages:**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 1. INITIATE SEARCH                                              │
+│ Marcus opens Library page                                       │
+│ • New search bar at top (prominent placement)                   │
+│ • Types "user authentication"                                   │
+│ • Search scope selector shows: "This conversation" vs "All"     │
+│ 🎯 Expectation: "Like Slack/Notion search but for audio"        │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 2. REVIEW RESULTS                                               │
+│ Results page shows:                                             │
+│ • 23 matches across 8 conversations                             │
+│ • Grouped by conversation (most relevant first)                 │
+│ • Each result shows:                                            │
+│   - Conversation title                                          │
+│   - Speaker + timestamp                                         │
+│   - Text snippet with highlighted term                          │
+│   - Relevance score (visual indicator)                          │
+│ 🎯 Scannable format: "I can quickly assess relevance"           │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 3. FILTER & REFINE                                              │
+│ Marcus uses sidebar filters:                                    │
+│ • Date range: "Last 3 months" ✓                                │
+│ • Speaker: (shows all speakers across conversations)            │
+│ • Topic: Selects "Security" and "Login"                         │
+│ • Results update live to 12 matches                             │
+│ 🎯 Progressive disclosure: "I can narrow down without           │
+│    losing context"                                              │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 4. NAVIGATE TO CONTEXT                                          │
+│ Marcus clicks a result snippet                                  │
+│ • Opens that conversation in Viewer                             │
+│ • Auto-seeks to the timestamp                                   │
+│ • Search term is highlighted in transcript                      │
+│ • Breadcrumb shows: "Search results > [Conversation title]"     │
+│ 🎯 Context preservation: "I can return to results"              │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 5. COMPILE INSIGHTS                                             │
+│ Back in search results, Marcus selects 5 key snippets           │
+│ • "Export selected" button appears                              │
+│ • Options: Copy to clipboard / Export to CSV / Share link       │
+│ • Exported format includes: conversation title, speaker,        │
+│   timestamp, full segment text                                  │
+│ 🎯 Workflow completion: "I can use this in my PRD"              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Technical Considerations:**
+- Full-text search across all user conversations (Firestore full-text limitations)
+- Real-time index updates as new conversations are processed
+- Ranking algorithm: exact match > term occurrence > topic match
+
+---
+
+### 2.3 Feature: Cross-Conversation Chatbot
+
+#### **User Journey: Research Analyst**
+
+**Persona:** Dr. Chen, Qualitative Researcher
+**Goal:** Identify common themes across 20 participant interviews
+**Context:** Needs to synthesize findings for research paper
+
+**Journey Stages:**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 1. ACCESS CROSS-CONVERSATION MODE                               │
+│ Dr. Chen navigates to Library page                              │
+│ • New tab in header: "Library" | "Cross-Conversation Insights"  │
+│ • Clicks "Cross-Conversation Insights"                          │
+│ • Page explains: "Ask questions across all your conversations"  │
+│ 🎯 Mode switching: "This is different from single-conversation  │
+│    questions"                                                   │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 2. SELECT SCOPE                                                 │
+│ Interface shows conversation selector:                          │
+│ • "All conversations" (default)                                 │
+│ • "Select specific conversations" (multi-select)                │
+│ • Dr. Chen filters by tag: "Study Participants"                 │
+│ • 20 conversations selected                                     │
+│ • Visual indicator: "Analyzing 20 conversations (~8 hours)"     │
+│ 🎯 Transparency: "I know what data is being analyzed"           │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 3. ASK COMPLEX QUESTION                                         │
+│ Dr. Chen types: "What are the most common frustrations          │
+│ mentioned by participants?"                                     │
+│ • Processing indicator shows: "Analyzing 20 conversations..."   │
+│ • Takes 15-20 seconds (longer than single conversation)         │
+│ • Progress bar shows partial results streaming in               │
+│ 🎯 Expectation setting: "This takes longer, but I see progress" │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 4. REVIEW SYNTHESIZED ANSWER                                    │
+│ Response shows:                                                 │
+│ • "Top 5 frustrations mentioned:                                │
+│   1. Slow load times (mentioned in 15/20 conversations)         │
+│      - [Participant A, 12:34] 'It takes forever...'            │
+│      - [Participant B, 8:45] 'The waiting is frustrating'      │
+│   2. Confusing navigation (12/20)                               │
+│   ..."                                                          │
+│ • Each mention is a clickable link to source                    │
+│ 🎯 Evidence-based synthesis: "AI shows its work"                │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 5. DRILL INTO SOURCES                                           │
+│ Dr. Chen clicks "View all mentions of 'slow load times'"        │
+│ • Opens expanded view with all 15 quotes                        │
+│ • Can play audio clip for each                                  │
+│ • Export options: Formatted report / CSV / Notion               │
+│ 🎯 Workflow integration: "This fits my research process"        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Cognitive Load Considerations:**
+- **Scope management** - Users need to understand which conversations are included
+- **Processing time** - Long operations need clear progress indicators
+- **Source attribution** - Every claim must link to specific conversation + timestamp
+- **Export formats** - Researchers need APA/MLA citations, not just raw data
+
+---
+
+### 2.4 Feature: Conversation Sharing
+
+#### **User Journey: Team Collaboration**
+
+**Persona:** Alex, Team Lead
+**Goal:** Share weekly standup recording with remote team member who missed the meeting
+**Context:** Need to grant access without exposing other private conversations
+
+**Journey Stages:**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 1. INITIATE SHARING                                             │
+│ Alex opens conversation in Library or Viewer                    │
+│ • New "Share" button in header (next to Delete)                 │
+│ • Clicks Share                                                  │
+│ • Modal opens: "Share 'Weekly Standup - Dec 19'"               │
+│ 🎯 Familiar pattern: "Like sharing a Google Doc"                │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 2. SELECT RECIPIENTS                                            │
+│ Modal shows:                                                    │
+│ • Email input field (autocompletes from team)                   │
+│ • "Anyone with the link" toggle (off by default)                │
+│ • Permission level dropdown:                                    │
+│   - View only (can read + listen)                               │
+│   - Comment (can add notes to sidebar)                          │
+│   - Edit (can rename speakers, update terms)                    │
+│ 🎯 Granular control: "I choose what they can do"                │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 3. CONFIGURE ACCESS                                             │
+│ Alex adds email: jamie@company.com                              │
+│ • Sets permission: "View only"                                  │
+│ • Expiration dropdown: "Never" / "7 days" / "30 days" / Custom  │
+│ • Optional message field: "Here's the standup you missed"       │
+│ • "Send invite" button                                          │
+│ 🎯 Security mindset: "I can limit access duration"              │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 4. RECIPIENT RECEIVES NOTIFICATION                              │
+│ Jamie receives email:                                           │
+│ • Subject: "Alex shared 'Weekly Standup - Dec 19' with you"    │
+│ • Body: Custom message + "Open Conversation" button             │
+│ • Clicks button → Redirects to app                              │
+│ • If not signed in: Prompted to sign in with Google             │
+│ • If signed in: Opens directly to Viewer                        │
+│ 🎯 Low friction: "One click to access"                          │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 5. MANAGE SHARED ACCESS                                         │
+│ Alex later revisits Share modal:                                │
+│ • Shows list of people with access                              │
+│ • Can revoke access (trash icon)                                │
+│ • Can change permission level                                   │
+│ • See activity log: "Jamie viewed 2 days ago"                   │
+│ 🎯 Ongoing control: "I can see and manage who has access"       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Security Considerations:**
+- Email verification required for new users
+- Shared conversations appear in Library with distinct visual indicator
+- Owner can always revoke access
+- Audit log tracks all access (GDPR compliance)
+
+---
+
+### 2.5 Feature: Large File Upload Support
+
+#### **User Journey: Enterprise Customer**
+
+**Persona:** Corporate training team uploading 3-hour webinar recording (450MB)
+**Goal:** Upload large file without failures or browser timeouts
+**Context:** Previous uploads failed at 200MB limit
+
+**Journey Stages:**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 1. SELECT LARGE FILE                                            │
+│ User clicks "Upload Audio"                                      │
+│ • Modal opens, drags 450MB MP4 file                             │
+│ • File size check runs client-side                              │
+│ • Instead of error, sees: "Large file detected (450MB)"         │
+│ • Message: "This will use chunked upload for reliability"       │
+│ 🎯 Transparency: "The app adapts to my file size"               │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 2. METADATA CAPTURE                                             │
+│ Before upload starts, form appears:                             │
+│ • "Title" field (pre-filled from filename)                      │
+│ • Optional "Description" field                                  │
+│ • "Expected duration" estimate (helps with processing)          │
+│ • "Start upload" button                                         │
+│ 🎯 Useful pause: "I can add context before 20-minute upload"    │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 3. RESUMABLE UPLOAD                                             │
+│ Upload begins with detailed progress:                           │
+│ • Chunk 1/45 (10MB each) uploaded                               │
+│ • Progress bar: 23% | 103MB / 450MB                             │
+│ • Speed: "5.2 MB/s"                                             │
+│ • Time remaining: "~6 minutes"                                  │
+│ • "Pause" and "Cancel" buttons visible                          │
+│ 🎯 Control: "I can pause if network is slow"                    │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 4. HANDLE INTERRUPTION                                          │
+│ WiFi disconnects at 67% (network error)                         │
+│ • Upload pauses automatically                                   │
+│ • Message: "Upload paused - waiting for connection"             │
+│ • WiFi reconnects after 30 seconds                              │
+│ • "Resume upload" button appears                                │
+│ • Click resumes from chunk 30/45 (not from start)               │
+│ 🎯 Resilience: "I don't lose 15 minutes of progress"            │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ 5. BACKGROUND PROCESSING                                        │
+│ Upload completes:                                               │
+│ • Modal closes automatically                                    │
+│ • Library shows new item with status "Uploading complete"       │
+│ • Processing begins (may take 30-45 minutes for 3-hour audio)   │
+│ • User can close browser - email notification when done         │
+│ • Notification settings: "Email me when processing completes"   │
+│ 🎯 Freedom: "I don't need to babysit this"                      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Technical Implementation:**
+- Multipart upload to Firebase Storage (5MB chunks)
+- Client-side resumable upload library
+- Server-side assembly of chunks
+- Background Cloud Function processing with email notification
+
+---
+
+## Part 3: Information Architecture Redesign
+
+### 3.1 Current vs. Proposed Navigation
+
+#### **Current Navigation (Simple Two-View)**
+
+```
+App
+├── Library (list view)
+└── Viewer (detail view)
+```
+
+**Problems:**
+- No home for cross-conversation features
+- No space for search results
+- No access to chatbot without opening a conversation
+
+#### **Proposed Navigation (Feature-Based)**
+
+```
+App
+├── Library
+│   ├── My Conversations (current default)
+│   ├── Shared With Me (new)
+│   └── Tags/Collections (new organization feature)
+│
+├── Search (new top-level)
+│   ├── Search results page
+│   └── Filters sidebar
+│
+├── Insights (new top-level)
+│   ├── Cross-Conversation Chat
+│   ├── Saved Queries
+│   └── Exported Reports
+│
+└── Conversation Viewer
+    ├── Transcript (current)
+    ├── Conversation Chat (new sidebar tab)
+    └── Share (new header action)
+```
+
+### 3.2 Global Navigation Pattern
+
+**Header Layout:**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ [Logo] [Library] [Search] [Insights] [Upload]    [Help] [User]  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Responsive Behavior (Mobile):**
+```
+┌──────────────────────────────────────────────────┐
+│ [☰ Menu] [Logo]              [Upload] [User]     │
+└──────────────────────────────────────────────────┘
+
+Menu expanded:
+┌──────────────────────────────────────────────────┐
+│ [X Close]                                        │
+│                                                  │
+│ → Library                                        │
+│ → Search                                         │
+│ → Insights                                       │
+│ → Help                                           │
+└──────────────────────────────────────────────────┘
+```
+
+### 3.3 Library Page - New Layout with Search
+
+**Desktop View:**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Library                                    [Upload] [User Menu]  │
+│ Your transcribed conversations                                  │
+│                                                                 │
+│ [🔍 Search conversations...]                    [⚙️ Filters ▾]  │
+│                                                                 │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ Tabs: [My Conversations] [Shared With Me] [Collections]    │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│                                                                 │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ Name              Date       Duration    Status      Actions│ │
+│ ├─────────────────────────────────────────────────────────────┤ │
+│ │ [🎤] Q4 Planning  Dec 19    1:34:22     Complete   [... ▾] │ │
+│ │ [🎤] Customer #12 Dec 18    45:12       Complete   [... ▾] │ │
+│ │ [🔄] Team Sync    Dec 17    --:--       Processing [... ]  │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Key Changes:**
+1. **Persistent search bar** at top (always visible)
+2. **Tab navigation** for My/Shared/Collections
+3. **Filter dropdown** for date range, speakers, topics, status
+4. **Actions menu** (•••) replaces hover-only delete button
+5. **Shared indicator** icon on items shared with you
+
+---
+
+## Part 4: Wireframes for Key New Features
+
+### 4.1 Conversation Chatbot Interface
+
+**Location:** Sidebar in Viewer (new tab alongside Terms/People)
+
+```
+┌─────────────────────────────────────────────────────┐
+│ [Context ▾] [People ▾] [Chat 💬]                    │
+├─────────────────────────────────────────────────────┤
+│                                                     │
+│  Ask about this conversation                        │
+│                                                     │
+│  ┌───────────────────────────────────────────────┐ │
+│  │ You:                                          │ │
+│  │ What budget numbers were mentioned?           │ │
+│  └───────────────────────────────────────────────┘ │
+│                                                     │
+│  ┌───────────────────────────────────────────────┐ │
+│  │ AI:                                           │ │
+│  │ Here are the budget figures mentioned:        │ │
+│  │                                               │ │
+│  │ • Q1: $2.4M [▶️ 34:12]                        │ │
+│  │ • Q2: $2.7M [▶️ 42:56]                        │ │
+│  │ • Annual: $11M [▶️ 51:30]                     │ │
+│  │                                               │ │
+│  │ Would you like me to summarize the budget     │ │
+│  │ discussion?                                   │ │
+│  └───────────────────────────────────────────────┘ │
+│                                                     │
+│  ┌───────────────────────────────────────────────┐ │
+│  │ Type your question...             [Send →]    │ │
+│  └───────────────────────────────────────────────┘ │
+│                                                     │
+│  [Clear chat] [Export conversation]                │
+└─────────────────────────────────────────────────────┘
+```
+
+**Interaction Details:**
+- Clicking timestamp `[▶️ 34:12]` seeks audio and scrolls transcript
+- "Clear chat" resets conversation context
+- "Export conversation" saves Q&A as markdown/PDF
+- Chat history persists per conversation (saved in Firestore)
+
+---
+
+### 4.2 Cross-Conversation Insights Page
+
+**Full-Page Layout:**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ [Library] [Search] [Insights] [Upload]         [Help] [User]    │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│ Cross-Conversation Insights                                     │
+│ Ask questions across multiple conversations                     │
+│                                                                 │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ 📊 Conversation Scope                                       │ │
+│ │                                                             │ │
+│ │ ○ All conversations (23 conversations, ~14 hours)           │ │
+│ │ ● Select specific (12 selected)                             │ │
+│ │                                                             │ │
+│ │ [Tag: Study Participants ✓] [Date: Last 30 days ✓]         │ │
+│ │ [Add filter +]                                              │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│                                                                 │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ 💬 Ask a Question                                           │ │
+│ │                                                             │ │
+│ │ ┌─────────────────────────────────────────────────────────┐ │ │
+│ │ │ What are the most common frustrations mentioned?       │ │ │
+│ │ │                                                         │ │ │
+│ │ │                                           [Analyze →]   │ │ │
+│ │ └─────────────────────────────────────────────────────────┘ │ │
+│ │                                                             │ │
+│ │ Example questions:                                          │ │
+│ │ • What topics appear across all conversations?              │ │
+│ │ • Who is mentioned most frequently?                         │ │
+│ │ • Summarize key decisions made                              │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│                                                                 │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ 📝 Analysis Results                                         │ │
+│ │                                                             │ │
+│ │ Top 5 frustrations mentioned:                               │ │
+│ │                                                             │ │
+│ │ 1. ⚡ Slow load times                                       │ │
+│ │    Mentioned in 15/20 conversations                         │ │
+│ │    [▼ Show all mentions]                                    │ │
+│ │                                                             │ │
+│ │ 2. 🧭 Confusing navigation                                  │ │
+│ │    Mentioned in 12/20 conversations                         │ │
+│ │    [▼ Show all mentions]                                    │ │
+│ │                                                             │ │
+│ │ ...                                                         │ │
+│ │                                                             │ │
+│ │ [Export report ↓] [Save query 💾]                           │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Interaction Flow:**
+1. User selects conversation scope (all or specific subset)
+2. User types question
+3. "Analyze" button triggers processing (15-20 sec)
+4. Results stream in progressively
+5. User can expand each finding to see source quotes
+6. Export options: PDF report, CSV, JSON, Notion integration
+
+---
+
+### 4.3 Search Results Page
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ [Library] [Search] [Insights] [Upload]         [Help] [User]    │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│ [🔍 user authentication                              ] [Search]  │
+│                                                                 │
+│ 23 results across 8 conversations                               │
+└─────────────────────────────────────────────────────────────────┘
+
+┌──────────────────┬──────────────────────────────────────────────┐
+│ Filters          │ Results                                      │
+│                  │                                              │
+│ Date Range       │ ┌──────────────────────────────────────────┐ │
+│ ○ All time       │ │ Customer Interview #12 - Dec 18          │ │
+│ ○ Last 7 days    │ │ Speaker: Sarah at 23:45                  │ │
+│ ● Last 30 days   │ │ "...the user authentication process is   │ │
+│ ○ Custom         │ │  really confusing for first-time users"  │ │
+│                  │ │                            [Open →] [▶️]  │ │
+│ Speakers         │ └──────────────────────────────────────────┘ │
+│ ☐ Alex (12)      │                                              │
+│ ☑ Sarah (8)      │ ┌──────────────────────────────────────────┐ │
+│ ☐ Marcus (3)     │ │ Q4 Planning Meeting - Dec 19             │ │
+│                  │ │ Speaker: Marcus at 1:04:22               │ │
+│ Topics           │ │ "...we need to redesign user              │ │
+│ ☑ Security (15)  │ │  authentication before launch"           │ │
+│ ☑ Login (10)     │ │                            [Open →] [▶️]  │ │
+│ ☐ UX (5)         │ └──────────────────────────────────────────┘ │
+│                  │                                              │
+│ [Clear filters]  │ ... (more results)                           │
+└──────────────────┴──────────────────────────────────────────────┘
+```
+
+**Interaction Details:**
+- Results are live-filtered as user checks/unchecks filters
+- [Open →] opens conversation in Viewer at that timestamp
+- [▶️] plays audio snippet without leaving search page (modal player)
+- Checkbox selection allows bulk export
+
+---
+
+### 4.4 Share Modal
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Share "Q4 Planning Meeting"                        [X]  │
+├─────────────────────────────────────────────────────────┤
+│                                                         │
+│ Share with people                                       │
+│ ┌─────────────────────────────────────────────────────┐ │
+│ │ Enter email addresses...                            │ │
+│ └─────────────────────────────────────────────────────┘ │
+│                                                         │
+│ Permission level                                        │
+│ ┌─────────────────────────────────────────────────────┐ │
+│ │ View only                                       [▾]  │ │
+│ └─────────────────────────────────────────────────────┘ │
+│ Options: View only / Can comment / Can edit            │
+│                                                         │
+│ Expiration                                              │
+│ ┌─────────────────────────────────────────────────────┐ │
+│ │ Never                                           [▾]  │ │
+│ └─────────────────────────────────────────────────────┘ │
+│ Options: Never / 7 days / 30 days / Custom date        │
+│                                                         │
+│ ☐ Anyone with the link can view                        │
+│   (Link: https://app.example.com/s/abc123)             │
+│                                                         │
+│ Message (optional)                                      │
+│ ┌─────────────────────────────────────────────────────┐ │
+│ │ Here's the Q4 planning meeting you asked about...   │ │
+│ │                                                     │ │
+│ └─────────────────────────────────────────────────────┘ │
+│                                                         │
+│ ─────────────────────────────────────────────────────── │
+│ People with access                                      │
+│                                                         │
+│ • jamie@company.com (View only) Viewed 2d ago [Revoke] │
+│ • alex@company.com (Owner)                              │
+│                                                         │
+├─────────────────────────────────────────────────────────┤
+│                          [Cancel]  [Send invite]        │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Part 5: Design System Considerations
+
+### 5.1 Component Patterns for New Features
+
+#### **Chat Message Component**
+
+**Variants:**
+- User message (right-aligned, blue background)
+- AI message (left-aligned, gray background)
+- System message (centered, italic)
+
+**Anatomy:**
+```
+┌─────────────────────────────────────────────────┐
+│ [Avatar] [Name]                      [Timestamp]│
+│          Message text with possible             │
+│          • Bullet points                        │
+│          • [Clickable timestamps]               │
+│          • **Markdown formatting**              │
+│                                                 │
+│          [Thumbs up] [Thumbs down] [Copy]       │
+└─────────────────────────────────────────────────┘
+```
+
+**Accessibility:**
+- Use `role="log"` for chat container (screen reader announces new messages)
+- Timestamp links have descriptive labels: "Jump to 34 minutes 12 seconds"
+
+---
+
+#### **Search Result Card**
+
+**Anatomy:**
+```
+┌─────────────────────────────────────────────────┐
+│ [Checkbox] [Conversation icon] Conversation Title│
+│            Speaker: [Name] at [Timestamp]        │
+│                                                 │
+│            "...text snippet with **highlighted** │
+│            search term in context..."           │
+│                                                 │
+│            [Open in Viewer] [Play snippet]      │
+└─────────────────────────────────────────────────┘
+```
+
+**States:**
+- Default
+- Hover (slight shadow lift)
+- Selected (checkbox checked, blue border)
+- Visited (dimmed, checkmark icon)
+
+---
+
+#### **Conversation Scope Selector**
+
+**Component for Cross-Conversation Insights:**
+
+```
+┌─────────────────────────────────────────────────┐
+│ 📊 Conversation Scope                           │
+│                                                 │
+│ Radio buttons:                                  │
+│ ○ All conversations (23 conversations, 14h)     │
+│ ● Select specific (12 selected)                 │
+│                                                 │
+│ When "Select specific" chosen:                  │
+│ ┌─────────────────────────────────────────────┐ │
+│ │ [Filter panel slides in]                    │ │
+│ │ Tags: [Study Participants ✓]                │ │
+│ │ Date: [Last 30 days ✓]                      │ │
+│ │ Speaker: [All speakers ▾]                   │ │
+│ └─────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────┘
+```
+
+**Progressive Disclosure:**
+- Default shows radio buttons only
+- Selecting "Select specific" reveals filter panel below
+
+---
+
+### 5.2 Color System Expansion
+
+**Current Palette (from existing code):**
+- Primary: Blue (used for interactive elements, active states)
+- Success: Emerald (used for complete status)
+- Warning: Amber (used for offline status)
+- Error: Red (used for failed status)
+- Neutral: Slate (used for text, borders, backgrounds)
+
+**New Semantic Colors Needed:**
+
+| Use Case | Color | Hex/Tailwind | Example |
+|----------|-------|--------------|---------|
+| AI message background | Light purple | `purple-50` | Chatbot responses |
+| Shared item indicator | Teal | `teal-500` | Library items shared with you |
+| Cross-conversation scope | Indigo | `indigo-100` | Scope selector background |
+| Search highlight | Yellow | `yellow-200` | Search term in results |
+| Person mention | Purple | `purple-200` | Person name highlights in transcript |
+
+---
+
+### 5.3 Typography Scale
+
+**Current Usage (inferred from code):**
+- H1: 2xl (24px) - Page titles
+- H2: lg (18px) - Section headers
+- Body: sm (14px) - Main content
+- Caption: xs (12px) - Metadata, timestamps
+
+**Additions Needed:**
+- **Display** (4xl/36px) - Empty states, hero sections
+- **Mono** (Fira Code or similar) - Timestamps, code snippets in AI responses
+
+---
+
+### 5.4 Spacing System
+
+**Recommendation:** Continue using Tailwind's 4px-based scale
+
+**Common Patterns:**
+- Card padding: `p-4` (16px)
+- Section gaps: `gap-6` (24px)
+- Button padding: `px-4 py-2` (16px horizontal, 8px vertical)
+- Sidebar width: `w-80` (320px)
+
+---
+
+## Part 6: Accessibility & Usability Recommendations
+
+### 6.1 WCAG 2.1 AA Compliance Checklist
+
+#### **Critical Issues to Address:**
+
+| Issue | Current State | Target | Implementation |
+|-------|---------------|--------|----------------|
+| **Keyboard navigation** | No keyboard shortcuts | Full keyboard support | Add keyboard shortcuts for play/pause, seek, navigation |
+| **Focus indicators** | Browser defaults | Custom focus rings | Use `ring-2 ring-blue-500` on all interactive elements |
+| **Color contrast** | Mostly good, some issues | 4.5:1 for text | Audit slate-400 text on white (may fail) |
+| **Alt text** | Icons have no labels | Descriptive labels | Add `aria-label` to icon buttons |
+| **Screen reader support** | Basic HTML semantics | Enhanced ARIA | Add live regions for chat, status updates |
+| **Mobile touch targets** | Some buttons < 44px | Minimum 44x44px | Increase small icon button sizes |
+
+---
+
+#### **Specific Fixes:**
+
+**1. Keyboard Shortcuts**
+
+```typescript
+// Add to Viewer component
+useEffect(() => {
+  const handleKeyPress = (e: KeyboardEvent) => {
+    // Ignore if typing in input
+    if (e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement) return;
+
+    switch(e.key) {
+      case ' ':
+        e.preventDefault();
+        togglePlay();
+        break;
+      case 'ArrowLeft':
+        seek(currentTime - 5000); // Skip back 5s
+        break;
+      case 'ArrowRight':
+        seek(currentTime + 5000); // Skip forward 5s
+        break;
+      case 'j':
+        // Jump to previous segment
+        break;
+      case 'k':
+        // Jump to next segment
+        break;
+      case '/':
+        // Focus search input
+        break;
+    }
+  };
+
+  window.addEventListener('keydown', handleKeyPress);
+  return () => window.removeEventListener('keydown', handleKeyPress);
+}, [currentTime, togglePlay, seek]);
+```
+
+**Visual Hint:** Add keyboard shortcut legend (press `?` to show)
+
+---
+
+**2. Focus Management**
+
+When modal opens (Share, Upload), focus should move to first input.
+When modal closes, focus should return to trigger button.
+
+```typescript
+const ShareModal = ({ onClose }) => {
+  const emailInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    emailInputRef.current?.focus();
+  }, []);
+
+  // ... rest of component
+};
+```
+
+---
+
+**3. Screen Reader Announcements**
+
+Use live regions for dynamic content:
+
+```tsx
+// In Library page, announce when new conversation finishes processing
+<div
+  role="status"
+  aria-live="polite"
+  className="sr-only"
+>
+  {justCompletedConversation &&
+    `${justCompletedConversation.title} processing complete`
+  }
+</div>
+```
+
+---
+
+### 6.2 Cognitive Load Reduction Strategies
+
+#### **Information Hierarchy Best Practices:**
+
+**1. Progressive Disclosure**
+- Show 5 search results initially, "Load more" button for next 20
+- Collapse long AI responses with "Show more" after 3 paragraphs
+- Hide advanced filters behind "More filters" dropdown
+
+**2. Defaults that Work for 80% of Users**
+- Search defaults to "All conversations" but remembers last scope
+- Share permission defaults to "View only"
+- Upload expands automatically to metadata form for files > 100MB
+
+**3. Status Transparency**
+- Always show what the system is doing: "Analyzing 12 conversations..."
+- Provide time estimates when possible: "~15 seconds remaining"
+- Explain why something failed: "Upload failed: File size exceeds 500MB limit"
+
+---
+
+#### **Reducing Decision Fatigue:**
+
+**Bad:** "Do you want to enable chunked upload?" (User doesn't know what this means)
+**Good:** Automatically detect file size and use appropriate upload method silently
+
+**Bad:** 12 sharing permission options
+**Good:** 3 clear options with help text
+- View only - "They can read and listen"
+- Can comment - "They can add notes to sidebar"
+- Can edit - "They can rename speakers and update terms"
+
+---
+
+### 6.3 Error Prevention & Recovery
+
+#### **Upload Failures:**
+
+**Current:** Silent failure or generic error
+**Improved:**
+1. Client-side validation before upload starts
+2. Clear error messages with recovery steps
+3. Option to retry automatically
+
+```tsx
+// Error message component
+<Alert variant="error">
+  <AlertCircle />
+  <div>
+    <strong>Upload failed: Connection lost</strong>
+    <p>Your upload was 67% complete (302MB / 450MB)</p>
+    <Button onClick={resumeUpload}>Resume from 302MB</Button>
+    <Button variant="ghost" onClick={cancelUpload}>Cancel</Button>
+  </div>
+</Alert>
+```
+
+---
+
+#### **AI Hallucination Detection:**
+
+**Problem:** Gemini may generate incorrect information
+**Solution:** Confidence scoring + source citation
+
+```tsx
+// In chatbot response
+<AIMessage>
+  <p>The budget for Q1 was <strong>$2.4M</strong>
+    <ConfidenceBadge level="high" timestamp="34:12" />
+  </p>
+  <p>The team discussed hiring <em>5-7 engineers</em>
+    <ConfidenceBadge level="medium" />
+    <InfoIcon tooltip="This is an estimate based on context, not a direct quote" />
+  </p>
+</AIMessage>
+```
+
+**Confidence levels:**
+- **High** - Direct quote with exact timestamp
+- **Medium** - Paraphrased from multiple mentions
+- **Low** - Inferred from context (shown with disclaimer)
+
+---
+
+### 6.4 Mobile Optimization Gaps
+
+#### **Current Issues:**
+
+1. **Sidebar hidden on mobile** - No access to Terms/People/Chat
+2. **Small touch targets** - Icon buttons are 32x32px (need 44x44px)
+3. **No swipe gestures** - Natural mobile interaction missing
+
+#### **Recommended Mobile UX:**
+
+**Bottom Sheet Pattern for Sidebar:**
+
+```
+┌──────────────────────────────────────┐
+│ [Transcript view]                    │
+│                                      │
+│ Segment 1: Speaker A                 │
+│ "This is the transcript..."          │
+│                                      │
+│ [Active segment highlighted]         │
+│                                      │
+│ ... more segments ...                │
+│                                      │
+│ ┌──────────────────────────────────┐ │
+│ │ [Context] [People] [Chat] 👆    │ │ ← Swipe up to expand
+│ └──────────────────────────────────┘ │
+│                                      │
+│ [Audio player fixed at bottom]       │
+└──────────────────────────────────────┘
+
+When swiped up:
+┌──────────────────────────────────────┐
+│ [Transcript view - 40% height]       │
+│ ...segments...                       │
+├──────────────────────────────────────┤
+│ [Context] [People] [Chat] 👇        │ ← Swipe down to collapse
+│                                      │
+│ [Sidebar content - 60% height]       │
+│                                      │
+│ [Term definitions / Chat interface]  │
+│                                      │
+└──────────────────────────────────────┘
+```
+
+**Implementation:** Use `react-spring-bottom-sheet` or similar library
+
+---
+
+#### **Touch Gesture Enhancements:**
+
+- Swipe left/right on segment → Skip to previous/next segment
+- Long press on timestamp → Copy to clipboard
+- Double-tap segment → Play that segment
+- Pinch on waveform (future feature) → Zoom in/out
+
+---
+
+## Part 7: Implementation Roadmap
+
+### 7.1 Phased Rollout Strategy
+
+#### **Phase 1: Search & Single-Conversation Chat (Sprint 1-2)**
+
+**Why first:**
+- Builds on existing infrastructure (Firestore, Gemini API)
+- Highest user value for current users
+- No new auth/sharing complexity
+
+**Deliverables:**
+- Search bar in Library with full-text search
+- Chat tab in Viewer sidebar
+- Keyboard shortcuts for accessibility
+
+**Success Metrics:**
+- 60% of users try search within first week
+- 40% of users ask at least one chat question
+- Average search → open time < 10 seconds
+
+---
+
+#### **Phase 2: Sharing & Collaboration (Sprint 3-4)**
+
+**Why second:**
+- Requires auth work (email verification, permissions)
+- Enables team use cases (MVP → Enterprise)
+- Sets foundation for multi-user features
+
+**Deliverables:**
+- Share modal with email invite
+- "Shared With Me" tab in Library
+- Permission levels (view/comment/edit)
+- Email notifications
+
+**Success Metrics:**
+- 25% of users share at least one conversation
+- Average time from share → first view < 24 hours
+- Zero security incidents (audit logs working)
+
+---
+
+#### **Phase 3: Cross-Conversation Insights (Sprint 5-6)**
+
+**Why third:**
+- Most complex feature (multi-conversation indexing)
+- Requires robust search from Phase 1
+- Benefits from sharing infrastructure (team insights)
+
+**Deliverables:**
+- Insights page with scope selector
+- Cross-conversation chat with source attribution
+- Saved queries and export functionality
+
+**Success Metrics:**
+- 15% of users with 10+ conversations use Insights
+- Average query response time < 20 seconds
+- 80% of responses include source citations
+
+---
+
+#### **Phase 4: Large File Support (Sprint 7)**
+
+**Why last:**
+- Infrastructure work (chunked upload, background processing)
+- Lower priority than collaboration features
+- Requires DevOps changes (Cloud Function memory limits)
+
+**Deliverables:**
+- Resumable upload with pause/resume
+- Email notification on processing complete
+- Metadata capture during upload
+
+**Success Metrics:**
+- Upload success rate for files > 200MB: > 95%
+- Average upload time improvement: 30% faster
+- User complaints about upload failures: < 5%
+
+---
+
+### 7.2 Technical Debt & Refactoring Needs
+
+**Before implementing new features, address:**
+
+1. **Library table component** - Extract to separate component, add sorting/filtering props
+2. **Modal system** - Create reusable modal wrapper (Share, Upload, Rename use same pattern)
+3. **Error boundaries** - Add React error boundaries for Chat and Search features
+4. **Firestore security rules** - Update rules for sharing (user can read if in `sharedWith` array)
+5. **Test coverage** - Current coverage unknown, aim for 70% before adding features
+
+---
+
+### 7.3 Performance Budgets
+
+**Page Load Targets:**
+- Library initial render: < 1.5s
+- Viewer initial render: < 2.0s
+- Search results: < 800ms
+- Chat response: < 5s (single conversation), < 20s (cross-conversation)
+
+**Bundle Size Limits:**
+- Initial bundle: < 300KB gzipped
+- Code-split chunks: < 100KB each
+- Lazy load: Chat components, Search results, Insights page
+
+---
+
+## Part 8: Design System Assets Needed
+
+### 8.1 New Components to Build
+
+| Component | Priority | Dependencies | Design File |
+|-----------|----------|--------------|-------------|
+| Chat message bubble | P0 | None | `chat-message.tsx` |
+| Search result card | P0 | None | `search-result.tsx` |
+| Share modal | P1 | Modal wrapper | `share-modal.tsx` |
+| Conversation scope selector | P1 | Filter components | `scope-selector.tsx` |
+| Confidence badge | P2 | Tooltip | `confidence-badge.tsx` |
+| Bottom sheet (mobile) | P2 | react-spring | `bottom-sheet.tsx` |
+| Keyboard shortcuts legend | P2 | Modal wrapper | `shortcuts-modal.tsx` |
+
+---
+
+### 8.2 Icon Additions Needed
+
+**Current library:** Lucide React (existing)
+
+**New icons to add:**
+- `MessageSquare` - Chat tab icon
+- `Share2` - Share button
+- `Filter` - Filter dropdown
+- `Sparkles` - AI/Gemini indicator
+- `Users2` - Shared with me indicator
+- `Layers` - Cross-conversation insights
+- `Download` - Export actions
+- `Link2` - Copy link action
+
+All icons already available in Lucide React - no custom SVGs needed.
+
+---
+
+### 8.3 Animation & Micro-interactions
+
+**New animations to implement:**
+
+1. **Chat message fade-in**
+   - Message slides up + fades in (200ms)
+   - Timestamp appears after message (stagger 100ms)
+
+2. **Search results loading skeleton**
+   - Pulse animation on loading cards
+   - Smooth transition when results populate
+
+3. **Share modal slide-down**
+   - Modal slides from top (not center zoom)
+   - Background blur transition (300ms)
+
+4. **Scope selector expand**
+   - Filter panel slides down (250ms ease-out)
+   - Height auto-animates (not instant)
+
+5. **Processing progress**
+   - Indeterminate spinner for < 3s operations
+   - Determinate progress bar for > 3s operations
+   - Success checkmark animation (scale + rotate)
+
+**Rationale:** Animations provide feedback and reduce perceived latency.
+
+---
+
+## Part 9: Accessibility Testing Plan
+
+### 9.1 Manual Testing Checklist
+
+**Screen Reader Testing (NVDA/JAWS on Windows, VoiceOver on Mac):**
+- [ ] All buttons have descriptive labels
+- [ ] Chat messages announce correctly with speaker
+- [ ] Search results announce result count
+- [ ] Loading states announce "Loading..." then result
+- [ ] Form errors announce via `aria-live` region
+
+**Keyboard Navigation Testing:**
+- [ ] Tab order follows visual layout
+- [ ] All interactive elements reachable by keyboard
+- [ ] Modal traps focus (can't tab outside)
+- [ ] Escape key closes modals
+- [ ] Shortcuts work without modifiers (no Ctrl+K traps)
+
+**Color Contrast Testing:**
+- [ ] Run axe DevTools on all new pages
+- [ ] Test with Windows High Contrast mode
+- [ ] Verify slate-400 text meets 4.5:1 ratio
+- [ ] Check focus indicators have 3:1 ratio
+
+---
+
+### 9.2 Automated Testing
+
+**Tools to integrate:**
+- `@axe-core/react` - Catch accessibility issues in development
+- `jest-axe` - Unit test accessibility violations
+- `cypress-axe` - E2E accessibility tests
+
+**Example test:**
+```typescript
+// Library.test.tsx
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);
+
+test('Library page has no accessibility violations', async () => {
+  const { container } = render(<Library />);
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});
+```
+
+---
+
+## Part 10: Open Questions & User Research Needs
+
+### 10.1 Questions for User Testing
+
+**Search Feature:**
+1. Do users expect search to include audio transcription text or just metadata (title, speakers)?
+2. How do users want to filter results - by date, speaker, topic, or relevance?
+3. Should search support boolean operators (AND, OR, NOT) or natural language only?
+
+**Chat Feature:**
+4. Do users trust AI responses without explicit source citations?
+5. How long are users willing to wait for cross-conversation analysis (10s? 30s? 1min?)?
+6. Should chat history persist across sessions or reset on each visit?
+
+**Sharing Feature:**
+7. What's the expected mental model for "shared conversations" - like Google Docs or Dropbox?
+8. Should shared conversations appear in a separate list or inline with "My Conversations"?
+9. Do users need granular permissions (view only, comment, edit) or just "can view"?
+
+**Large Files:**
+10. What file size limit is acceptable for the target user base (200MB? 500MB? 1GB?)?
+11. Should upload continue in background if user closes browser, or require tab to stay open?
+12. Do users need batch upload (multiple files at once) or one-at-a-time is sufficient?
+
+---
+
+### 10.2 Recommended User Research Studies
+
+**Study 1: Usability Testing of Search + Chat (n=8 users)**
+- **Method:** Moderated remote sessions (60 min each)
+- **Tasks:**
+  1. Find a specific conversation from 3 months ago
+  2. Ask chatbot to summarize key decisions
+  3. Verify chatbot answer by jumping to timestamp
+- **Metrics:** Task success rate, time on task, user confidence rating
+- **Timing:** Before Phase 1 implementation (wireframe testing)
+
+**Study 2: Share Modal Comprehension (n=20 users)**
+- **Method:** Unmoderated card sorting + tree testing
+- **Questions:**
+  1. Sort sharing permissions by expected access level
+  2. Find where to revoke someone's access
+  3. Find where to see who has viewed the conversation
+- **Metrics:** Findability score, time to complete, error rate
+- **Timing:** During Phase 2 design iteration
+
+**Study 3: Cross-Conversation Insights Concept Test (n=12 users)**
+- **Method:** Think-aloud protocol with interactive prototype
+- **Scenarios:**
+  1. "Find common themes across customer interviews"
+  2. "See which decisions were made in Q4 planning meetings"
+  3. "Export insights for a report"
+- **Metrics:** Ease of use (SUS score), feature comprehension, likelihood to use
+- **Timing:** Before Phase 3 implementation
+
+---
+
+## Appendix: Design Patterns Library
+
+### A1. Component Specification: Chat Message
+
+```typescript
+interface ChatMessageProps {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  timestamp?: string;
+  sources?: { text: string; timestamp: string; conversationId: string }[];
+  onTimestampClick?: (timestamp: string) => void;
+  onSourceClick?: (conversationId: string, timestamp: string) => void;
+}
+
+export const ChatMessage: React.FC<ChatMessageProps> = ({
+  role,
+  content,
+  timestamp,
+  sources,
+  onTimestampClick,
+  onSourceClick
+}) => {
+  return (
+    <div className={cn(
+      "flex gap-3 mb-4",
+      role === 'user' && "flex-row-reverse"
+    )}>
+      <Avatar role={role} />
+      <div className={cn(
+        "flex-1 rounded-lg p-3",
+        role === 'user' ? "bg-blue-100" : "bg-slate-100"
+      )}>
+        <Markdown content={content} />
+        {sources && sources.length > 0 && (
+          <div className="mt-2 pt-2 border-t border-slate-200">
+            <p className="text-xs text-slate-500 mb-1">Sources:</p>
+            {sources.map((source, idx) => (
+              <button
+                key={idx}
+                onClick={() => onSourceClick?.(source.conversationId, source.timestamp)}
+                className="block text-xs text-blue-600 hover:underline"
+              >
+                {source.text} [{source.timestamp}]
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+      {timestamp && (
+        <span className="text-xs text-slate-400">{timestamp}</span>
+      )}
+    </div>
+  );
+};
+```
+
+---
+
+### A2. Responsive Breakpoint Strategy
+
+**Tailwind breakpoints:**
+- `sm`: 640px - Small tablets, large phones in landscape
+- `md`: 768px - Tablets
+- `lg`: 1024px - Small laptops (current sidebar breakpoint)
+- `xl`: 1280px - Desktop
+- `2xl`: 1536px - Large desktop
+
+**Recommended layouts:**
+
+| Screen Size | Library Layout | Viewer Layout |
+|-------------|----------------|---------------|
+| < 640px (mobile) | Single column list with cards | Transcript only, bottom sheet for sidebar |
+| 640px - 1024px (tablet) | 2-column grid | Transcript with floating sidebar toggle |
+| 1024px+ (desktop) | Table with all columns | Split view (transcript 70% + sidebar 30%) |
+
+---
+
+### A3. Error Message Copy Guidelines
+
+**Tone:** Friendly but direct, explain what happened and what to do next
+
+**Template:**
+```
+[Emoji] [What happened]
+[Why it happened - optional]
+[Action buttons]
+```
+
+**Examples:**
+
+```
+❌ Upload failed
+Your internet connection was lost halfway through the upload.
+
+[Retry from 302MB] [Cancel]
+```
+
+```
+⚠️ Search took too long
+We're searching across 150 conversations, which is taking longer than expected.
+
+[Keep waiting] [Cancel]
+```
+
+```
+🚫 Can't share this conversation
+You need to be the owner to share. Contact alex@company.com to request sharing permissions.
+
+[Got it]
+```
+
+---
+
+## Summary & Next Steps
+
+### Key Recommendations
+
+1. **Prioritize search + single-conversation chat** - Highest value, lowest complexity
+2. **Design sharing with security-first mindset** - Email verification, audit logs, revocable access
+3. **Use progressive disclosure** - Don't overwhelm with 5 new top-level nav items
+4. **Test cross-conversation insights early** - Most novel feature, highest risk of poor UX
+5. **Address accessibility gaps before launch** - Keyboard shortcuts, ARIA labels, focus management
+
+### Metrics to Track Post-Launch
+
+- **Adoption:** % of users who try each new feature within 30 days
+- **Engagement:** Median queries per user per week (search + chat)
+- **Collaboration:** % of conversations shared, average viewers per shared item
+- **Performance:** P95 response time for chat queries
+- **Satisfaction:** NPS score, feature-specific ratings
+
+### Design Assets Delivery
+
+**Next steps for development team:**
+1. Review this document and flag any unclear sections
+2. Prioritize Phase 1 features (search + chat) for next sprint planning
+3. Request high-fidelity mockups if needed (this doc provides wireframes)
+4. Schedule user research sessions for Share modal testing
+5. Set up accessibility testing tools (`axe`, `jest-axe`, `cypress-axe`)
+
+---
+
+**Document End**
+Questions? Contact UX team for clarification or design iteration workshops.

--- a/App.tsx
+++ b/App.tsx
@@ -1,18 +1,20 @@
 import React, { useState } from 'react';
 import { Library } from './pages/Library';
 import { Viewer } from './pages/Viewer';
+import { AdminDashboard } from './pages/AdminDashboard';
 import { AuthProvider } from './contexts/AuthContext';
 import { ConversationProvider, useConversations } from './contexts/ConversationContext';
 import { ProtectedRoute } from './components/auth/ProtectedRoute';
+import { AdminRoute } from './components/auth/AdminRoute';
 
 /**
  * AppContent - Main app routing logic
  *
- * Simplified to just handle view switching. All state management
- * is delegated to ConversationContext. Much cleaner than before.
+ * Handles view switching between Library, Viewer, and Admin Dashboard.
+ * Admin dashboard is gated by AdminRoute component.
  */
 function AppContent() {
-  const [currentView, setCurrentView] = useState<'library' | 'viewer'>('library');
+  const [currentView, setCurrentView] = useState<'library' | 'viewer' | 'admin'>('library');
   const { isLoaded, activeConversation, setActiveConversationId } = useConversations();
 
   const handleOpen = (id: string) => {
@@ -25,6 +27,14 @@ function AppContent() {
     setActiveConversationId(null);
   };
 
+  const handleAdminClick = () => {
+    setCurrentView('admin');
+  };
+
+  const handleAdminBack = () => {
+    setCurrentView('library');
+  };
+
   if (!isLoaded) {
     return (
       <div className="h-screen w-screen flex items-center justify-center bg-slate-50 text-slate-400">
@@ -33,11 +43,19 @@ function AppContent() {
     );
   }
 
+  if (currentView === 'admin') {
+    return (
+      <AdminRoute fallback={<Library onOpen={handleOpen} onAdminClick={handleAdminClick} />}>
+        <AdminDashboard onBack={handleAdminBack} />
+      </AdminRoute>
+    );
+  }
+
   if (currentView === 'viewer' && activeConversation) {
     return <Viewer onBack={handleBack} />;
   }
 
-  return <Library onOpen={handleOpen} />;
+  return <Library onOpen={handleOpen} onAdminClick={handleAdminClick} />;
 }
 
 /**

--- a/components/auth/AdminRoute.tsx
+++ b/components/auth/AdminRoute.tsx
@@ -1,0 +1,22 @@
+import React, { ReactNode } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface AdminRouteProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+/**
+ * AdminRoute - Gate admin-only content
+ *
+ * Renders children only if the current user has isAdmin=true in Firestore.
+ * Shows fallback (or nothing) otherwise. Not a full redirect component -
+ * just a simple conditional render for admin UI sections.
+ */
+export const AdminRoute: React.FC<AdminRouteProps> = ({ children, fallback = null }) => {
+  const { isAdmin, loading } = useAuth();
+
+  if (loading) return null;
+  if (!isAdmin) return <>{fallback}</>;
+  return <>{children}</>;
+};

--- a/firestore.rules
+++ b/firestore.rules
@@ -16,6 +16,13 @@ service cloud.firestore {
       return isAuthenticated() && request.auth.uid == userId;
     }
 
+    // Helper function: Check if user is admin
+    function isAdmin() {
+      return request.auth != null &&
+        exists(/databases/$(database)/documents/users/$(request.auth.uid)) &&
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true;
+    }
+
     // Helper function: Validate conversation document structure
     function isValidConversation() {
       let data = request.resource.data;
@@ -53,6 +60,12 @@ service cloud.firestore {
       // Users can delete their own conversations
       allow delete: if isAuthenticated()
         && resource.data.userId == request.auth.uid;
+    }
+
+    // Metrics collection - admin read only, Cloud Functions write only
+    match /_metrics/{doc} {
+      allow read: if isAdmin();
+      allow write: if false; // Only Cloud Functions can write metrics
     }
 
     // Future: Shares subcollection for collaboration

--- a/functions/jest.config.js
+++ b/functions/jest.config.js
@@ -1,0 +1,17 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.test.ts',
+    '!src/__tests__/**'
+  ],
+  // Mock firebase-functions logger by default
+  setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts'],
+  // Ignore lib directory
+  modulePathIgnorePatterns: ['<rootDir>/lib/']
+};

--- a/functions/src/__tests__/circuitBreaker.test.ts
+++ b/functions/src/__tests__/circuitBreaker.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for circuit breaker
+ */
+
+import { CircuitBreaker } from '../circuitBreaker';
+
+// Mock the logger to avoid actual logging during tests
+jest.mock('../logger', () => ({
+  log: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+describe('CircuitBreaker', () => {
+  let circuit: CircuitBreaker;
+
+  beforeEach(() => {
+    // Create fresh circuit breaker for each test
+    circuit = new CircuitBreaker('test-service', {
+      failureThreshold: 2,
+      resetTimeout: 1000,
+      halfOpenRequests: 1
+    });
+  });
+
+  it('should start in closed state', () => {
+    const stats = circuit.getStats();
+    expect(stats.state).toBe('closed');
+    expect(stats.failureCount).toBe(0);
+    expect(stats.successCount).toBe(0);
+  });
+
+  it('should allow requests in closed state', () => {
+    expect(circuit.isAllowed()).toBe(true);
+  });
+
+  it('should transition to open after failureThreshold failures', async () => {
+    const failingFn = jest.fn().mockRejectedValue(new Error('Service down'));
+
+    // First failure
+    await expect(circuit.execute(failingFn)).rejects.toThrow('Service down');
+    expect(circuit.getStats().state).toBe('closed');
+
+    // Second failure - should open circuit
+    await expect(circuit.execute(failingFn)).rejects.toThrow('Service down');
+    expect(circuit.getStats().state).toBe('open');
+  });
+
+  it('should block requests when circuit is open', async () => {
+    const failingFn = jest.fn().mockRejectedValue(new Error('Service down'));
+
+    // Trigger circuit open
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+
+    // Circuit should be open now
+    expect(circuit.getStats().state).toBe('open');
+
+    // Next request should be blocked
+    await expect(circuit.execute(failingFn)).rejects.toThrow('Circuit breaker open');
+  });
+
+  it('should call fallback when circuit is open', async () => {
+    const failingFn = jest.fn().mockRejectedValue(new Error('Service down'));
+    const fallbackFn = jest.fn().mockResolvedValue('fallback result');
+
+    // Trigger circuit open
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+
+    // Circuit should be open, fallback should be called
+    const result = await circuit.execute(failingFn, fallbackFn);
+    expect(result).toBe('fallback result');
+    expect(fallbackFn).toHaveBeenCalled();
+  });
+
+  it('should transition to half-open after resetTimeout', async () => {
+    const failingFn = jest.fn().mockRejectedValue(new Error('Service down'));
+
+    // Trigger circuit open
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+    expect(circuit.getStats().state).toBe('open');
+
+    // Wait for reset timeout (1000ms)
+    await new Promise(resolve => setTimeout(resolve, 1100));
+
+    // Check if circuit transitions to half-open
+    expect(circuit.isAllowed()).toBe(true);
+    const stats = circuit.getStats();
+    expect(stats.state).toBe('half-open');
+  });
+
+  it('should transition to closed after halfOpenRequests successes', async () => {
+    const failingFn = jest.fn().mockRejectedValue(new Error('Service down'));
+    const successFn = jest.fn().mockResolvedValue('success');
+
+    // Trigger circuit open
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+    expect(circuit.getStats().state).toBe('open');
+
+    // Wait for reset timeout
+    await new Promise(resolve => setTimeout(resolve, 1100));
+
+    // Circuit should be half-open, try a successful request
+    await circuit.execute(successFn);
+
+    // Circuit should be closed after 1 success (halfOpenRequests = 1)
+    const stats = circuit.getStats();
+    expect(stats.state).toBe('closed');
+    expect(stats.failureCount).toBe(0);
+  });
+
+  it('should transition back to open if request fails in half-open state', async () => {
+    const failingFn = jest.fn().mockRejectedValue(new Error('Service down'));
+
+    // Trigger circuit open
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+    expect(circuit.getStats().state).toBe('open');
+
+    // Wait for reset timeout
+    await new Promise(resolve => setTimeout(resolve, 1100));
+
+    // Circuit should be half-open, try a failing request
+    await expect(circuit.execute(failingFn)).rejects.toThrow('Service down');
+
+    // Circuit should be open again
+    expect(circuit.getStats().state).toBe('open');
+  });
+
+  it('should reset circuit manually', async () => {
+    const failingFn = jest.fn().mockRejectedValue(new Error('Service down'));
+
+    // Trigger circuit open
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+    expect(circuit.getStats().state).toBe('open');
+
+    // Manual reset
+    circuit.reset();
+
+    // Circuit should be closed
+    const stats = circuit.getStats();
+    expect(stats.state).toBe('closed');
+    expect(stats.failureCount).toBe(0);
+    expect(stats.successCount).toBe(0);
+  });
+
+  it('should track total requests and failures', async () => {
+    const failingFn = jest.fn().mockRejectedValue(new Error('Service down'));
+    const successFn = jest.fn().mockResolvedValue('success');
+
+    // Mix of successes and failures
+    await circuit.execute(successFn);
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+    await circuit.execute(successFn);
+
+    const stats = circuit.getStats();
+    expect(stats.totalRequests).toBe(3);
+    expect(stats.totalFailures).toBe(1);
+  });
+
+  it('should reset failure count after success in closed state', async () => {
+    const failingFn = jest.fn().mockRejectedValue(new Error('Service down'));
+    const successFn = jest.fn().mockResolvedValue('success');
+
+    // One failure
+    await expect(circuit.execute(failingFn)).rejects.toThrow();
+    expect(circuit.getStats().failureCount).toBe(1);
+
+    // Success should reset failure count
+    await circuit.execute(successFn);
+    expect(circuit.getStats().failureCount).toBe(0);
+    expect(circuit.getStats().state).toBe('closed');
+  });
+});

--- a/functions/src/__tests__/logger.test.ts
+++ b/functions/src/__tests__/logger.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for structured logger utility
+ */
+
+import { formatMessage } from '../logger';
+
+describe('logger', () => {
+  describe('formatMessage', () => {
+    it('should format message with no context', () => {
+      const result = formatMessage('Test message');
+      expect(result).toBe('Test message');
+    });
+
+    it('should format message with conversationId', () => {
+      const result = formatMessage('Test message', {
+        conversationId: 'abc123def456' // pragma: allowlist secret
+      });
+      expect(result).toBe('[abc123de] Test message');
+    });
+
+    it('should format message with stage', () => {
+      const result = formatMessage('Test message', {
+        stage: 'gemini'
+      });
+      expect(result).toBe('[gemini] Test message');
+    });
+
+    it('should format message with conversationId and stage', () => {
+      const result = formatMessage('Test message', {
+        conversationId: 'abc123def456', // pragma: allowlist secret
+        stage: 'whisperx'
+      });
+      expect(result).toBe('[abc123de][whisperx] Test message');
+    });
+
+    it('should handle empty context object', () => {
+      const result = formatMessage('Test message', {});
+      expect(result).toBe('Test message');
+    });
+
+    it('should handle short conversationId', () => {
+      const result = formatMessage('Test message', {
+        conversationId: 'abc'
+      });
+      expect(result).toBe('[abc] Test message');
+    });
+
+    it('should ignore extra context fields in formatting', () => {
+      const result = formatMessage('Test message', {
+        conversationId: 'abc123def456', // pragma: allowlist secret
+        userId: 'user123',
+        duration: 1000,
+        customField: 'ignored'
+      });
+      // Only conversationId is used in prefix
+      expect(result).toBe('[abc123de] Test message');
+    });
+  });
+});

--- a/functions/src/__tests__/setup.ts
+++ b/functions/src/__tests__/setup.ts
@@ -1,0 +1,11 @@
+// Jest setup for Firebase Functions tests
+// Mock firebase-functions logger to prevent actual logging during tests
+
+jest.mock('firebase-functions', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+  }
+}));

--- a/functions/src/circuitBreaker.ts
+++ b/functions/src/circuitBreaker.ts
@@ -1,0 +1,224 @@
+/**
+ * Circuit Breaker pattern for external API calls
+ *
+ * Protects against cascading failures when external services are down.
+ * States: closed (normal) → open (failing) → half-open (testing) → closed
+ */
+
+import { log } from './logger';
+
+type CircuitState = 'closed' | 'open' | 'half-open';
+
+interface CircuitBreakerConfig {
+  failureThreshold: number;    // Failures before opening circuit
+  resetTimeout: number;         // Milliseconds before trying half-open
+  halfOpenRequests: number;     // Successes needed to close circuit
+}
+
+interface CircuitStats {
+  state: CircuitState;
+  failureCount: number;
+  successCount: number;
+  lastFailureTime?: number;
+  totalRequests: number;
+  totalFailures: number;
+}
+
+/**
+ * Circuit breaker for external API calls
+ * Prevents hammering a failing service and provides fast-fail behavior
+ */
+export class CircuitBreaker {
+  private state: CircuitState = 'closed';
+  private failureCount = 0;
+  private successCount = 0;
+  private lastFailureTime?: number;
+  private totalRequests = 0;
+  private totalFailures = 0;
+
+  constructor(
+    private readonly name: string,
+    private readonly config: CircuitBreakerConfig
+  ) {
+    log.info(`Circuit breaker initialized: ${name}`, {
+      stage: 'circuit-breaker',
+      failureThreshold: config.failureThreshold,
+      resetTimeout: config.resetTimeout
+    });
+  }
+
+  /**
+   * Execute a function with circuit breaker protection
+   * Throws error if circuit is open, calls fallback if provided
+   */
+  async execute<T>(
+    fn: () => Promise<T>,
+    fallback?: () => Promise<T>
+  ): Promise<T> {
+    this.totalRequests++;
+
+    // Check if circuit allows request
+    if (!this.isAllowed()) {
+      log.warn(`Circuit breaker OPEN for ${this.name} - request blocked`, {
+        stage: 'circuit-breaker',
+        state: this.state,
+        failureCount: this.failureCount
+      });
+
+      if (fallback) {
+        log.info(`Using fallback for ${this.name}`, { stage: 'circuit-breaker' });
+        return fallback();
+      }
+
+      throw new Error(`Circuit breaker open for ${this.name} - service unavailable`);
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess();
+      return result;
+    } catch (error) {
+      this.onFailure(error);
+
+      // Still throw the error after recording it
+      // Caller decides how to handle
+      throw error;
+    }
+  }
+
+  /**
+   * Check if circuit allows request
+   */
+  isAllowed(): boolean {
+    if (this.state === 'closed') {
+      return true;
+    }
+
+    if (this.state === 'open') {
+      // Check if enough time has passed to try half-open
+      const now = Date.now();
+      const timeSinceFailure = this.lastFailureTime
+        ? now - this.lastFailureTime
+        : Infinity;
+
+      if (timeSinceFailure >= this.config.resetTimeout) {
+        this.transitionTo('half-open');
+        return true;
+      }
+
+      return false;
+    }
+
+    // half-open state - allow requests
+    return true;
+  }
+
+  /**
+   * Get current circuit breaker statistics
+   */
+  getStats(): CircuitStats {
+    return {
+      state: this.state,
+      failureCount: this.failureCount,
+      successCount: this.successCount,
+      lastFailureTime: this.lastFailureTime,
+      totalRequests: this.totalRequests,
+      totalFailures: this.totalFailures
+    };
+  }
+
+  /**
+   * Manually reset circuit breaker to closed state
+   */
+  reset(): void {
+    log.info(`Circuit breaker manually reset: ${this.name}`, {
+      stage: 'circuit-breaker'
+    });
+    this.transitionTo('closed');
+    this.failureCount = 0;
+    this.successCount = 0;
+    this.lastFailureTime = undefined;
+  }
+
+  /**
+   * Handle successful request
+   */
+  private onSuccess(): void {
+    this.failureCount = 0;
+
+    if (this.state === 'half-open') {
+      this.successCount++;
+
+      if (this.successCount >= this.config.halfOpenRequests) {
+        this.transitionTo('closed');
+        this.successCount = 0;
+      }
+    }
+  }
+
+  /**
+   * Handle failed request
+   */
+  private onFailure(error: unknown): void {
+    this.failureCount++;
+    this.totalFailures++;
+    this.lastFailureTime = Date.now();
+
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    log.warn(`Circuit breaker failure for ${this.name}`, {
+      stage: 'circuit-breaker',
+      failureCount: this.failureCount,
+      threshold: this.config.failureThreshold,
+      error: errorMessage
+    });
+
+    if (this.state === 'half-open') {
+      // Failure during half-open - go back to open
+      this.transitionTo('open');
+      this.successCount = 0;
+    } else if (this.failureCount >= this.config.failureThreshold) {
+      // Too many failures - open circuit
+      this.transitionTo('open');
+    }
+  }
+
+  /**
+   * Transition to new state with logging
+   */
+  private transitionTo(newState: CircuitState): void {
+    if (this.state === newState) {
+      return;
+    }
+
+    log.warn(`Circuit breaker state change: ${this.name} ${this.state} → ${newState}`, {
+      stage: 'circuit-breaker',
+      oldState: this.state,
+      newState,
+      failureCount: this.failureCount,
+      totalFailures: this.totalFailures
+    });
+
+    this.state = newState;
+  }
+}
+
+/**
+ * Circuit breaker for Replicate (WhisperX) API
+ * Conservative settings - 2 failures triggers open
+ */
+export const replicateCircuit = new CircuitBreaker('replicate', {
+  failureThreshold: 2,
+  resetTimeout: 60000,      // 1 minute
+  halfOpenRequests: 1
+});
+
+/**
+ * Circuit breaker for Gemini API
+ * More lenient - 3 failures before opening
+ */
+export const geminiCircuit = new CircuitBreaker('gemini', {
+  failureThreshold: 3,
+  resetTimeout: 30000,       // 30 seconds
+  halfOpenRequests: 2
+});

--- a/functions/src/logger.ts
+++ b/functions/src/logger.ts
@@ -1,0 +1,133 @@
+/**
+ * Structured logging utility for Cloud Functions
+ *
+ * Wraps firebase-functions logger with context-aware formatting.
+ * All logs include conversationId/userId when available for traceability.
+ */
+
+import { logger } from 'firebase-functions';
+
+interface LogContext {
+  conversationId?: string;
+  userId?: string;
+  stage?: string;
+  duration?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Format log message with context prefix
+ * Example: "[abc12345][gemini] Analysis complete"
+ */
+export function formatMessage(message: string, context?: LogContext): string {
+  const prefix = context?.conversationId
+    ? `[${context.conversationId.slice(0, 8)}]`
+    : '';
+  const stage = context?.stage ? `[${context.stage}]` : '';
+  return `${prefix}${stage} ${message}`.trim();
+}
+
+/**
+ * Logger interface for type-safe logging
+ */
+interface Logger {
+  info(message: string, context?: LogContext): void;
+  warn(message: string, context?: LogContext): void;
+  error(message: string, context?: LogContext): void;
+  debug(message: string, context?: LogContext): void;
+  timing(operation: string, durationMs: number, context?: LogContext): void;
+  timed<T>(operation: string, fn: () => Promise<T>, context?: LogContext): Promise<{ result: T; durationMs: number }>;
+  child(defaultContext: LogContext): Logger;
+}
+
+/**
+ * Structured logger with context support
+ */
+export const log: Logger = {
+  /**
+   * Info-level logs (default visibility)
+   */
+  info(message: string, context?: LogContext): void {
+    const formatted = formatMessage(message, context);
+    logger.info(formatted, context);
+  },
+
+  /**
+   * Warning-level logs
+   */
+  warn(message: string, context?: LogContext): void {
+    const formatted = formatMessage(message, context);
+    logger.warn(formatted, context);
+  },
+
+  /**
+   * Error-level logs
+   */
+  error(message: string, context?: LogContext): void {
+    const formatted = formatMessage(message, context);
+    logger.error(formatted, context);
+  },
+
+  /**
+   * Debug-level logs (only visible when LOG_LEVEL=DEBUG)
+   */
+  debug(message: string, context?: LogContext): void {
+    // Only log debug messages if LOG_LEVEL is DEBUG
+    if (process.env.LOG_LEVEL === 'DEBUG') {
+      const formatted = formatMessage(message, context);
+      logger.debug(formatted, context);
+    }
+  },
+
+  /**
+   * Log timing information
+   */
+  timing(operation: string, durationMs: number, context?: LogContext): void {
+    const formatted = formatMessage(
+      `${operation} took ${durationMs}ms (${(durationMs / 1000).toFixed(1)}s)`,
+      { ...context, duration: durationMs }
+    );
+    logger.info(formatted, { ...context, duration: durationMs });
+  },
+
+  /**
+   * Execute function and log timing
+   * Returns { result, durationMs } for use in metrics
+   */
+  async timed<T>(
+    operation: string,
+    fn: () => Promise<T>,
+    context?: LogContext
+  ): Promise<{ result: T; durationMs: number }> {
+    const startTime = Date.now();
+    const result = await fn();
+    const durationMs = Date.now() - startTime;
+
+    this.timing(operation, durationMs, context);
+
+    return { result, durationMs };
+  },
+
+  /**
+   * Create child logger with default context
+   * Useful for scoping all logs in a function to a specific conversation
+   */
+  child(defaultContext: LogContext): Logger {
+    return {
+      info: (message: string, context?: LogContext) =>
+        log.info(message, { ...defaultContext, ...context }),
+      warn: (message: string, context?: LogContext) =>
+        log.warn(message, { ...defaultContext, ...context }),
+      error: (message: string, context?: LogContext) =>
+        log.error(message, { ...defaultContext, ...context }),
+      debug: (message: string, context?: LogContext) =>
+        log.debug(message, { ...defaultContext, ...context }),
+      timing: (operation: string, durationMs: number, context?: LogContext) =>
+        log.timing(operation, durationMs, { ...defaultContext, ...context }),
+      timed: <T>(operation: string, fn: () => Promise<T>, context?: LogContext) =>
+        log.timed(operation, fn, { ...defaultContext, ...context }),
+      child: (childContext: LogContext) =>
+        log.child({ ...defaultContext, ...childContext })
+    };
+  }
+};

--- a/functions/src/metrics.ts
+++ b/functions/src/metrics.ts
@@ -1,0 +1,79 @@
+/**
+ * Processing metrics collection
+ *
+ * Records timing and outcome data for each transcription job.
+ * Stored in _metrics collection for analysis and monitoring.
+ */
+
+import { FieldValue } from 'firebase-admin/firestore';
+import { db } from './index';
+import { log } from './logger';
+
+/**
+ * Processing stage timings (in milliseconds)
+ */
+export interface ProcessingMetrics {
+  conversationId: string;
+  userId: string;
+  status: 'success' | 'failed';
+  errorMessage?: string;
+  alignmentStatus?: 'aligned' | 'fallback';
+
+  // Stage timings (ms)
+  timingMs: {
+    download: number;
+    whisperx: number;
+    buildSegments: number;
+    gemini: number;
+    speakerCorrection: number;
+    transform: number;
+    firestore: number;
+    total: number;
+  };
+
+  // Result counts
+  segmentCount: number;
+  speakerCount: number;
+  termCount: number;
+  topicCount: number;
+  personCount: number;
+  speakerCorrectionsApplied: number;
+
+  // Audio metadata
+  audioSizeMB: number;
+  durationMs: number;
+
+  // Timestamp
+  timestamp: FieldValue;
+}
+
+/**
+ * Record processing metrics to Firestore
+ * Stored in _metrics collection for analysis
+ */
+export async function recordMetrics(metrics: Omit<ProcessingMetrics, 'timestamp'>): Promise<void> {
+  try {
+    const metricsWithTimestamp: ProcessingMetrics = {
+      ...metrics,
+      timestamp: FieldValue.serverTimestamp()
+    };
+
+    await db.collection('_metrics').add(metricsWithTimestamp);
+
+    log.info('Metrics recorded', {
+      conversationId: metrics.conversationId,
+      stage: 'metrics',
+      status: metrics.status,
+      totalMs: metrics.timingMs.total
+    });
+  } catch (error) {
+    // Don't fail the transcription if metrics recording fails
+    // Just log the error
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    log.warn('Failed to record metrics', {
+      conversationId: metrics.conversationId,
+      stage: 'metrics',
+      error: errorMessage
+    });
+  }
+}

--- a/pages/AdminDashboard.tsx
+++ b/pages/AdminDashboard.tsx
@@ -1,0 +1,266 @@
+import React, { useState, useEffect } from 'react';
+import { collection, query, orderBy, limit, getDocs } from 'firebase/firestore';
+import { db } from '../firebase-config';
+import { Button } from '../components/Button';
+import { ArrowLeft, Activity, Clock, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
+import { formatTime } from '../utils';
+
+interface AdminDashboardProps {
+  onBack: () => void;
+}
+
+interface MetricData {
+  conversationId: string;
+  processingTimeMs?: number;
+  success: boolean;
+  timestamp: string;
+  userId?: string;
+  errorMessage?: string;
+  alignmentStatus?: 'aligned' | 'fallback' | 'pending';
+}
+
+/**
+ * AdminDashboard - Observability metrics view for admin users
+ *
+ * Shows aggregate processing stats and recent job history from _metrics collection.
+ * Server-side Cloud Functions write to _metrics after each processing job.
+ * Simple table display - no fancy charts yet, just the data we need.
+ */
+export const AdminDashboard: React.FC<AdminDashboardProps> = ({ onBack }) => {
+  const [metrics, setMetrics] = useState<MetricData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchMetrics = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        // Query _metrics collection - most recent first, limit to 50
+        const metricsQuery = query(
+          collection(db, '_metrics'),
+          orderBy('timestamp', 'desc'),
+          limit(50)
+        );
+
+        const snapshot = await getDocs(metricsQuery);
+        const data: MetricData[] = [];
+
+        snapshot.forEach((doc) => {
+          const docData = doc.data();
+          data.push({
+            conversationId: doc.id,
+            processingTimeMs: docData.processingTimeMs,
+            success: docData.success ?? false,
+            timestamp: docData.timestamp,
+            userId: docData.userId,
+            errorMessage: docData.errorMessage,
+            alignmentStatus: docData.alignmentStatus,
+          });
+        });
+
+        setMetrics(data);
+      } catch (err) {
+        console.error('[AdminDashboard] Failed to fetch metrics:', err);
+        setError('Failed to load metrics. Check console for details.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchMetrics();
+  }, []);
+
+  // Calculate aggregate stats
+  const totalJobs = metrics.length;
+  const successfulJobs = metrics.filter((m) => m.success).length;
+  const failedJobs = totalJobs - successfulJobs;
+  const successRate = totalJobs > 0 ? ((successfulJobs / totalJobs) * 100).toFixed(1) : '0';
+
+  const avgProcessingTime =
+    metrics.length > 0
+      ? metrics.reduce((sum, m) => sum + (m.processingTimeMs || 0), 0) / metrics.length
+      : 0;
+
+  const alignedCount = metrics.filter((m) => m.alignmentStatus === 'aligned').length;
+  const fallbackCount = metrics.filter((m) => m.alignmentStatus === 'fallback').length;
+
+  return (
+    <div className="min-h-screen bg-slate-50 p-6 md:p-12">
+      <div className="max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-2xl font-bold text-slate-900">Admin Dashboard</h1>
+            <p className="text-slate-500 mt-1">Processing metrics and observability</p>
+          </div>
+          <Button variant="ghost" onClick={onBack} className="gap-2">
+            <ArrowLeft size={18} />
+            Back to Library
+          </Button>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 size={40} className="text-blue-500 animate-spin" />
+          </div>
+        ) : error ? (
+          <div className="bg-red-50 border border-red-200 rounded-xl p-6 text-red-700">
+            {error}
+          </div>
+        ) : (
+          <>
+            {/* Aggregate Stats */}
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
+              <StatCard
+                icon={<Activity size={20} />}
+                label="Total Jobs"
+                value={totalJobs.toString()}
+                color="blue"
+              />
+              <StatCard
+                icon={<CheckCircle2 size={20} />}
+                label="Success Rate"
+                value={`${successRate}%`}
+                color="emerald"
+              />
+              <StatCard
+                icon={<Clock size={20} />}
+                label="Avg Processing Time"
+                value={formatTime(avgProcessingTime)}
+                color="purple"
+              />
+              <StatCard
+                icon={<XCircle size={20} />}
+                label="Failed Jobs"
+                value={failedJobs.toString()}
+                color="red"
+              />
+            </div>
+
+            {/* Alignment Stats */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+              <StatCard
+                icon={<CheckCircle2 size={20} />}
+                label="WhisperX Aligned"
+                value={alignedCount.toString()}
+                color="emerald"
+              />
+              <StatCard
+                icon={<XCircle size={20} />}
+                label="Fallback (Gemini)"
+                value={fallbackCount.toString()}
+                color="amber"
+              />
+            </div>
+
+            {/* Recent Jobs Table */}
+            <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
+              <div className="px-6 py-4 border-b border-slate-200">
+                <h2 className="font-semibold text-slate-900">Recent Processing Jobs</h2>
+              </div>
+
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead className="bg-slate-50 border-b border-slate-200">
+                    <tr className="text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                      <th className="px-6 py-3">Timestamp</th>
+                      <th className="px-6 py-3">Conversation ID</th>
+                      <th className="px-6 py-3">Status</th>
+                      <th className="px-6 py-3">Processing Time</th>
+                      <th className="px-6 py-3">Alignment</th>
+                      <th className="px-6 py-3">Error</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100">
+                    {metrics.length === 0 ? (
+                      <tr>
+                        <td colSpan={6} className="px-6 py-12 text-center text-slate-500">
+                          No metrics data available yet
+                        </td>
+                      </tr>
+                    ) : (
+                      metrics.map((metric) => (
+                        <tr key={metric.conversationId} className="hover:bg-slate-50">
+                          <td className="px-6 py-4 text-sm text-slate-600">
+                            {new Date(metric.timestamp).toLocaleString()}
+                          </td>
+                          <td className="px-6 py-4 text-sm text-slate-900 font-mono">
+                            {metric.conversationId.substring(0, 12)}...
+                          </td>
+                          <td className="px-6 py-4">
+                            {metric.success ? (
+                              <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-700">
+                                <CheckCircle2 size={12} />
+                                Success
+                              </span>
+                            ) : (
+                              <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">
+                                <XCircle size={12} />
+                                Failed
+                              </span>
+                            )}
+                          </td>
+                          <td className="px-6 py-4 text-sm text-slate-600">
+                            {metric.processingTimeMs ? formatTime(metric.processingTimeMs) : '--'}
+                          </td>
+                          <td className="px-6 py-4">
+                            {metric.alignmentStatus === 'aligned' ? (
+                              <span className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-700">
+                                WhisperX
+                              </span>
+                            ) : metric.alignmentStatus === 'fallback' ? (
+                              <span className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700">
+                                Fallback
+                              </span>
+                            ) : (
+                              <span className="text-slate-400 text-xs">--</span>
+                            )}
+                          </td>
+                          <td className="px-6 py-4 text-sm text-red-600">
+                            {metric.errorMessage || '--'}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// Helper component for stat cards
+interface StatCardProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  color: 'blue' | 'emerald' | 'purple' | 'red' | 'amber';
+}
+
+const StatCard: React.FC<StatCardProps> = ({ icon, label, value, color }) => {
+  const colorClasses = {
+    blue: 'bg-blue-100 text-blue-600',
+    emerald: 'bg-emerald-100 text-emerald-600',
+    purple: 'bg-purple-100 text-purple-600',
+    red: 'bg-red-100 text-red-600',
+    amber: 'bg-amber-100 text-amber-600',
+  };
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+      <div className="flex items-center gap-3 mb-2">
+        <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${colorClasses[color]}`}>
+          {icon}
+        </div>
+        <div className="text-xs font-semibold text-slate-500 uppercase tracking-wider">{label}</div>
+      </div>
+      <div className="text-2xl font-bold text-slate-900">{value}</div>
+    </div>
+  );
+};

--- a/pages/Library.tsx
+++ b/pages/Library.tsx
@@ -2,18 +2,21 @@ import React, { useState, useRef, useCallback } from 'react';
 import { Conversation } from '../types';
 import { formatTime, cn, createMockConversation } from '../utils';
 import { useConversations } from '../contexts/ConversationContext';
-import { FileAudio, Calendar, Clock, ChevronRight, UploadCloud, X, Loader2, File as FileIcon, AlertCircle, Trash2, Cloud, CloudOff, RefreshCw, CheckCircle2 } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext';
+import { FileAudio, Calendar, Clock, ChevronRight, UploadCloud, X, Loader2, File as FileIcon, AlertCircle, Trash2, Cloud, CloudOff, RefreshCw, CheckCircle2, Settings } from 'lucide-react';
 import { Button } from '../components/Button';
 import { UserMenu } from '../components/auth/UserMenu';
 import { ProcessingProgress } from '../components/viewer/ProcessingProgress';
 
 interface LibraryProps {
   onOpen: (id: string) => void;
+  onAdminClick: () => void;
 }
 
-export const Library: React.FC<LibraryProps> = ({ onOpen }) => {
+export const Library: React.FC<LibraryProps> = ({ onOpen, onAdminClick }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { conversations, addConversation, deleteConversation, syncStatus } = useConversations();
+  const { isAdmin } = useAuth();
 
   const handleDelete = (e: React.MouseEvent, id: string) => {
     e.stopPropagation();
@@ -73,6 +76,16 @@ export const Library: React.FC<LibraryProps> = ({ onOpen }) => {
              <p className="text-slate-500 mt-1">Your transcribed conversations and meetings.</p>
           </div>
           <div className="flex items-center gap-3">
+            {isAdmin && (
+              <Button
+                variant="ghost"
+                onClick={onAdminClick}
+                className="gap-2"
+              >
+                <Settings size={18} />
+                Admin Dashboard
+              </Button>
+            )}
             <Button
               onClick={() => setIsModalOpen(true)}
               className="gap-2 shadow-lg shadow-blue-500/20"

--- a/types.ts
+++ b/types.ts
@@ -83,6 +83,17 @@ export interface PlaybackState {
   playbackRate: number;
 }
 
+// User profile stored in Firestore users/{userId} collection
+export interface UserProfile {
+  userId: string;
+  email: string;
+  displayName?: string;
+  photoURL?: string;
+  isAdmin: boolean; // Admin users can access observability dashboard
+  createdAt: string;
+  lastLoginAt?: string;
+}
+
 // Processing step enum for granular status tracking
 export enum ProcessingStep {
   PENDING = 'pending',


### PR DESCRIPTION
## Summary
- Adds admin-only observability dashboard for viewing processing metrics
- Single admin user identified via `isAdmin` field in Firestore `users/{userId}` collection
- Dashboard displays aggregate stats and recent processing jobs from `_metrics` collection

## Changes
- **AuthContext**: Extended with `isAdmin` state fetched from Firestore on auth
- **AdminRoute**: New component to gate admin-only content
- **AdminDashboard**: New page displaying metrics (success rate, processing time, alignment stats)
- **Library**: Admin Dashboard button visible only for admin users
- **firestore.rules**: Added `isAdmin()` helper and `_metrics` collection rules

## Test plan
- [ ] Create user document in Firestore with `isAdmin: true`
- [ ] Sign in as admin user
- [ ] Verify "Admin Dashboard" button appears in Library header
- [ ] Navigate to dashboard and verify metrics display
- [ ] Sign in as non-admin user and verify button is hidden