### PR TITLE
fix: WhisperX diarization, usage stats, and admin dashboard

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -24,6 +24,30 @@
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "_pricing",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "model", "order": "ASCENDING" },
+        { "fieldPath": "effectiveFrom", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "_metrics",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "_userEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -66,9 +66,10 @@ service cloud.firestore {
     // Observability Collections - Various read access, Cloud Functions write
     // =======================================================================
 
-    // Metrics collection - admin read only, Cloud Functions write
+    // Metrics collection - users can read their own, admin can read all
     match /_metrics/{doc} {
-      allow read: if isAdmin();
+      allow read: if isAdmin() ||
+        (isAuthenticated() && resource.data.userId == request.auth.uid);
       allow write: if false; // Only Cloud Functions can write metrics
     }
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -29,5 +29,5 @@ export { getSignedAudioUrl } from './getAudioUrl';
 // Export stats tracking triggers
 export { onConversationCreated, onConversationDeleted } from './statsTriggers';
 
-// Export scheduled stats aggregation
-export { computeDailyStats } from './statsAggregator';
+// Export scheduled stats aggregation and manual trigger
+export { computeDailyStats, triggerStatsComputation } from './statsAggregator';

--- a/pages/UserStats.tsx
+++ b/pages/UserStats.tsx
@@ -29,7 +29,9 @@ interface UserStatsProps {
 export const UserStats: React.FC<UserStatsProps> = ({ onBack }) => {
   const { user } = useAuth();
   const { data: stats, loading: statsLoading, error: statsError, refetch } = useMyStats();
+  // Always pass user ID - even for admins, "My Usage Stats" shows their own stats
   const { data: recentMetrics, loading: metricsLoading } = useRecentMetrics({
+    userId: user?.uid,
     maxResults: 20
   });
 


### PR DESCRIPTION
## Summary
Fixes multiple issues discovered after audio upload testing:

- **WhisperX JSON parsing errors** - Large responses (~18MB) were getting truncated, causing JSON parse failures
- **Broken diarization** - Every word was being assigned to alternating speakers (10,000+ segments for a single file)
- **Usage stats not visible** - Users couldn't see their own metrics due to Firestore security rules
- **Admin Dashboard empty** - No global stats until scheduled job runs at 2 AM UTC

## Changes

### Backend (Cloud Functions)
- Add `transcribeWithWhisperXRobust()` using Replicate predictions API with manual polling (fixes large response truncation)
- Add `groupWordSegmentsBySpeaker()` to merge word-level segments into sentences (fixes diarization)
- Add `transcribeWithGeminiFallback()` for complete WhisperX failure scenarios
- Add `triggerStatsComputation` callable function for manual stats computation

### Firestore
- Update rules: users can read their own `_metrics` documents
- Add composite indexes for `_pricing`, `_metrics`, `_userEvents` collections

### Frontend
- Fix `metricsService.getRecentMetrics()` to query with userId filter in Firestore
- Fix `UserStats.tsx` to always pass current user's ID
- Add "Compute Stats Now" button to Admin Dashboard

## Test plan
- [ ] Upload a new audio file and verify diarization produces sentence-level segments (not word-level)
- [ ] Check that status updates to "complete" automatically after processing
- [ ] Visit "My Usage Stats" as a non-admin user and verify metrics appear
- [ ] Visit Admin Dashboard and click "Compute Stats Now" to populate overview data
- [ ] Verify pricing data loads without console errors