### PR TITLE
feat(ux): Foundation Polish UX suite - keyboard shortcuts, stats nav, branded modals

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -65,7 +65,7 @@ function AppContent() {
   }
 
   if (currentView === 'viewer' && activeConversation) {
-    return <Viewer onBack={handleBack} />;
+    return <Viewer onBack={handleBack} onStatsClick={handleStatsClick} />;
   }
 
   return <Library onOpen={handleOpen} onAdminClick={handleAdminClick} onStatsClick={handleStatsClick} />;

--- a/components/auth/UserMenu.tsx
+++ b/components/auth/UserMenu.tsx
@@ -1,14 +1,18 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
-import { LogOut, User as UserIcon } from 'lucide-react';
+import { LogOut, User as UserIcon, BarChart3 } from 'lucide-react';
+
+interface UserMenuProps {
+  onStatsClick?: () => void;
+}
 
 /**
  * UserMenu - Dropdown menu for authenticated users
  *
- * Shows user profile info (photo, name, email) and sign-out option.
+ * Shows user profile info (photo, name, email), My Stats link, and sign-out option.
  * Clicking outside the dropdown closes it automatically.
  */
-export const UserMenu: React.FC = () => {
+export const UserMenu: React.FC<UserMenuProps> = ({ onStatsClick }) => {
   const { user, signOut } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -115,6 +119,23 @@ export const UserMenu: React.FC = () => {
 
           {/* Actions */}
           <div className="py-1">
+            {onStatsClick && (
+              <button
+                onClick={() => {
+                  onStatsClick();
+                  setIsOpen(false);
+                }}
+                className={`
+                  w-full flex items-center gap-3 px-4 py-2
+                  text-sm text-slate-700
+                  hover:bg-slate-50 active:bg-slate-100
+                  transition-colors duration-150
+                `}
+              >
+                <BarChart3 className="w-4 h-4" />
+                <span>My Stats</span>
+              </button>
+            )}
             <button
               onClick={handleSignOut}
               className={`

--- a/components/library/AbortConfirmModal.tsx
+++ b/components/library/AbortConfirmModal.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect } from 'react';
+import { X, AlertTriangle } from 'lucide-react';
+import { Button } from '../Button';
+
+interface AbortConfirmModalProps {
+  conversationTitle: string;
+  currentProgress?: number; // 0-100
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * AbortConfirmModal - Branded confirmation for aborting processing
+ *
+ * Shows conversation context and warns about partial costs.
+ * Follows RenameSpeakerModal pattern for consistency.
+ */
+export const AbortConfirmModal: React.FC<AbortConfirmModalProps> = ({
+  conversationTitle,
+  currentProgress = 0,
+  onConfirm,
+  onCancel
+}) => {
+  // Close on Escape key
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/60 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-white w-full max-w-md rounded-xl shadow-2xl p-6 scale-100 animate-in zoom-in-95 duration-200"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="abort-title"
+      >
+        {/* Header */}
+        <div className="flex justify-between items-start mb-4">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center">
+              <AlertTriangle className="text-amber-600" size={20} />
+            </div>
+            <div>
+              <h3 id="abort-title" className="text-lg font-semibold text-slate-900">
+                Cancel Processing?
+              </h3>
+            </div>
+          </div>
+          <button
+            onClick={onCancel}
+            className="text-slate-400 hover:text-slate-600 transition-colors"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="mb-6 space-y-3">
+          <div className="bg-slate-50 rounded-lg p-3 border border-slate-200">
+            <p className="text-sm font-medium text-slate-900 mb-1">Conversation:</p>
+            <p className="text-sm text-slate-600 truncate">{conversationTitle}</p>
+          </div>
+
+          {currentProgress > 0 && (
+            <div className="bg-slate-50 rounded-lg p-3 border border-slate-200">
+              <p className="text-sm font-medium text-slate-900 mb-2">Current Progress:</p>
+              <div className="flex items-center gap-3">
+                <div className="flex-1 h-2 bg-slate-200 rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-blue-500 transition-all duration-300"
+                    style={{ width: `${currentProgress}%` }}
+                  />
+                </div>
+                <span className="text-sm font-medium text-slate-700">{currentProgress}%</span>
+              </div>
+            </div>
+          )}
+
+          <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+            <p className="text-sm text-amber-800">
+              <span className="font-medium">Warning:</span> Processing costs may still be incurred
+              for work completed so far. The conversation will be marked as cancelled and removed
+              from your library.
+            </p>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3">
+          <Button variant="ghost" onClick={onCancel}>
+            Keep Processing
+          </Button>
+          <Button
+            variant="primary"
+            onClick={onConfirm}
+            className="bg-amber-600 hover:bg-amber-700 focus:ring-amber-500"
+          >
+            Cancel Job
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/library/ProcessingProgressRow.tsx
+++ b/components/library/ProcessingProgressRow.tsx
@@ -1,0 +1,173 @@
+import React, { useState } from 'react';
+import { ProcessingProgress, ProcessingStep } from '../../types';
+import { ChevronDown, ChevronRight, StopCircle, Loader2, Clock } from 'lucide-react';
+import { cn } from '../../utils';
+import { Button } from '../Button';
+
+interface ProcessingProgressRowProps {
+  progress?: ProcessingProgress;
+  onAbort: () => void;
+}
+
+/**
+ * ProcessingProgressRow - Expandable progress row for library view
+ *
+ * Shows current step, percent, ETA, and ratio (if available).
+ * Expands to show detailed info and Abort button.
+ */
+export const ProcessingProgressRow: React.FC<ProcessingProgressRowProps> = ({
+  progress,
+  onAbort
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // Fallback for legacy data
+  if (!progress) {
+    return (
+      <div className="flex items-center gap-2">
+        <Loader2 size={14} className="text-blue-500 animate-spin" />
+        <span className="text-xs text-blue-600 font-medium">Processing...</span>
+      </div>
+    );
+  }
+
+  const { currentStep, percentComplete, estimatedRemainingMs, stepMeta } = progress;
+
+  // Get step label (prefer stepMeta, fallback to step enum)
+  const getStepLabel = () => {
+    if (stepMeta?.label) return stepMeta.label;
+
+    // Fallback labels
+    const labels: Record<ProcessingStep, string> = {
+      [ProcessingStep.PENDING]: 'Queued',
+      [ProcessingStep.UPLOADING]: 'Uploading',
+      [ProcessingStep.PRE_ANALYZING]: 'Pre-analyzing',
+      [ProcessingStep.TRANSCRIBING]: 'Transcribing',
+      [ProcessingStep.ANALYZING]: 'Analyzing',
+      [ProcessingStep.REASSIGNING]: 'Reassigning Speakers',
+      [ProcessingStep.ALIGNING]: 'Aligning',
+      [ProcessingStep.FINALIZING]: 'Finalizing',
+      [ProcessingStep.COMPLETE]: 'Complete',
+      [ProcessingStep.FAILED]: 'Failed'
+    };
+
+    return labels[currentStep] || 'Processing';
+  };
+
+  // Calculate ETA display
+  const getEtaDisplay = () => {
+    if (!estimatedRemainingMs || estimatedRemainingMs <= 0) {
+      return 'Calculating...';
+    }
+
+    const seconds = Math.ceil(estimatedRemainingMs / 1000);
+    if (seconds < 60) {
+      return `${seconds}s`;
+    }
+
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes}m ${remainingSeconds}s`;
+  };
+
+  const isProcessing = ![ProcessingStep.COMPLETE, ProcessingStep.FAILED].includes(currentStep);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Collapsed view - always visible */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="p-1 hover:bg-slate-100 rounded transition-colors"
+          aria-label={isExpanded ? 'Collapse details' : 'Expand details'}
+        >
+          {isExpanded ? (
+            <ChevronDown size={14} className="text-slate-500" />
+          ) : (
+            <ChevronRight size={14} className="text-slate-500" />
+          )}
+        </button>
+
+        <Loader2
+          size={14}
+          className={cn(
+            'text-blue-500',
+            isProcessing && 'animate-spin'
+          )}
+        />
+
+        <div className="flex-1 min-w-0 flex items-center gap-2">
+          <span className="text-xs font-medium text-slate-700 truncate">
+            {getStepLabel()}
+          </span>
+          <span className="text-xs text-blue-600 font-medium shrink-0">
+            {percentComplete}%
+          </span>
+        </div>
+
+        {/* ETA badge */}
+        {estimatedRemainingMs && estimatedRemainingMs > 0 && (
+          <div className="flex items-center gap-1 text-xs text-slate-500 shrink-0">
+            <Clock size={12} />
+            <span>{getEtaDisplay()}</span>
+          </div>
+        )}
+      </div>
+
+      {/* Progress bar */}
+      <div className="w-full bg-slate-200 rounded-full h-1.5 overflow-hidden ml-6">
+        <div
+          className="h-full bg-blue-500 rounded-full transition-all duration-500"
+          style={{ width: `${percentComplete}%` }}
+        />
+      </div>
+
+      {/* Expanded details */}
+      {isExpanded && (
+        <div
+          className="ml-6 mt-1 p-3 bg-slate-50 rounded-lg border border-slate-200 space-y-3 animate-in fade-in slide-in-from-top-1 duration-200"
+        >
+          {/* Step details */}
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            <div>
+              <span className="text-slate-500">Current Step:</span>
+              <p className="font-medium text-slate-900 mt-0.5">{getStepLabel()}</p>
+            </div>
+            <div>
+              <span className="text-slate-500">Progress:</span>
+              <p className="font-medium text-slate-900 mt-0.5">{percentComplete}%</p>
+            </div>
+            {estimatedRemainingMs && estimatedRemainingMs > 0 && (
+              <div>
+                <span className="text-slate-500">Est. Remaining:</span>
+                <p className="font-medium text-slate-900 mt-0.5">{getEtaDisplay()}</p>
+              </div>
+            )}
+            {stepMeta?.description && (
+              <div className="col-span-2">
+                <span className="text-slate-500">Details:</span>
+                <p className="text-slate-700 mt-0.5">{stepMeta.description}</p>
+              </div>
+            )}
+          </div>
+
+          {/* Abort button */}
+          <div className="pt-2 border-t border-slate-200">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAbort();
+              }}
+              className="w-full gap-2 text-amber-600 hover:text-amber-700 hover:bg-amber-50"
+            >
+              <StopCircle size={14} />
+              Cancel Processing
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/shared/CostIndicator.tsx
+++ b/components/shared/CostIndicator.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import { DollarSign, Info } from 'lucide-react';
+import { cn } from '../../utils';
+import { formatUsd } from '../../services/metricsService';
+import { EstimatedCost } from '../../services/metricsService';
+
+interface CostIndicatorProps {
+  cost: number | EstimatedCost;
+  size?: 'sm' | 'md' | 'lg';
+  showIcon?: boolean;
+  showBreakdown?: boolean;
+  className?: string;
+}
+
+/**
+ * CostIndicator - Reusable cost display component
+ *
+ * Shows estimated or actual processing costs with color-coded thresholds:
+ * - Green: $0 - $0.50
+ * - Amber: $0.50 - $2.00
+ * - Red: > $2.00
+ *
+ * Optional breakdown tooltip shows cost per service (Gemini, WhisperX, Diarization).
+ */
+export const CostIndicator: React.FC<CostIndicatorProps> = ({
+  cost,
+  size = 'md',
+  showIcon = true,
+  showBreakdown = true,
+  className
+}) => {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  // Extract total cost and breakdown
+  const totalCost = typeof cost === 'number' ? cost : cost.totalUsd;
+  const breakdown = typeof cost === 'object' ? cost : null;
+
+  // Determine color based on threshold
+  const getColorClass = () => {
+    if (totalCost <= 0.50) {
+      return 'text-emerald-700 bg-emerald-100 border-emerald-200';
+    } else if (totalCost <= 2.00) {
+      return 'text-amber-700 bg-amber-100 border-amber-200';
+    } else {
+      return 'text-red-700 bg-red-100 border-red-200';
+    }
+  };
+
+  // Size variants
+  const sizeClasses = {
+    sm: 'text-xs px-2 py-0.5',
+    md: 'text-sm px-2.5 py-1',
+    lg: 'text-base px-3 py-1.5'
+  };
+
+  const iconSizes = {
+    sm: 10,
+    md: 14,
+    lg: 16
+  };
+
+  return (
+    <div className="relative inline-block">
+      <div
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-full font-medium border',
+          getColorClass(),
+          sizeClasses[size],
+          showBreakdown && breakdown && 'cursor-help',
+          className
+        )}
+        onMouseEnter={() => showBreakdown && breakdown && setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+      >
+        {showIcon && <DollarSign size={iconSizes[size]} />}
+        <span>{formatUsd(totalCost)}</span>
+        {showBreakdown && breakdown && (
+          <Info size={iconSizes[size]} className="opacity-60" />
+        )}
+      </div>
+
+      {/* Breakdown Tooltip */}
+      {showTooltip && breakdown && (
+        <div
+          className="absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 bg-slate-900 text-white text-xs rounded-lg p-3 shadow-xl animate-in fade-in slide-in-from-bottom-1 duration-150"
+          role="tooltip"
+        >
+          <div className="font-semibold mb-2 pb-2 border-b border-slate-700">
+            Cost Breakdown
+          </div>
+          <div className="space-y-1.5">
+            <div className="flex justify-between">
+              <span className="text-slate-300">Gemini Analysis:</span>
+              <span className="font-mono">{formatUsd(breakdown.geminiUsd)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-slate-300">WhisperX:</span>
+              <span className="font-mono">{formatUsd(breakdown.whisperxUsd)}</span>
+            </div>
+            {breakdown.diarizationUsd > 0 && (
+              <div className="flex justify-between">
+                <span className="text-slate-300">Diarization:</span>
+                <span className="font-mono">{formatUsd(breakdown.diarizationUsd)}</span>
+              </div>
+            )}
+            <div className="flex justify-between pt-1.5 mt-1.5 border-t border-slate-700 font-semibold">
+              <span>Total:</span>
+              <span className="font-mono">{formatUsd(breakdown.totalUsd)}</span>
+            </div>
+          </div>
+          {/* Tooltip arrow */}
+          <div className="absolute top-full left-1/2 -translate-x-1/2 -mt-px">
+            <div className="w-2 h-2 bg-slate-900 rotate-45"></div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/shared/DeleteConfirmModal.tsx
+++ b/components/shared/DeleteConfirmModal.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect } from 'react';
+import { X, Trash2, AlertTriangle } from 'lucide-react';
+import { Button } from '../Button';
+import { CostIndicator } from './CostIndicator';
+
+interface DeleteConfirmModalProps {
+  conversationTitle: string;
+  estimatedCost?: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * DeleteConfirmModal - Branded confirmation for deleting conversations
+ *
+ * Shows conversation context, estimated cost, and permanent deletion warning.
+ * Supports keyboard shortcuts: Enter to confirm, Escape to cancel.
+ */
+export const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
+  conversationTitle,
+  estimatedCost,
+  onConfirm,
+  onCancel
+}) => {
+  // Handle keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        onConfirm();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onConfirm, onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/60 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-white w-full max-w-md rounded-xl shadow-2xl p-6 scale-100 animate-in zoom-in-95 duration-200"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-title"
+      >
+        {/* Header */}
+        <div className="flex justify-between items-start mb-4">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-red-100 flex items-center justify-center">
+              <Trash2 className="text-red-600" size={20} />
+            </div>
+            <div>
+              <h3 id="delete-title" className="text-lg font-semibold text-slate-900">
+                Delete Conversation?
+              </h3>
+            </div>
+          </div>
+          <button
+            onClick={onCancel}
+            className="text-slate-400 hover:text-slate-600 transition-colors"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="mb-6 space-y-3">
+          <div className="bg-slate-50 rounded-lg p-3 border border-slate-200">
+            <p className="text-sm font-medium text-slate-900 mb-1">Conversation:</p>
+            <p className="text-sm text-slate-600 truncate">{conversationTitle}</p>
+          </div>
+
+          {estimatedCost !== undefined && estimatedCost > 0 && (
+            <div className="bg-slate-50 rounded-lg p-3 border border-slate-200">
+              <p className="text-sm font-medium text-slate-900 mb-2">Processing Cost:</p>
+              <CostIndicator cost={estimatedCost} size="md" showBreakdown={false} />
+            </div>
+          )}
+
+          <div className="bg-red-50 border border-red-200 rounded-lg p-3">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="text-red-600 shrink-0 mt-0.5" size={16} />
+              <div>
+                <p className="text-sm text-red-800">
+                  <span className="font-medium">This action cannot be undone.</span>
+                </p>
+                <p className="text-sm text-red-700 mt-1">
+                  The conversation and all associated data will be permanently deleted from your
+                  library and cloud storage.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3">
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={onConfirm}
+            className="bg-red-600 hover:bg-red-700 focus:ring-red-500"
+          >
+            Delete
+          </Button>
+        </div>
+
+        {/* Keyboard hint */}
+        <div className="mt-4 pt-3 border-t border-slate-100">
+          <p className="text-xs text-slate-500 text-center">
+            Press <kbd className="px-1.5 py-0.5 bg-slate-100 border border-slate-300 rounded text-[10px] font-mono">Enter</kbd> to delete or{' '}
+            <kbd className="px-1.5 py-0.5 bg-slate-100 border border-slate-300 rounded text-[10px] font-mono">Esc</kbd> to cancel
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/viewer/KeyboardShortcutsModal.tsx
+++ b/components/viewer/KeyboardShortcutsModal.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect } from 'react';
+import { X, Play, Pause, SkipBack, SkipForward, HelpCircle } from 'lucide-react';
+
+interface KeyboardShortcutsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * KeyboardShortcutsModal - Modal listing all keyboard shortcuts
+ *
+ * Organized by category for easy scanning.
+ * Accessible via ? key from anywhere in the viewer.
+ */
+export const KeyboardShortcutsModal: React.FC<KeyboardShortcutsModalProps> = ({
+  isOpen,
+  onClose
+}) => {
+  // Close on Escape key
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      return () => document.removeEventListener('keydown', handleEscape);
+    }
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const shortcuts = [
+    {
+      category: 'Playback',
+      items: [
+        { keys: ['Space'], description: 'Play / Pause', icon: <Play size={16} /> },
+        { keys: ['←', 'J'], description: 'Seek back 5 seconds', icon: <SkipBack size={16} /> },
+        { keys: ['→', 'K'], description: 'Seek forward 5 seconds', icon: <SkipForward size={16} /> }
+      ]
+    },
+    {
+      category: 'Help',
+      items: [
+        { keys: ['?'], description: 'Show this help', icon: <HelpCircle size={16} /> },
+        { keys: ['Esc'], description: 'Close modal', icon: <X size={16} /> }
+      ]
+    }
+  ];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/60 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white w-full max-w-md rounded-xl shadow-2xl p-6 scale-100 animate-in zoom-in-95 duration-200"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="shortcuts-title"
+      >
+        {/* Header */}
+        <div className="flex justify-between items-center mb-6">
+          <h3 id="shortcuts-title" className="text-lg font-semibold text-slate-900">
+            Keyboard Shortcuts
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-600 transition-colors"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Shortcuts by category */}
+        <div className="space-y-6">
+          {shortcuts.map((category) => (
+            <div key={category.category}>
+              <h4 className="text-sm font-semibold text-slate-500 uppercase tracking-wider mb-3">
+                {category.category}
+              </h4>
+              <div className="space-y-2">
+                {category.items.map((item, idx) => (
+                  <div
+                    key={idx}
+                    className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-slate-50"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="text-slate-400">{item.icon}</div>
+                      <span className="text-sm text-slate-700">{item.description}</span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      {item.keys.map((key, keyIdx) => (
+                        <React.Fragment key={keyIdx}>
+                          {keyIdx > 0 && (
+                            <span className="text-xs text-slate-400 mx-1">or</span>
+                          )}
+                          <kbd className="px-2 py-1 text-xs font-mono bg-slate-100 border border-slate-300 rounded shadow-sm">
+                            {key}
+                          </kbd>
+                        </React.Fragment>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer tip */}
+        <div className="mt-6 pt-4 border-t border-slate-100">
+          <p className="text-xs text-slate-500 text-center">
+            Shortcuts work anywhere except when typing in text fields
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/viewer/ViewerHeader.tsx
+++ b/components/viewer/ViewerHeader.tsx
@@ -11,6 +11,7 @@ interface ViewerHeaderProps {
   createdAt: string;
   isSyncing: boolean;
   onBack: () => void;
+  onStatsClick?: () => void;
   // Drift correction metrics (for legacy display)
   driftCorrectionApplied?: boolean;
   driftRatio?: number;
@@ -31,6 +32,7 @@ export const ViewerHeader: React.FC<ViewerHeaderProps> = ({
   createdAt,
   isSyncing,
   onBack,
+  onStatsClick,
   driftCorrectionApplied,
   driftRatio,
   driftMs,
@@ -114,7 +116,7 @@ export const ViewerHeader: React.FC<ViewerHeaderProps> = ({
         <button className="p-2 hover:bg-slate-100 rounded text-slate-500">
           <MoreHorizontal size={20} />
         </button>
-        <UserMenu />
+        <UserMenu onStatsClick={onStatsClick} />
       </div>
     </header>
   );

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react';
+
+interface KeyboardShortcutsCallbacks {
+  togglePlay?: () => void;
+  seekBack?: () => void;
+  seekForward?: () => void;
+  openHelp?: () => void;
+}
+
+/**
+ * useKeyboardShortcuts - Centralized keyboard shortcut handling
+ *
+ * Handles global keyboard shortcuts for the viewer:
+ * - Space: Play/Pause
+ * - ← or J: Seek back 5s
+ * - → or K: Seek forward 5s
+ * - ?: Open keyboard shortcuts help modal
+ * - Escape: Close modal (handled by modal components)
+ *
+ * Ignores events when user is typing in form fields.
+ * Shows a first-time tooltip to introduce keyboard shortcuts.
+ */
+export const useKeyboardShortcuts = (callbacks: KeyboardShortcutsCallbacks) => {
+  const [showFirstTimeTooltip, setShowFirstTimeTooltip] = useState(false);
+  const [helpModalOpen, setHelpModalOpen] = useState(false);
+
+  // Check if this is the first time seeing keyboard shortcuts
+  useEffect(() => {
+    const hasSeenTooltip = localStorage.getItem('keyboard-shortcuts-shown');
+    if (!hasSeenTooltip) {
+      // Show tooltip after a brief delay so it doesn't appear jarring on page load
+      const timer = setTimeout(() => {
+        setShowFirstTimeTooltip(true);
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+  }, []);
+
+  // Mark tooltip as seen and hide it
+  const dismissTooltip = () => {
+    localStorage.setItem('keyboard-shortcuts-shown', 'true');
+    setShowFirstTimeTooltip(false);
+  };
+
+  // Global keyboard event listener
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Don't intercept if user is typing in a form field
+      const target = e.target as HTMLElement;
+      const isFormField =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable;
+
+      if (isFormField) return;
+
+      // Handle shortcuts
+      switch (e.key) {
+        case ' ':
+          e.preventDefault(); // Prevent page scroll
+          callbacks.togglePlay?.();
+          if (showFirstTimeTooltip) {
+            dismissTooltip();
+          }
+          break;
+
+        case 'ArrowLeft':
+        case 'j':
+        case 'J':
+          e.preventDefault();
+          callbacks.seekBack?.();
+          if (showFirstTimeTooltip) {
+            dismissTooltip();
+          }
+          break;
+
+        case 'ArrowRight':
+        case 'k':
+        case 'K':
+          e.preventDefault();
+          callbacks.seekForward?.();
+          if (showFirstTimeTooltip) {
+            dismissTooltip();
+          }
+          break;
+
+        case '?':
+          e.preventDefault();
+          callbacks.openHelp?.();
+          setHelpModalOpen(true);
+          if (showFirstTimeTooltip) {
+            dismissTooltip();
+          }
+          break;
+
+        case 'Escape':
+          // Close help modal if open
+          if (helpModalOpen) {
+            setHelpModalOpen(false);
+          }
+          break;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [callbacks, showFirstTimeTooltip, helpModalOpen]);
+
+  return {
+    showFirstTimeTooltip,
+    dismissTooltip,
+    helpModalOpen,
+    openHelpModal: () => setHelpModalOpen(true),
+    closeHelpModal: () => setHelpModalOpen(false)
+  };
+};

--- a/pages/UserStats.tsx
+++ b/pages/UserStats.tsx
@@ -21,6 +21,7 @@ import {
   MetricsTableSkeleton
 } from '../components/metrics';
 import { formatUsd } from '../services/metricsService';
+import { CostIndicator } from '../components/shared/CostIndicator';
 
 interface UserStatsProps {
   onBack: () => void;
@@ -99,12 +100,23 @@ export const UserStats: React.FC<UserStatsProps> = ({ onBack }) => {
                       sublabel={`${stats.lifetime.totalAudioFiles} audio files`}
                       icon={<Clock size={20} className="text-purple-500" />}
                     />
-                    <StatCard
-                      label="Estimated Cost"
-                      value={formatUsd(stats.lifetime.estimatedCostUsd)}
-                      sublabel="LLM processing costs"
-                      icon={<DollarSign size={20} className="text-amber-500" />}
-                    />
+                    <div className="bg-white rounded-xl border border-slate-200 p-4">
+                      <div className="flex items-center gap-3 mb-3">
+                        <DollarSign size={20} className="text-amber-500" />
+                        <div className="flex-1">
+                          <p className="text-xs text-slate-500 font-medium">Estimated Cost</p>
+                        </div>
+                      </div>
+                      <div className="flex items-baseline gap-2">
+                        <CostIndicator
+                          cost={stats.lifetime.estimatedCostUsd}
+                          size="lg"
+                          showIcon={false}
+                          showBreakdown={false}
+                        />
+                      </div>
+                      <p className="text-xs text-slate-500 mt-2">LLM processing costs</p>
+                    </div>
                   </>
                 ) : (
                   <div className="col-span-4 text-center text-slate-500 py-8 bg-white rounded-lg border border-slate-200">
@@ -142,9 +154,14 @@ export const UserStats: React.FC<UserStatsProps> = ({ onBack }) => {
                         <p className="text-sm text-slate-500">Conversations created</p>
                       </div>
                       <div>
-                        <p className="text-2xl font-bold text-slate-900">
-                          {formatUsd(stats.last7Days.estimatedCostUsd)}
-                        </p>
+                        <div className="mb-1">
+                          <CostIndicator
+                            cost={stats.last7Days.estimatedCostUsd}
+                            size="md"
+                            showIcon={false}
+                            showBreakdown={false}
+                          />
+                        </div>
                         <p className="text-sm text-slate-500">Est. cost</p>
                       </div>
                     </div>
@@ -173,9 +190,14 @@ export const UserStats: React.FC<UserStatsProps> = ({ onBack }) => {
                         <p className="text-sm text-slate-500">Conversations created</p>
                       </div>
                       <div>
-                        <p className="text-2xl font-bold text-slate-900">
-                          {formatUsd(stats.last30Days.estimatedCostUsd)}
-                        </p>
+                        <div className="mb-1">
+                          <CostIndicator
+                            cost={stats.last30Days.estimatedCostUsd}
+                            size="md"
+                            showIcon={false}
+                            showBreakdown={false}
+                          />
+                        </div>
                         <p className="text-sm text-slate-500">Est. cost</p>
                       </div>
                     </div>

--- a/src/__tests__/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/__tests__/hooks/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,176 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useKeyboardShortcuts } from '../../../hooks/useKeyboardShortcuts';
+
+describe('useKeyboardShortcuts', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should show first-time tooltip when not previously shown', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useKeyboardShortcuts({
+      togglePlay: vi.fn(),
+      seekBack: vi.fn(),
+      seekForward: vi.fn()
+    }));
+
+    expect(result.current.showFirstTimeTooltip).toBe(false);
+
+    // Fast-forward past the 1s delay
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(result.current.showFirstTimeTooltip).toBe(true);
+
+    vi.useRealTimers();
+  });
+
+  it('should not show tooltip if already shown before', () => {
+    localStorage.setItem('keyboard-shortcuts-shown', 'true');
+    vi.useFakeTimers();
+
+    const { result } = renderHook(() => useKeyboardShortcuts({
+      togglePlay: vi.fn(),
+      seekBack: vi.fn(),
+      seekForward: vi.fn()
+    }));
+
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(result.current.showFirstTimeTooltip).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it('should call togglePlay on Space key', () => {
+    const togglePlay = vi.fn();
+    renderHook(() => useKeyboardShortcuts({
+      togglePlay,
+      seekBack: vi.fn(),
+      seekForward: vi.fn()
+    }));
+
+    const event = new KeyboardEvent('keydown', { key: ' ' });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(togglePlay).toHaveBeenCalled();
+  });
+
+  it('should call seekBack on ArrowLeft key', () => {
+    const seekBack = vi.fn();
+    renderHook(() => useKeyboardShortcuts({
+      togglePlay: vi.fn(),
+      seekBack,
+      seekForward: vi.fn()
+    }));
+
+    const event = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(seekBack).toHaveBeenCalled();
+  });
+
+  it('should call seekForward on ArrowRight key', () => {
+    const seekForward = vi.fn();
+    renderHook(() => useKeyboardShortcuts({
+      togglePlay: vi.fn(),
+      seekBack: vi.fn(),
+      seekForward
+    }));
+
+    const event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(seekForward).toHaveBeenCalled();
+  });
+
+  it('should not trigger shortcuts when typing in input fields', () => {
+    const togglePlay = vi.fn();
+    renderHook(() => useKeyboardShortcuts({
+      togglePlay,
+      seekBack: vi.fn(),
+      seekForward: vi.fn()
+    }));
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    const event = new KeyboardEvent('keydown', {
+      key: ' ',
+      bubbles: true
+    });
+    Object.defineProperty(event, 'target', { value: input, enumerable: true });
+
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(togglePlay).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  it('should dismiss tooltip and mark as shown', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useKeyboardShortcuts({
+      togglePlay: vi.fn(),
+      seekBack: vi.fn(),
+      seekForward: vi.fn()
+    }));
+
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(result.current.showFirstTimeTooltip).toBe(true);
+
+    act(() => {
+      result.current.dismissTooltip();
+    });
+
+    expect(result.current.showFirstTimeTooltip).toBe(false);
+    expect(localStorage.getItem('keyboard-shortcuts-shown')).toBe('true');
+
+    vi.useRealTimers();
+  });
+
+  it('should open and close help modal', () => {
+    const { result } = renderHook(() => useKeyboardShortcuts({
+      togglePlay: vi.fn(),
+      seekBack: vi.fn(),
+      seekForward: vi.fn()
+    }));
+
+    expect(result.current.helpModalOpen).toBe(false);
+
+    // Open via ? key
+    const openEvent = new KeyboardEvent('keydown', { key: '?' });
+    act(() => {
+      document.dispatchEvent(openEvent);
+    });
+
+    expect(result.current.helpModalOpen).toBe(true);
+
+    // Close via Escape key
+    const closeEvent = new KeyboardEvent('keydown', { key: 'Escape' });
+    act(() => {
+      document.dispatchEvent(closeEvent);
+    });
+
+    expect(result.current.helpModalOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- **Keyboard shortcuts** for Viewer: Space (play/pause), ←/→/J/K (seek), ? (help modal), Escape (close)
- **My Stats navigation** added to user dropdown in Library and Viewer
- **Processing progress rows** now expandable with step/percent/ETA and inline abort
- **Branded confirmation modals** replace `window.confirm` for delete/abort actions
- **CostIndicator component** with color-coded thresholds (green/amber/red) and breakdown tooltip

## New Components (6)
| Component | Purpose |
|-----------|---------|
| `useKeyboardShortcuts` | Centralized keyboard handling with form field exclusion |
| `KeyboardShortcutsModal` | Accessible modal showing organized key bindings |
| `CostIndicator` | Reusable cost display with color thresholds |
| `AbortConfirmModal` | Branded abort confirmation with progress context |
| `DeleteConfirmModal` | Branded delete confirmation with cost display |
| `ProcessingProgressRow` | Expandable progress with step/ETA/abort |

## Modified Files (6)
- `App.tsx` - Pass `onStatsClick` to Viewer
- `UserMenu.tsx` - Add "My Stats" dropdown item
- `ViewerHeader.tsx` - Forward `onStatsClick` to UserMenu
- `Viewer.tsx` - Integrate keyboard shortcuts hook and modal
- `Library.tsx` - Replace `window.confirm`, use new modals/progress row
- `UserStats.tsx` - Add CostIndicator to stats cards

## Test plan
- [x] Build passes (`npm run build`)
- [x] Tests pass (34/34, 8 new for useKeyboardShortcuts)
- [x] Manual: Press `?` in Viewer → shortcuts modal opens
- [x] Manual: Press Space in Viewer → audio plays/pauses
- [x] Manual: Click user avatar → "My Stats" link visible
- [x] Manual: Delete conversation → branded modal (not browser confirm)
- [x] Manual: Processing row → expandable with abort button

## Screenshots
N/A - UI components, recommend manual testing

## Notes
- CostIndicator not added to upload/abort modals due to backend data unavailability (cost data not on Conversation document during processing)
- First-time keyboard tooltip shows once, persisted via localStorage