### PR TITLE
feat: add abort mechanism and retry logic for processing jobs

### DIFF
--- a/functions/src/metrics.ts
+++ b/functions/src/metrics.ts
@@ -70,7 +70,7 @@ export interface EstimatedCost {
 export interface ProcessingMetrics {
   conversationId: string;
   userId: string;
-  status: 'success' | 'failed';
+  status: 'success' | 'failed' | 'aborted';
   errorMessage?: string;
   alignmentStatus?: 'aligned' | 'fallback';
 

--- a/functions/src/userEvents.ts
+++ b/functions/src/userEvents.ts
@@ -22,7 +22,8 @@ export type UserEventType =
   | 'conversation_created'
   | 'conversation_deleted'
   | 'processing_completed'
-  | 'processing_failed';
+  | 'processing_failed'
+  | 'processing_aborted';
 
 /**
  * A single user activity event
@@ -245,6 +246,20 @@ function applyEventToStats(
       stats.lifetime.jobsFailed++;
       stats.last7Days.jobsFailed++;
       stats.last30Days.jobsFailed++;
+      break;
+
+    case 'processing_aborted':
+      // Aborted counts as failed for job stats (user cancelled)
+      stats.lifetime.jobsFailed++;
+      stats.last7Days.jobsFailed++;
+      stats.last30Days.jobsFailed++;
+
+      // Still track any costs incurred before abort
+      if (metadata?.estimatedCostUsd && typeof metadata.estimatedCostUsd === 'number') {
+        stats.lifetime.estimatedCostUsd += metadata.estimatedCostUsd;
+        stats.last7Days.estimatedCostUsd += metadata.estimatedCostUsd;
+        stats.last30Days.estimatedCostUsd += metadata.estimatedCostUsd;
+      }
       break;
   }
 }

--- a/types.ts
+++ b/types.ts
@@ -53,7 +53,8 @@ export interface Conversation {
   updatedAt: string; // For sync conflict resolution and tracking
   durationMs: number;
   audioUrl?: string; // Added field for real audio playback
-  status: 'processing' | 'needs_review' | 'complete' | 'failed';
+  status: 'processing' | 'needs_review' | 'complete' | 'failed' | 'aborted';
+  abortRequested?: boolean;  // Set to true to request abort, Cloud Function checks this
   speakers: Record<string, Speaker>;
   segments: Segment[];
   terms: Record<string, Term>;


### PR DESCRIPTION
## Summary
- Users can now cancel in-progress transcription jobs from the Library page
- Adds retry logic with exponential backoff for Firestore writes that timeout
- Partial resource usage is tracked even when jobs are aborted (costs still recorded)

## Changes
- **Cloud Function** (`functions/src/transcribe.ts`):
  - Added `AbortRequestedError` class and `checkAbort()` function that polls Firestore for abort flag
  - Added `retryWithBackoff()` function with exponential backoff (2s, 4s, 8s) for transient errors
  - Checkpoints after download, WhisperX, Gemini analysis, and speaker correction
  - Partial metrics tracker accumulates usage as processing progresses

- **Metrics** (`functions/src/metrics.ts`):
  - Added `'aborted'` status to ProcessingMetrics type

- **User Events** (`functions/src/userEvents.ts`):
  - Added `'processing_aborted'` event type
  - Aborted jobs count as failed in user stats but still track incurred costs

- **Firestore Service** (`services/firestoreService.ts`):
  - Added `abortProcessing(conversationId)` function that sets `abortRequested: true`

- **Library UI** (`pages/Library.tsx`):
  - Added abort button (⏹) next to processing conversations
  - Added handling for 'aborted' status with amber "Cancelled" badge
  - Confirmation dialog warns about partial costs

- **Types** (`types.ts`):
  - Added `'aborted'` to status union
  - Added `abortRequested?: boolean` field

## Test plan
- [ ] Upload an audio file and verify processing starts
- [ ] Click abort button on processing conversation
- [ ] Verify conversation status changes to "Cancelled"
- [ ] Check `_metrics` collection for aborted job with partial costs
- [ ] Check `_user_events` collection for `processing_aborted` event
- [ ] Verify abort button only shows for processing conversations
- [ ] Verify delete button works for aborted conversations