### PR TITLE
fix: add Cloud Scheduler Admin role for scheduled functions

### DIFF
--- a/docs/how-to/firebase-setup.md
+++ b/docs/how-to/firebase-setup.md
@@ -386,6 +386,7 @@ The service account needs these roles in [Google Cloud IAM](https://console.clou
 |------|---------|
 | **Firebase Rules Admin** | Deploy Firestore and Storage security rules |
 | **Cloud Functions Admin** | Deploy Cloud Functions |
+| **Cloud Scheduler Admin** | Manage scheduled functions (daily stats, etc.) |
 | **Service Account User** | Allow functions to run as service account |
 | **Cloud Datastore User** | Read/write Firestore data |
 | **Storage Admin** | Manage Firebase Storage |
@@ -402,6 +403,7 @@ SA_EMAIL="firebase-adminsdk-xxxxx@${PROJECT_ID}.iam.gserviceaccount.com"
 for ROLE in \
   roles/firebaserules.admin \
   roles/cloudfunctions.admin \
+  roles/cloudscheduler.admin \
   roles/iam.serviceAccountUser \
   roles/datastore.user \
   roles/storage.admin \
@@ -427,6 +429,10 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
 gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:$SA_EMAIL" \
   --role="roles/cloudfunctions.admin"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/cloudscheduler.admin"
 
 gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:$SA_EMAIL" \

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -642,7 +642,7 @@ When an audio file is uploaded to Storage, this event pipeline triggers transcri
 
 | Service Account | Purpose | Key Roles |
 |-----------------|---------|-----------|
-| `firebase-adminsdk-*@PROJECT.iam.gserviceaccount.com` | CI/CD deployment | Cloud Functions Admin, Secret Manager Admin, Firebase Admin |
+| `firebase-adminsdk-*@PROJECT.iam.gserviceaccount.com` | CI/CD deployment | Cloud Functions Admin, Cloud Scheduler Admin, Secret Manager Admin, Firebase Admin |
 | `PROJECT@appspot.gserviceaccount.com` | Cloud Functions runtime | Secret Manager Secret Accessor (auto-granted) |
 
 #### Google-Managed Service Agents
@@ -669,6 +669,7 @@ These are automatically created and managed by Google Cloud:
 │                    firebase-adminsdk-* SA                         │
 ├───────────────────────────────────────────────────────────────────┤
 │  roles/cloudfunctions.admin    → deploy functions                 │
+│  roles/cloudscheduler.admin    → manage scheduled functions       │
 │  roles/firebaserules.admin     → deploy security rules            │
 │  roles/firebase.admin          → Firebase Extensions API          │
 │  roles/storage.admin           → manage Storage                   │

--- a/scripts/gcp-setup.sh
+++ b/scripts/gcp-setup.sh
@@ -352,6 +352,7 @@ log_info "Deployment SA: $SA_EMAIL"
 # Deployment service account roles
 DEPLOYMENT_ROLES=(
     "roles/cloudfunctions.admin"
+    "roles/cloudscheduler.admin"  # Required for scheduled functions
     "roles/firebaserules.admin"
     "roles/firebase.admin"
     "roles/storage.admin"


### PR DESCRIPTION
## Summary
- Adds `roles/cloudscheduler.admin` to deployment service account to fix scheduled function deployment

## Problem
Firebase deploy was failing with:
```
lacks IAM permission "cloudscheduler.jobs.update" for the resource
```

This occurred when deploying scheduled functions like `computeDailyStats`.

## Solution
Added `roles/cloudscheduler.admin` role to the deployment service account in:
- `scripts/gcp-setup.sh` - DEPLOYMENT_ROLES array
- `docs/how-to/firebase-setup.md` - IAM roles table and CLI commands
- `docs/reference/architecture.md` - Service account tables and diagrams

## Test plan
- [ ] Run `gcp-setup.sh` to apply new role (or manually via gcloud)
- [ ] Deploy Firebase functions: `firebase deploy --only functions`
- [ ] Verify scheduled functions deploy without permission errors