### PR TITLE
feat(progress): add granular PRE_ANALYZING and REASSIGNING steps

### DIFF
--- a/components/viewer/ProcessingProgress.tsx
+++ b/components/viewer/ProcessingProgress.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ProcessingProgress as ProcessingProgressType, ProcessingStep, StepMeta } from '../../types';
-import { Loader2, Upload, Mic, Brain, Activity, CheckCircle2, AlertCircle, Sparkles } from 'lucide-react';
+import { Loader2, Upload, Mic, Brain, Activity, CheckCircle2, AlertCircle, Sparkles, Users, Search } from 'lucide-react';
 import { cn } from '../../utils';
 
 interface ProcessingProgressProps {
@@ -119,6 +119,13 @@ export const ProcessingProgress: React.FC<ProcessingProgressProps> = ({ progress
       bgClass: 'bg-blue-100',
       progressClass: 'bg-blue-500'
     },
+    [ProcessingStep.PRE_ANALYZING]: {
+      icon: Search,
+      label: 'Pre-analyzing',
+      textClass: 'text-cyan-600',
+      bgClass: 'bg-cyan-100',
+      progressClass: 'bg-cyan-500'
+    },
     [ProcessingStep.TRANSCRIBING]: {
       icon: Mic,
       label: 'Transcribing',
@@ -132,6 +139,13 @@ export const ProcessingProgress: React.FC<ProcessingProgressProps> = ({ progress
       textClass: 'text-indigo-600',
       bgClass: 'bg-indigo-100',
       progressClass: 'bg-indigo-500'
+    },
+    [ProcessingStep.REASSIGNING]: {
+      icon: Users,
+      label: 'Reassigning Speakers',
+      textClass: 'text-amber-600',
+      bgClass: 'bg-amber-100',
+      progressClass: 'bg-amber-500'
     },
     [ProcessingStep.ALIGNING]: {
       icon: Activity,

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -411,6 +411,86 @@ interface PersonOccurrence {
 }
 ```
 
+### ProcessingStep
+
+Enum representing granular processing stages:
+
+```typescript
+enum ProcessingStep {
+  PENDING = 'pending',         // Waiting to start
+  UPLOADING = 'uploading',     // Audio uploading to Storage
+  TRANSCRIBING = 'transcribing', // WhisperX transcription
+  ANALYZING = 'analyzing',     // Gemini analysis (terms, topics, people)
+  ALIGNING = 'aligning',       // WhisperX timestamp alignment
+  FINALIZING = 'finalizing',   // Writing results to Firestore
+  COMPLETE = 'complete',       // Processing finished successfully
+  FAILED = 'failed'            // Processing failed with error
+}
+```
+
+### StepMeta
+
+Metadata for enhanced UI display of processing steps:
+
+```typescript
+interface StepMeta {
+  label: string;              // Human-readable step name (e.g., "Transcribing Audio")
+  description?: string;       // Optional detailed description of current activity
+  category: 'pending' | 'active' | 'success' | 'error';  // Visual state category
+}
+```
+
+**Category Values:**
+- `'pending'` - Step not yet started (gray/muted styling)
+- `'active'` - Step currently in progress (blue/animated styling)
+- `'success'` - Step completed successfully (green/check styling)
+- `'error'` - Step failed with error (red/warning styling)
+
+### ProcessingProgress
+
+Real-time processing status for user feedback:
+
+```typescript
+interface ProcessingProgress {
+  currentStep: ProcessingStep;       // Current processing stage
+  percentComplete: number;           // 0-100 progress percentage
+  stepStartedAt?: string;            // ISO timestamp when current step began
+  estimatedRemainingMs?: number;     // Estimated time to completion
+  errorMessage?: string;             // Error details if failed
+  stepMeta?: StepMeta;               // Optional metadata for enhanced UI feedback
+}
+```
+
+**Backward Compatibility Note:** The `stepMeta` field is optional to maintain compatibility with existing conversations created before this feature was added. Legacy data will have `stepMeta: undefined`, and UI components should gracefully handle this case by falling back to default display behavior based on `currentStep`.
+
+**Example JSON:**
+```json
+{
+  "currentStep": "analyzing",
+  "percentComplete": 65,
+  "stepStartedAt": "2025-01-15T14:30:00.000Z",
+  "estimatedRemainingMs": 45000,
+  "stepMeta": {
+    "label": "Analyzing Content",
+    "description": "Extracting topics, terms, and identifying speakers...",
+    "category": "active"
+  }
+}
+```
+
+### ProcessingTimeline
+
+Timeline tracking for performance analysis and debugging:
+
+```typescript
+interface ProcessingTimeline {
+  stepName: ProcessingStep;   // Which step this entry represents
+  startedAt: string;          // ISO timestamp when step started
+  completedAt?: string;       // ISO timestamp when step completed (absent if in-progress)
+  durationMs?: number;        // Duration in milliseconds (computed when completedAt is set)
+}
+```
+
 ## Firebase Storage Structure
 
 ```

--- a/functions/src/progressManager.ts
+++ b/functions/src/progressManager.ts
@@ -5,8 +5,10 @@ import { db } from './index';
 export enum ProcessingStep {
   PENDING = 'pending',
   UPLOADING = 'uploading',
+  PRE_ANALYZING = 'pre_analyzing',
   TRANSCRIBING = 'transcribing',
   ANALYZING = 'analyzing',
+  REASSIGNING = 'reassigning',
   ALIGNING = 'aligning',
   FINALIZING = 'finalizing',
   COMPLETE = 'complete',
@@ -17,8 +19,10 @@ export enum ProcessingStep {
 const STEP_PERCENTAGES: Record<ProcessingStep, number> = {
   [ProcessingStep.PENDING]: 0,
   [ProcessingStep.UPLOADING]: 15,
+  [ProcessingStep.PRE_ANALYZING]: 25,
   [ProcessingStep.TRANSCRIBING]: 40,
   [ProcessingStep.ANALYZING]: 60,
+  [ProcessingStep.REASSIGNING]: 75,
   [ProcessingStep.ALIGNING]: 85,
   [ProcessingStep.FINALIZING]: 95,
   [ProcessingStep.COMPLETE]: 100,
@@ -44,6 +48,11 @@ const STEP_META: Record<ProcessingStep, StepMeta> = {
     description: 'Uploading audio file to storage',
     category: 'active'
   },
+  [ProcessingStep.PRE_ANALYZING]: {
+    label: 'Pre-analyzing',
+    description: 'Identifying speakers and analyzing audio structure',
+    category: 'active'
+  },
   [ProcessingStep.TRANSCRIBING]: {
     label: 'Transcribing',
     description: 'Converting speech to text with speaker diarization',
@@ -52,6 +61,11 @@ const STEP_META: Record<ProcessingStep, StepMeta> = {
   [ProcessingStep.ANALYZING]: {
     label: 'Analyzing',
     description: 'Extracting topics, terms, and detecting people mentioned',
+    category: 'active'
+  },
+  [ProcessingStep.REASSIGNING]: {
+    label: 'Reassigning Speakers',
+    description: 'Correcting speaker identification based on content analysis',
     category: 'active'
   },
   [ProcessingStep.ALIGNING]: {

--- a/types.ts
+++ b/types.ts
@@ -99,8 +99,10 @@ export interface UserProfile {
 export enum ProcessingStep {
   PENDING = 'pending',
   UPLOADING = 'uploading',
+  PRE_ANALYZING = 'pre_analyzing',
   TRANSCRIBING = 'transcribing',
   ANALYZING = 'analyzing',
+  REASSIGNING = 'reassigning',
   ALIGNING = 'aligning',
   FINALIZING = 'finalizing',
   COMPLETE = 'complete',


### PR DESCRIPTION
## Summary

- Add two new processing steps (`PRE_ANALYZING` at 25%, `REASSIGNING` at 75%) to eliminate UI progress gaps
- Fix setStep call ordering bug where progress went backwards (40% → 25%)
- Users now see smooth progression through all significant phases instead of jumps

## Progress Flow

**Before:** `UPLOADING (15%) → TRANSCRIBING (40%) → ANALYZING (60%) → FINALIZING (95%)`

**After:** `UPLOADING (15%) → PRE_ANALYZING (25%) → TRANSCRIBING (40%) → ANALYZING (60%) → REASSIGNING (75%) → FINALIZING (95%)`

## Changes

| File | Change |
|------|--------|
| `types.ts` | Add PRE_ANALYZING, REASSIGNING to ProcessingStep enum |
| `functions/src/progressManager.ts` | Add enum values, percentages (25%, 75%), and STEP_META |
| `functions/src/transcribe.ts` | Fix setStep ordering - PRE_ANALYZING at start, TRANSCRIBING before WhisperX |
| `components/viewer/ProcessingProgress.tsx` | Add legacy fallback styling (defensive) |
| `docs/reference/data-model.md` | Document ProcessingStep, StepMeta, ProcessingProgress interfaces |

## Test Plan

- [ ] Deploy to Firebase and upload an audio file
- [ ] Verify UI shows "Pre-analyzing" (25%) before "Transcribing" (40%)
- [ ] Verify UI shows "Reassigning Speakers" (75%) after "Analyzing" (60%)
- [ ] Confirm progress never goes backwards
- [ ] Check console logs match UI step transitions