### PR TITLE
fix: add Cloud Scheduler API for scheduled functions

### DIFF
--- a/docs/how-to/firebase-setup.md
+++ b/docs/how-to/firebase-setup.md
@@ -108,6 +108,7 @@ Enable each API by clicking the links below:
 | API | Purpose | Link |
 |-----|---------|------|
 | **Cloud Functions** | Run server-side transcription | [Enable](https://console.cloud.google.com/apis/library/cloudfunctions.googleapis.com) |
+| **Cloud Scheduler** | Scheduled functions (daily stats aggregation) | [Enable](https://console.cloud.google.com/apis/library/cloudscheduler.googleapis.com) |
 | **Cloud Build** | Build container images | [Enable](https://console.cloud.google.com/apis/library/cloudbuild.googleapis.com) |
 | **Artifact Registry** | Store container images | [Enable](https://console.cloud.google.com/apis/library/artifactregistry.googleapis.com) |
 | **Secret Manager** | Store API keys securely | [Enable](https://console.cloud.google.com/apis/library/secretmanager.googleapis.com) |
@@ -128,6 +129,7 @@ PROJECT_ID="your-project-id"
 # Enable all required APIs in a single command
 gcloud services enable \
   cloudfunctions.googleapis.com \
+  cloudscheduler.googleapis.com \
   cloudbuild.googleapis.com \
   artifactregistry.googleapis.com \
   secretmanager.googleapis.com \

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -561,6 +561,7 @@ The application requires the following Google Cloud APIs:
 | API | Service | Purpose |
 |-----|---------|---------|
 | `cloudfunctions.googleapis.com` | Cloud Functions | Serverless function execution |
+| `cloudscheduler.googleapis.com` | Cloud Scheduler | Scheduled functions (daily stats aggregation) |
 | `cloudbuild.googleapis.com` | Cloud Build | Build container images for functions |
 | `artifactregistry.googleapis.com` | Artifact Registry | Store container images |
 | `run.googleapis.com` | Cloud Run | Functions v2 runtime (functions run as containers) |

--- a/scripts/gcp-setup.sh
+++ b/scripts/gcp-setup.sh
@@ -260,6 +260,7 @@ APIS=(
     "identitytoolkit.googleapis.com"
     # Cloud Functions
     "cloudfunctions.googleapis.com"
+    "cloudscheduler.googleapis.com"
     "eventarc.googleapis.com"
     "pubsub.googleapis.com"
     # Cloud Run (frontend)


### PR DESCRIPTION
## Summary

Adds `cloudscheduler.googleapis.com` to the required APIs list. This API is needed for the scheduled aggregation function (`computeGlobalStats`) added in #51.

## Changes

- `scripts/gcp-setup.sh` - Added to APIS array
- `docs/how-to/firebase-setup.md` - Added console link + CLI command  
- `docs/reference/architecture.md` - Added to Required APIs table

## Context

The Firebase deploy failed with:
```
Permissions denied enabling cloudscheduler.googleapis.com.
```

This happens because scheduled Cloud Functions (using `onSchedule()`) require the Cloud Scheduler API, which wasn't in our setup scripts.

## Test plan

- [ ] Run `gcloud services enable cloudscheduler.googleapis.com` on existing project
- [ ] Re-run Firebase deploy workflow
- [ ] Verify `computeGlobalStats` function deploys successfully