### PR TITLE
feat: switch to thomasmol/whisper-diarization model

### DIFF
--- a/functions/src/alignment.ts
+++ b/functions/src/alignment.ts
@@ -15,9 +15,9 @@
 import Replicate from 'replicate';
 import fuzz from 'fuzzball';
 
-// Whisper diarization model on Replicate - provides word-level timestamps + speaker diarization
-// Using rafaelgalle/whisper-diarization-advanced: stable, recently updated, good for multi-speaker audio
-const WHISPERX_MODEL = 'rafaelgalle/whisper-diarization-advanced:56dcb55b658e0cb096d663aca0c44bac1466f3acf4304f8ff35af555dc43c9c9';
+// Whisper diarization model on Replicate - provides word/sentence-level timestamps + speaker diarization
+// Using thomasmol/whisper-diarization: Whisper Large V3 Turbo, better diarization, groups segments by speaker
+const WHISPERX_MODEL = 'thomasmol/whisper-diarization:1495a9cddc83b2203b0d8d3516e38b80fd1572ebc4bc5700ac1da56a9b3ed886';
 
 // =============================================================================
 // Configuration


### PR DESCRIPTION
## Summary

Switches WhisperX model from `rafaelgalle/whisper-diarization-advanced` to `thomasmol/whisper-diarization`.

**Problem:** The rafaelgalle model was returning broken diarization (50/50 speaker splits) even with num_speakers and prompt hints.

**Solution:** thomasmol/whisper-diarization:
- Uses **Whisper Large V3 Turbo** (faster, more accurate)
- Has **group_segments** parameter (default true) → returns sentence-level segments
- 4.1M runs with better community feedback
- Same API parameters we already use: `num_speakers`, `prompt`, `language`

## Key Difference

| Feature | rafaelgalle | thomasmol |
|---------|------------|-----------|
| Output | Word-level (1 word per segment) | Sentence-level (grouped by speaker) |
| Diarization | Broken (50/50 splits) | Expected: Better grouping |
| Whisper | Unknown version | Large V3 Turbo |

## Test plan

- [ ] Deploy to Firebase
- [ ] Upload audio with multiple speakers
- [ ] Check if segments are sentence-level (not word-level)
- [ ] Check if diarization correctly identifies speakers
- [ ] Compare speaker distribution in logs