### PR TITLE
fix: exclude test files from functions build

### DIFF
--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -15,5 +15,8 @@
   "compileOnSave": true,
   "include": [
     "src"
+  ],
+  "exclude": [
+    "src/__tests__"
   ]
 }


### PR DESCRIPTION
Fixes Firebase Deploy failure by excluding `src/__tests__` from TypeScript compilation in functions. Tests use Jest's own TS compilation.