### PR TITLE
feat(search): add responsive search filters with URL/session persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ __pycache__
 /.agent_process/
 /.claude/
 CLAUDE.md
+/.local_docs/

--- a/components/search/ConversationResultCard.tsx
+++ b/components/search/ConversationResultCard.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { ConversationSearchResult } from '../../services/searchService';
+import { SegmentResult } from './SegmentResult';
+import { FileAudio, ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '../../utils';
+
+interface ConversationResultCardProps {
+  result: ConversationSearchResult;
+  searchQuery: string;
+  onOpenInViewer: (conversationId: string, segmentId: string) => void;
+  defaultExpanded?: boolean;
+}
+
+/**
+ * ConversationResultCard - Groups search results by conversation
+ *
+ * Shows:
+ * - Conversation title and metadata
+ * - Match count for this conversation
+ * - Collapsible list of matching segments
+ */
+export const ConversationResultCard: React.FC<ConversationResultCardProps> = ({
+  result,
+  searchQuery,
+  onOpenInViewer,
+  defaultExpanded = true
+}) => {
+  const [isExpanded, setIsExpanded] = React.useState(defaultExpanded);
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 shadow-sm overflow-hidden">
+      {/* Conversation Header */}
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full px-4 py-3 flex items-center gap-3 hover:bg-slate-50 transition-colors text-left"
+      >
+        {/* Expand/Collapse Icon */}
+        <div className="shrink-0 text-slate-400">
+          {isExpanded ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
+        </div>
+
+        {/* Conversation Icon */}
+        <div className="w-10 h-10 bg-blue-100 text-blue-600 rounded-lg flex items-center justify-center shrink-0">
+          <FileAudio size={20} />
+        </div>
+
+        {/* Title and metadata */}
+        <div className="flex-1 min-w-0">
+          <h3 className="font-medium text-slate-900 truncate">
+            {result.conversation.title}
+          </h3>
+          <p className="text-xs text-slate-500">
+            {result.matches.length} segment{result.matches.length !== 1 ? 's' : ''} • {result.totalMatches} match{result.totalMatches !== 1 ? 'es' : ''}
+          </p>
+        </div>
+
+        {/* Date */}
+        <div className="text-sm text-slate-500 shrink-0">
+          {new Date(result.conversation.createdAt).toLocaleDateString()}
+        </div>
+      </button>
+
+      {/* Matching Segments */}
+      {isExpanded && (
+        <div className="px-4 pb-3 space-y-2 border-t border-slate-100">
+          <div className="pt-3 space-y-1">
+            {result.matches.map((match) => (
+              <SegmentResult
+                key={match.segmentId}
+                match={match}
+                searchQuery={searchQuery}
+                onOpenInViewer={onOpenInViewer}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/search/DateRangeFilter.tsx
+++ b/components/search/DateRangeFilter.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { SearchFilters } from '../../hooks/useSearchFilters';
+
+interface DateRangeFilterProps {
+  dateRange: SearchFilters['dateRange'];
+  customStart?: Date;
+  customEnd?: Date;
+  onDateRangeChange: (range: SearchFilters['dateRange']) => void;
+  onCustomDateChange: (start: Date | undefined, end: Date | undefined) => void;
+}
+
+/**
+ * DateRangeFilter - Date range filter with preset and custom options
+ *
+ * Provides:
+ * - Radio buttons for All Time, Last 7/30/90 Days
+ * - Custom range with date inputs
+ * - Clean, accessible form controls
+ */
+export const DateRangeFilter: React.FC<DateRangeFilterProps> = ({
+  dateRange,
+  customStart,
+  customEnd,
+  onDateRangeChange,
+  onCustomDateChange
+}) => {
+  const handleCustomStartChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newStart = e.target.value ? new Date(e.target.value) : undefined;
+    onCustomDateChange(newStart, customEnd);
+  };
+
+  const handleCustomEndChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newEnd = e.target.value ? new Date(e.target.value) : undefined;
+    onCustomDateChange(customStart, newEnd);
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Preset ranges */}
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="radio"
+          name="dateRange"
+          value="all"
+          checked={dateRange === 'all'}
+          onChange={(e) => onDateRangeChange(e.target.value as SearchFilters['dateRange'])}
+          className="text-blue-500 focus:ring-blue-500"
+        />
+        <span className="text-sm text-slate-700">All Time</span>
+      </label>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="radio"
+          name="dateRange"
+          value="7d"
+          checked={dateRange === '7d'}
+          onChange={(e) => onDateRangeChange(e.target.value as SearchFilters['dateRange'])}
+          className="text-blue-500 focus:ring-blue-500"
+        />
+        <span className="text-sm text-slate-700">Last 7 Days</span>
+      </label>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="radio"
+          name="dateRange"
+          value="30d"
+          checked={dateRange === '30d'}
+          onChange={(e) => onDateRangeChange(e.target.value as SearchFilters['dateRange'])}
+          className="text-blue-500 focus:ring-blue-500"
+        />
+        <span className="text-sm text-slate-700">Last 30 Days</span>
+      </label>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="radio"
+          name="dateRange"
+          value="90d"
+          checked={dateRange === '90d'}
+          onChange={(e) => onDateRangeChange(e.target.value as SearchFilters['dateRange'])}
+          className="text-blue-500 focus:ring-blue-500"
+        />
+        <span className="text-sm text-slate-700">Last 90 Days</span>
+      </label>
+
+      {/* Custom range */}
+      <div>
+        <label className="flex items-center gap-2 cursor-pointer mb-2">
+          <input
+            type="radio"
+            name="dateRange"
+            value="custom"
+            checked={dateRange === 'custom'}
+            onChange={(e) => onDateRangeChange(e.target.value as SearchFilters['dateRange'])}
+            className="text-blue-500 focus:ring-blue-500"
+          />
+          <span className="text-sm text-slate-700">Custom Range</span>
+        </label>
+
+        {dateRange === 'custom' && (
+          <div className="ml-6 space-y-2">
+            <div>
+              <label className="block text-xs text-slate-500 mb-1">From</label>
+              <input
+                type="date"
+                value={customStart ? customStart.toISOString().split('T')[0] : ''}
+                onChange={handleCustomStartChange}
+                className="w-full px-2 py-1.5 text-sm border border-slate-200 rounded focus:border-blue-400 focus:ring-2 focus:ring-blue-100 outline-none"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-slate-500 mb-1">To</label>
+              <input
+                type="date"
+                value={customEnd ? customEnd.toISOString().split('T')[0] : ''}
+                onChange={handleCustomEndChange}
+                className="w-full px-2 py-1.5 text-sm border border-slate-200 rounded focus:border-blue-400 focus:ring-2 focus:ring-blue-100 outline-none"
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/components/search/FilterBottomSheet.tsx
+++ b/components/search/FilterBottomSheet.tsx
@@ -1,0 +1,247 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+import { SearchFilters } from '../../hooks/useSearchFilters';
+import { SpeakerOption, TopicOption } from '../../hooks/useSearch';
+import { DateRangeFilter } from './DateRangeFilter';
+import { SpeakerFilter } from './SpeakerFilter';
+import { TopicFilter } from './TopicFilter';
+import { Button } from '../Button';
+
+interface FilterBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  filters: SearchFilters;
+  activeFilterCount: number;
+  speakerOptions: SpeakerOption[];
+  topicOptions: TopicOption[];
+  onDateRangeChange: (range: SearchFilters['dateRange']) => void;
+  onCustomDateChange: (start: Date | undefined, end: Date | undefined) => void;
+  onToggleSpeaker: (speakerId: string) => void;
+  onToggleTopic: (topicId: string) => void;
+  onClearAll: () => void;
+}
+
+/**
+ * FilterBottomSheet - Mobile bottom sheet for filters
+ *
+ * Features:
+ * - Slides up from bottom with backdrop
+ * - Drag-to-dismiss gesture (swipe down >80px to close)
+ * - Same filter content as sidebar
+ * - Apply and Clear buttons at bottom
+ */
+export const FilterBottomSheet: React.FC<FilterBottomSheetProps> = ({
+  isOpen,
+  onClose,
+  filters,
+  activeFilterCount,
+  speakerOptions,
+  topicOptions,
+  onDateRangeChange,
+  onCustomDateChange,
+  onToggleSpeaker,
+  onToggleTopic,
+  onClearAll
+}) => {
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const [dragState, setDragState] = useState({
+    isDragging: false,
+    startY: 0,
+    currentY: 0
+  });
+
+  // Handle escape key to close
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  // Prevent body scroll when open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  // Drag gesture handlers for dismiss
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setDragState({
+      isDragging: true,
+      startY: e.touches[0].clientY,
+      currentY: 0
+    });
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!dragState.isDragging) return;
+
+    const deltaY = e.touches[0].clientY - dragState.startY;
+
+    // Only allow downward drag (positive deltaY)
+    if (deltaY > 0) {
+      setDragState(prev => ({
+        ...prev,
+        currentY: deltaY
+      }));
+    }
+  };
+
+  const handleTouchEnd = () => {
+    if (!dragState.isDragging) return;
+
+    const DISMISS_THRESHOLD = 80; // pixels
+
+    if (dragState.currentY > DISMISS_THRESHOLD) {
+      // Close the sheet if drag exceeded threshold
+      onClose();
+    }
+
+    // Reset drag state (sheet will animate back if not closing)
+    setDragState({
+      isDragging: false,
+      startY: 0,
+      currentY: 0
+    });
+  };
+
+  // Calculate transform for drag visual feedback
+  const getDragTransform = () => {
+    if (dragState.isDragging && dragState.currentY > 0) {
+      return `translateY(${dragState.currentY}px)`;
+    }
+    return 'translateY(0)';
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/30 z-40 md:hidden"
+        onClick={onClose}
+      />
+
+      {/* Bottom Sheet */}
+      <div
+        ref={sheetRef}
+        className="fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl shadow-2xl z-50 max-h-[85vh] flex flex-col md:hidden"
+        style={{
+          transform: getDragTransform(),
+          transition: dragState.isDragging ? 'none' : 'transform 0.2s ease-out'
+        }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        {/* Drag handle */}
+        <div className="pt-2 pb-1 flex justify-center">
+          <div className="w-12 h-1 bg-slate-300 rounded-full" />
+        </div>
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200">
+          <h2 className="font-semibold text-slate-900">
+            Filters
+            {activeFilterCount > 0 && (
+              <span className="ml-2 text-sm text-blue-600">({activeFilterCount})</span>
+            )}
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-slate-100 rounded-lg transition-colors"
+          >
+            <X size={20} className="text-slate-600" />
+          </button>
+        </div>
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-6">
+          {/* Date Range */}
+          <div>
+            <h3 className="text-sm font-medium text-slate-700 mb-3">Date Range</h3>
+            <DateRangeFilter
+              dateRange={filters.dateRange}
+              customStart={filters.customStart}
+              customEnd={filters.customEnd}
+              onDateRangeChange={onDateRangeChange}
+              onCustomDateChange={onCustomDateChange}
+            />
+          </div>
+
+          {/* Speakers */}
+          <div>
+            <h3 className="text-sm font-medium text-slate-700 mb-3">
+              Speakers
+              {filters.speakers.length > 0 && (
+                <span className="ml-1.5 text-xs text-blue-600 font-semibold">
+                  ({filters.speakers.length})
+                </span>
+              )}
+            </h3>
+            <div className="max-h-48 overflow-y-auto">
+              <SpeakerFilter
+                selectedSpeakers={filters.speakers}
+                speakerOptions={speakerOptions}
+                onToggleSpeaker={onToggleSpeaker}
+              />
+            </div>
+          </div>
+
+          {/* Topics */}
+          <div>
+            <h3 className="text-sm font-medium text-slate-700 mb-3">
+              Topics
+              {filters.topics.length > 0 && (
+                <span className="ml-1.5 text-xs text-blue-600 font-semibold">
+                  ({filters.topics.length})
+                </span>
+              )}
+            </h3>
+            <div className="max-h-64 overflow-y-auto">
+              <TopicFilter
+                selectedTopics={filters.topics}
+                topicOptions={topicOptions}
+                onToggleTopic={onToggleTopic}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Footer buttons */}
+        <div className="flex gap-2 px-4 py-3 border-t border-slate-200 bg-slate-50">
+          {activeFilterCount > 0 && (
+            <Button
+              variant="outline"
+              onClick={() => {
+                onClearAll();
+                onClose();
+              }}
+              className="flex-1"
+            >
+              Clear All
+            </Button>
+          )}
+          <Button
+            onClick={onClose}
+            className="flex-1"
+          >
+            Apply
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/components/search/FilterSidebar.tsx
+++ b/components/search/FilterSidebar.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from 'react';
+import { ChevronDown, ChevronUp, X } from 'lucide-react';
+import { SearchFilters } from '../../hooks/useSearchFilters';
+import { SpeakerOption, TopicOption } from '../../hooks/useSearch';
+import { DateRangeFilter } from './DateRangeFilter';
+import { SpeakerFilter } from './SpeakerFilter';
+import { TopicFilter } from './TopicFilter';
+import { Button } from '../Button';
+
+interface FilterSidebarProps {
+  filters: SearchFilters;
+  activeFilterCount: number;
+  speakerOptions: SpeakerOption[];
+  topicOptions: TopicOption[];
+  onDateRangeChange: (range: SearchFilters['dateRange']) => void;
+  onCustomDateChange: (start: Date | undefined, end: Date | undefined) => void;
+  onToggleSpeaker: (speakerId: string) => void;
+  onToggleTopic: (topicId: string) => void;
+  onClearAll: () => void;
+}
+
+/**
+ * FilterSidebar - Desktop filter sidebar with collapsible sections
+ *
+ * 300px width sidebar with:
+ * - Clear all button
+ * - Collapsible filter sections
+ * - Date range, speaker, and topic filters
+ */
+export const FilterSidebar: React.FC<FilterSidebarProps> = ({
+  filters,
+  activeFilterCount,
+  speakerOptions,
+  topicOptions,
+  onDateRangeChange,
+  onCustomDateChange,
+  onToggleSpeaker,
+  onToggleTopic,
+  onClearAll
+}) => {
+  const [expandedSections, setExpandedSections] = useState({
+    dateRange: true,
+    speakers: true,
+    topics: true
+  });
+
+  const toggleSection = (section: keyof typeof expandedSections) => {
+    setExpandedSections(prev => ({ ...prev, [section]: !prev[section] }));
+  };
+
+  return (
+    <div className="w-[300px] bg-white rounded-xl shadow-sm border border-slate-200 p-4 h-fit sticky top-6">
+      {/* Header with clear all */}
+      <div className="flex items-center justify-between mb-4 pb-3 border-b border-slate-200">
+        <h2 className="font-semibold text-slate-900">Filters</h2>
+        {activeFilterCount > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClearAll}
+            className="gap-1 text-slate-600 hover:text-slate-900"
+          >
+            <X size={14} />
+            Clear all
+          </Button>
+        )}
+      </div>
+
+      {/* Date Range Section */}
+      <div className="mb-4">
+        <button
+          onClick={() => toggleSection('dateRange')}
+          className="w-full flex items-center justify-between py-2 text-sm font-medium text-slate-700 hover:text-slate-900"
+        >
+          <span>Date Range</span>
+          {expandedSections.dateRange ? (
+            <ChevronUp size={16} className="text-slate-400" />
+          ) : (
+            <ChevronDown size={16} className="text-slate-400" />
+          )}
+        </button>
+        {expandedSections.dateRange && (
+          <div className="mt-2 pl-1">
+            <DateRangeFilter
+              dateRange={filters.dateRange}
+              customStart={filters.customStart}
+              customEnd={filters.customEnd}
+              onDateRangeChange={onDateRangeChange}
+              onCustomDateChange={onCustomDateChange}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Speakers Section */}
+      <div className="mb-4">
+        <button
+          onClick={() => toggleSection('speakers')}
+          className="w-full flex items-center justify-between py-2 text-sm font-medium text-slate-700 hover:text-slate-900"
+        >
+          <span>
+            Speakers
+            {filters.speakers.length > 0 && (
+              <span className="ml-1.5 text-xs text-blue-600 font-semibold">
+                ({filters.speakers.length})
+              </span>
+            )}
+          </span>
+          {expandedSections.speakers ? (
+            <ChevronUp size={16} className="text-slate-400" />
+          ) : (
+            <ChevronDown size={16} className="text-slate-400" />
+          )}
+        </button>
+        {expandedSections.speakers && (
+          <div className="mt-2 pl-1 max-h-48 overflow-y-auto">
+            <SpeakerFilter
+              selectedSpeakers={filters.speakers}
+              speakerOptions={speakerOptions}
+              onToggleSpeaker={onToggleSpeaker}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Topics Section */}
+      <div>
+        <button
+          onClick={() => toggleSection('topics')}
+          className="w-full flex items-center justify-between py-2 text-sm font-medium text-slate-700 hover:text-slate-900"
+        >
+          <span>
+            Topics
+            {filters.topics.length > 0 && (
+              <span className="ml-1.5 text-xs text-blue-600 font-semibold">
+                ({filters.topics.length})
+              </span>
+            )}
+          </span>
+          {expandedSections.topics ? (
+            <ChevronUp size={16} className="text-slate-400" />
+          ) : (
+            <ChevronDown size={16} className="text-slate-400" />
+          )}
+        </button>
+        {expandedSections.topics && (
+          <div className="mt-2 pl-1 max-h-64 overflow-y-auto">
+            <TopicFilter
+              selectedTopics={filters.topics}
+              topicOptions={topicOptions}
+              onToggleTopic={onToggleTopic}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/components/search/SearchResults.tsx
+++ b/components/search/SearchResults.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { SearchResults as SearchResultsType } from '../../services/searchService';
+import { ConversationResultCard } from './ConversationResultCard';
+import { ZeroResultsState } from './ZeroResultsState';
+import { Button } from '../Button';
+import { Loader2 } from 'lucide-react';
+
+interface SearchResultsProps {
+  results: SearchResultsType;
+  searchQuery: string;
+  isLoading: boolean;
+  hasMore: boolean;
+  onLoadMore: () => void;
+  onOpenInViewer: (conversationId: string, segmentId: string) => void;
+}
+
+/**
+ * SearchResults - Orchestrates search results display
+ *
+ * Handles:
+ * - Loading state
+ * - Zero results state
+ * - Grouped conversation results
+ * - Pagination with "Load more" button
+ */
+export const SearchResults: React.FC<SearchResultsProps> = ({
+  results,
+  searchQuery,
+  isLoading,
+  hasMore,
+  onLoadMore,
+  onOpenInViewer
+}) => {
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16">
+        <Loader2 size={32} className="text-blue-500 animate-spin mb-3" />
+        <p className="text-slate-600">Searching conversations...</p>
+      </div>
+    );
+  }
+
+  // Empty query state - show prompt to search
+  if (!searchQuery.trim()) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <p className="text-slate-500">Enter a search term to find transcript segments</p>
+      </div>
+    );
+  }
+
+  // Zero results state
+  if (results.totalResults === 0) {
+    return <ZeroResultsState searchQuery={searchQuery} />;
+  }
+
+  // Results
+  return (
+    <div className="space-y-4">
+      {/* Results header */}
+      <div className="text-sm text-slate-600">
+        Found <span className="font-semibold text-slate-900">{results.totalResults}</span> match{results.totalResults !== 1 ? 'es' : ''} across{' '}
+        <span className="font-semibold text-slate-900">{results.results.length}</span> conversation{results.results.length !== 1 ? 's' : ''}
+      </div>
+
+      {/* Conversation result cards */}
+      <div className="space-y-3">
+        {results.results.map((result) => (
+          <ConversationResultCard
+            key={result.conversationId}
+            result={result}
+            searchQuery={searchQuery}
+            onOpenInViewer={onOpenInViewer}
+          />
+        ))}
+      </div>
+
+      {/* Load more button */}
+      {hasMore && (
+        <div className="flex justify-center pt-4">
+          <Button
+            variant="ghost"
+            onClick={onLoadMore}
+            className="gap-2"
+          >
+            Load more results
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/search/SegmentResult.tsx
+++ b/components/search/SegmentResult.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { SegmentMatch } from '../../services/searchService';
+import { highlightMatches } from '../../utils/textHighlight';
+import { formatTime } from '../../utils';
+import { Clock } from 'lucide-react';
+
+interface SegmentResultProps {
+  match: SegmentMatch;
+  searchQuery: string;
+  onOpenInViewer: (conversationId: string, segmentId: string) => void;
+}
+
+/**
+ * SegmentResult - Individual search result showing a matching segment
+ *
+ * Displays:
+ * - Timestamp of when the segment occurs
+ * - Snippet with highlighted search terms
+ * - "Open in Viewer" action to jump to this segment
+ */
+export const SegmentResult: React.FC<SegmentResultProps> = ({
+  match,
+  searchQuery,
+  onOpenInViewer
+}) => {
+  const highlightedSegments = highlightMatches(match.snippet, searchQuery);
+
+  return (
+    <div className="border-l-2 border-slate-200 pl-3 py-2 hover:border-blue-400 transition-colors group">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          {/* Timestamp */}
+          <div className="flex items-center gap-1.5 text-xs text-slate-500 mb-1">
+            <Clock size={12} />
+            <span>{formatTime(match.segment.startMs)}</span>
+          </div>
+
+          {/* Snippet with highlighting */}
+          <p className="text-sm text-slate-700 leading-relaxed">
+            {highlightedSegments.map((seg, idx) => (
+              seg.isMatch ? (
+                <mark
+                  key={idx}
+                  className="bg-yellow-200 text-slate-900 font-medium px-0.5 rounded"
+                >
+                  {seg.text}
+                </mark>
+              ) : (
+                <span key={idx}>{seg.text}</span>
+              )
+            ))}
+          </p>
+        </div>
+
+        {/* Open in Viewer button */}
+        <button
+          onClick={() => onOpenInViewer(match.conversationId, match.segmentId)}
+          className="shrink-0 px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 rounded transition-colors opacity-0 group-hover:opacity-100"
+        >
+          Open
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/components/search/SpeakerFilter.tsx
+++ b/components/search/SpeakerFilter.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { SpeakerOption } from '../../hooks/useSearch';
+
+interface SpeakerFilterProps {
+  selectedSpeakers: string[];
+  speakerOptions: SpeakerOption[];
+  onToggleSpeaker: (speakerId: string) => void;
+}
+
+/**
+ * SpeakerFilter - Speaker selection filter with match counts
+ *
+ * Displays checkboxes for each speaker found in the current search results.
+ * Shows match counts to help users understand filter impact.
+ */
+export const SpeakerFilter: React.FC<SpeakerFilterProps> = ({
+  selectedSpeakers,
+  speakerOptions,
+  onToggleSpeaker
+}) => {
+  // Show message if no speakers available
+  if (speakerOptions.length === 0) {
+    return (
+      <p className="text-sm text-slate-400 italic">
+        No speakers found in results
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {speakerOptions.map((option) => (
+        <label
+          key={option.speakerId}
+          className="flex items-center gap-2 cursor-pointer group"
+        >
+          <input
+            type="checkbox"
+            checked={selectedSpeakers.includes(option.speakerId)}
+            onChange={() => onToggleSpeaker(option.speakerId)}
+            className="text-blue-500 focus:ring-blue-500 rounded"
+          />
+          <span className="text-sm text-slate-700 flex-1 group-hover:text-slate-900">
+            {option.displayName}
+          </span>
+          <span className="text-xs text-slate-400 tabular-nums">
+            {option.matchCount}
+          </span>
+        </label>
+      ))}
+    </div>
+  );
+};

--- a/components/search/TopicFilter.tsx
+++ b/components/search/TopicFilter.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { TopicOption } from '../../hooks/useSearch';
+
+interface TopicFilterProps {
+  selectedTopics: string[];
+  topicOptions: TopicOption[];
+  onToggleTopic: (topicId: string) => void;
+}
+
+/**
+ * TopicFilter - Topic selection filter with match counts
+ *
+ * Displays checkboxes for each topic found in the current search results.
+ * Shows match counts to help users understand filter impact.
+ */
+export const TopicFilter: React.FC<TopicFilterProps> = ({
+  selectedTopics,
+  topicOptions,
+  onToggleTopic
+}) => {
+  // Show message if no topics available
+  if (topicOptions.length === 0) {
+    return (
+      <p className="text-sm text-slate-400 italic">
+        No topics found in results
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {topicOptions.map((option) => (
+        <label
+          key={option.topicId}
+          className="flex items-start gap-2 cursor-pointer group"
+        >
+          <input
+            type="checkbox"
+            checked={selectedTopics.includes(option.topicId)}
+            onChange={() => onToggleTopic(option.topicId)}
+            className="text-blue-500 focus:ring-blue-500 rounded mt-0.5"
+          />
+          <span className="text-sm text-slate-700 flex-1 group-hover:text-slate-900 leading-snug">
+            {option.title}
+          </span>
+          <span className="text-xs text-slate-400 tabular-nums mt-0.5">
+            {option.matchCount}
+          </span>
+        </label>
+      ))}
+    </div>
+  );
+};

--- a/components/search/ZeroResultsState.tsx
+++ b/components/search/ZeroResultsState.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { SearchX } from 'lucide-react';
+
+interface ZeroResultsStateProps {
+  searchQuery: string;
+}
+
+/**
+ * ZeroResultsState - Empty state when no search results found
+ *
+ * Provides helpful suggestions to the user on how to improve their search.
+ */
+export const ZeroResultsState: React.FC<ZeroResultsStateProps> = ({ searchQuery }) => {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+      {/* Icon */}
+      <div className="w-16 h-16 bg-slate-100 rounded-full flex items-center justify-center mb-4">
+        <SearchX size={32} className="text-slate-400" />
+      </div>
+
+      {/* Message */}
+      <h3 className="text-lg font-semibold text-slate-900 mb-2">
+        No results for "{searchQuery}"
+      </h3>
+
+      {/* Suggestions */}
+      <div className="max-w-md text-sm text-slate-600 space-y-2">
+        <p>Try adjusting your search:</p>
+        <ul className="list-disc list-inside text-left space-y-1 mt-3">
+          <li>Check for typos or spelling errors</li>
+          <li>Use fewer or different keywords</li>
+          <li>Try more general terms</li>
+          <li>Search for partial words (e.g., "analy" instead of "analysis")</li>
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -615,6 +615,8 @@ service cloud.firestore {
 }
 ```
 
+**Search Functionality Note**: The full-text search feature (added in search_discovery_scope_02) runs entirely client-side and does **not** require additional Firestore indexes. Search operates on conversations already loaded into the client from the existing `userId` + `createdAt` index. All matching, ranking, and snippet extraction happens in the browser using `services/searchService.ts`.
+
 ## Service API
 
 ### FirestoreService

--- a/hooks/useDebounce.ts
+++ b/hooks/useDebounce.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * useDebounce - Debounces a value by delaying updates
+ *
+ * Classic debounce pattern: delays updating the value until the input
+ * has stopped changing for the specified delay period. Perfect for
+ * search inputs where you don't want to fire queries on every keystroke.
+ *
+ * @param value - The value to debounce (e.g., search query string)
+ * @param delay - Delay in milliseconds before updating (default 300ms)
+ * @returns The debounced value
+ */
+export function useDebounce<T>(value: T, delay: number = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    // Set up timeout to update debounced value after delay
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Clean up timeout if value changes before delay expires
+    // This is the key to debouncing: cancel and restart on every change
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/hooks/useSearch.ts
+++ b/hooks/useSearch.ts
@@ -1,0 +1,185 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useDebounce } from './useDebounce';
+import { searchConversations, paginateResults, filterSearchResults, SearchResults } from '../services/searchService';
+import { Conversation, Speaker, Topic } from '../types';
+import { SearchFilters } from './useSearchFilters';
+
+interface UseSearchOptions {
+  conversations: Conversation[];
+  initialQuery?: string;
+  resultsPerPage?: number;
+  filters?: SearchFilters; // Optional filters
+}
+
+export interface SpeakerOption {
+  speakerId: string;
+  displayName: string;
+  matchCount: number;
+}
+
+export interface TopicOption {
+  topicId: string;
+  title: string;
+  matchCount: number;
+}
+
+interface UseSearchReturn {
+  query: string;
+  setQuery: (query: string) => void;
+  results: SearchResults;
+  isLoading: boolean;
+  hasMore: boolean;
+  loadMore: () => void;
+  // Derived filter options from current results
+  speakerOptions: SpeakerOption[];
+  topicOptions: TopicOption[];
+}
+
+/**
+ * useSearch - Orchestrates search state, debouncing, filtering, and pagination
+ *
+ * Manages:
+ * - Search query state
+ * - Debounced search execution (prevents searching on every keystroke)
+ * - Filter application (after search, before pagination)
+ * - Pagination with "load more" functionality
+ * - Loading state during debounce delay
+ * - Derived speaker/topic options from filtered results
+ * - URL synchronization (handled by parent component)
+ */
+export function useSearch({
+  conversations,
+  initialQuery = '',
+  resultsPerPage = 20,
+  filters
+}: UseSearchOptions): UseSearchReturn {
+  const [query, setQuery] = useState(initialQuery);
+  const [offset, setOffset] = useState(0);
+
+  // Debounce the query to avoid searching on every keystroke
+  const debouncedQuery = useDebounce(query, 300);
+
+  // Loading state: true during debounce delay
+  const isLoading = query !== debouncedQuery && query.trim() !== '';
+
+  // Reset pagination when query or filters change
+  useEffect(() => {
+    setOffset(0);
+  }, [debouncedQuery, filters]);
+
+  // Sync initialQuery prop to state (for back/forward navigation)
+  useEffect(() => {
+    setQuery(initialQuery);
+  }, [initialQuery]);
+
+  // Perform search (memoized to avoid re-running on every render)
+  const allResults = useMemo(() => {
+    return searchConversations(conversations, debouncedQuery);
+  }, [conversations, debouncedQuery]);
+
+  // Apply filters to search results (before pagination)
+  const filteredResults = useMemo(() => {
+    if (!filters) return allResults;
+    return filterSearchResults(allResults, filters, conversations);
+  }, [allResults, filters, conversations]);
+
+  // Derive speaker options from filtered results
+  const speakerOptions = useMemo(() => {
+    return deriveSpeakerOptions(filteredResults);
+  }, [filteredResults]);
+
+  // Derive topic options from filtered results
+  const topicOptions = useMemo(() => {
+    return deriveTopicOptions(filteredResults);
+  }, [filteredResults]);
+
+  // Paginate results
+  const paginatedResults = useMemo(() => {
+    return paginateResults(filteredResults, offset + resultsPerPage, 0);
+  }, [filteredResults, offset, resultsPerPage]);
+
+  // Check if there are more results to load
+  const hasMore = paginatedResults.totalResults > offset + resultsPerPage;
+
+  // Load more handler
+  const loadMore = () => {
+    setOffset(prev => prev + resultsPerPage);
+  };
+
+  return {
+    query,
+    setQuery,
+    results: paginatedResults,
+    isLoading,
+    hasMore,
+    loadMore,
+    speakerOptions,
+    topicOptions
+  };
+}
+
+/**
+ * Derive speaker options from search results with match counts
+ */
+function deriveSpeakerOptions(results: SearchResults): SpeakerOption[] {
+  const speakerCounts = new Map<string, { speaker: Speaker; count: number }>();
+
+  for (const convResult of results.results) {
+    for (const match of convResult.matches) {
+      const speakerId = match.segment.speakerId;
+      const speaker = convResult.conversation.speakers[speakerId];
+
+      if (speaker) {
+        const existing = speakerCounts.get(speakerId);
+        if (existing) {
+          existing.count += match.matchCount;
+        } else {
+          speakerCounts.set(speakerId, { speaker, count: match.matchCount });
+        }
+      }
+    }
+  }
+
+  // Convert to array and sort by match count
+  return Array.from(speakerCounts.values())
+    .map(({ speaker, count }) => ({
+      speakerId: speaker.speakerId,
+      displayName: speaker.displayName,
+      matchCount: count
+    }))
+    .sort((a, b) => b.matchCount - a.matchCount);
+}
+
+/**
+ * Derive topic options from search results with match counts
+ */
+function deriveTopicOptions(results: SearchResults): TopicOption[] {
+  const topicCounts = new Map<string, { topic: Topic; count: number }>();
+
+  for (const convResult of results.results) {
+    // For each match, find which topic(s) it belongs to
+    for (const match of convResult.matches) {
+      const segmentIndex = match.segment.index;
+
+      for (const topic of convResult.conversation.topics) {
+        if (segmentIndex >= topic.startIndex && segmentIndex <= topic.endIndex) {
+          const existing = topicCounts.get(topic.topicId);
+          if (existing) {
+            existing.count += match.matchCount;
+          } else {
+            topicCounts.set(topic.topicId, { topic, count: match.matchCount });
+          }
+        }
+      }
+    }
+  }
+
+  // Convert to array and sort by match count
+  return Array.from(topicCounts.values())
+    .map(({ topic, count }) => ({
+      topicId: topic.topicId,
+      title: topic.title,
+      matchCount: count
+    }))
+    .sort((a, b) => b.matchCount - a.matchCount);
+}

--- a/hooks/useSearchFilters.ts
+++ b/hooks/useSearchFilters.ts
@@ -1,0 +1,242 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export interface SearchFilters {
+  dateRange: 'all' | '7d' | '30d' | '90d' | 'custom';
+  customStart?: Date;
+  customEnd?: Date;
+  speakers: string[]; // Array of speakerIds
+  topics: string[]; // Array of topicIds
+}
+
+interface UseSearchFiltersReturn {
+  filters: SearchFilters;
+  setDateRange: (range: SearchFilters['dateRange']) => void;
+  setCustomDateRange: (start: Date | undefined, end: Date | undefined) => void;
+  setSpeakers: (speakers: string[]) => void;
+  setTopics: (topics: string[]) => void;
+  toggleSpeaker: (speakerId: string) => void;
+  toggleTopic: (topicId: string) => void;
+  clearAll: () => void;
+  activeFilterCount: number;
+}
+
+const DEFAULT_FILTERS: SearchFilters = {
+  dateRange: 'all',
+  speakers: [],
+  topics: []
+};
+
+const STORAGE_KEY = 'search_filters';
+
+/**
+ * useSearchFilters - Manages search filter state with URL and sessionStorage sync
+ *
+ * Filter state is persisted in:
+ * 1. URL query params (primary source, enables sharing)
+ * 2. sessionStorage (fallback when URL is empty)
+ *
+ * URL params:
+ * - dateRange: 'all' | '7d' | '30d' | '90d' | 'custom'
+ * - from: ISO date string (for custom range)
+ * - to: ISO date string (for custom range)
+ * - speakers: comma-separated speaker IDs
+ * - topics: comma-separated topic IDs
+ */
+export function useSearchFilters(): UseSearchFiltersReturn {
+  const [filters, setFilters] = useState<SearchFilters>(() => {
+    // Initialize from URL or sessionStorage
+    return parseFiltersFromUrl() || loadFiltersFromStorage() || DEFAULT_FILTERS;
+  });
+
+  // Sync filters to URL and sessionStorage whenever they change
+  useEffect(() => {
+    syncFiltersToUrl(filters);
+    saveFiltersToStorage(filters);
+  }, [filters]);
+
+  // Handle browser back/forward navigation
+  useEffect(() => {
+    const handlePopState = () => {
+      const urlFilters = parseFiltersFromUrl();
+      if (urlFilters) {
+        setFilters(urlFilters);
+      }
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  // Filter setters
+  const setDateRange = useCallback((range: SearchFilters['dateRange']) => {
+    setFilters(prev => ({
+      ...prev,
+      dateRange: range,
+      // Clear custom dates if switching away from custom
+      customStart: range === 'custom' ? prev.customStart : undefined,
+      customEnd: range === 'custom' ? prev.customEnd : undefined
+    }));
+  }, []);
+
+  const setCustomDateRange = useCallback((start: Date | undefined, end: Date | undefined) => {
+    setFilters(prev => ({
+      ...prev,
+      dateRange: 'custom',
+      customStart: start,
+      customEnd: end
+    }));
+  }, []);
+
+  const setSpeakers = useCallback((speakers: string[]) => {
+    setFilters(prev => ({ ...prev, speakers }));
+  }, []);
+
+  const setTopics = useCallback((topics: string[]) => {
+    setFilters(prev => ({ ...prev, topics }));
+  }, []);
+
+  const toggleSpeaker = useCallback((speakerId: string) => {
+    setFilters(prev => ({
+      ...prev,
+      speakers: prev.speakers.includes(speakerId)
+        ? prev.speakers.filter(id => id !== speakerId)
+        : [...prev.speakers, speakerId]
+    }));
+  }, []);
+
+  const toggleTopic = useCallback((topicId: string) => {
+    setFilters(prev => ({
+      ...prev,
+      topics: prev.topics.includes(topicId)
+        ? prev.topics.filter(id => id !== topicId)
+        : [...prev.topics, topicId]
+    }));
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setFilters(DEFAULT_FILTERS);
+  }, []);
+
+  // Calculate active filter count (excluding 'all' date range)
+  const activeFilterCount =
+    (filters.dateRange !== 'all' ? 1 : 0) +
+    filters.speakers.length +
+    filters.topics.length;
+
+  return {
+    filters,
+    setDateRange,
+    setCustomDateRange,
+    setSpeakers,
+    setTopics,
+    toggleSpeaker,
+    toggleTopic,
+    clearAll,
+    activeFilterCount
+  };
+}
+
+/**
+ * Parse filters from URL query params
+ */
+function parseFiltersFromUrl(): SearchFilters | null {
+  const params = new URLSearchParams(window.location.search);
+
+  const dateRange = params.get('dateRange') as SearchFilters['dateRange'] | null;
+  const from = params.get('from');
+  const to = params.get('to');
+  const speakersParam = params.get('speakers');
+  const topicsParam = params.get('topics');
+
+  // If no filter params exist, return null
+  if (!dateRange && !speakersParam && !topicsParam) {
+    return null;
+  }
+
+  return {
+    dateRange: dateRange || 'all',
+    customStart: from ? new Date(from) : undefined,
+    customEnd: to ? new Date(to) : undefined,
+    speakers: speakersParam ? speakersParam.split(',').filter(Boolean) : [],
+    topics: topicsParam ? topicsParam.split(',').filter(Boolean) : []
+  };
+}
+
+/**
+ * Sync filters to URL query params (replaceState to avoid polluting history)
+ */
+function syncFiltersToUrl(filters: SearchFilters): void {
+  const params = new URLSearchParams(window.location.search);
+
+  // Date range
+  if (filters.dateRange !== 'all') {
+    params.set('dateRange', filters.dateRange);
+  } else {
+    params.delete('dateRange');
+  }
+
+  // Custom date range
+  if (filters.dateRange === 'custom' && filters.customStart) {
+    params.set('from', filters.customStart.toISOString());
+  } else {
+    params.delete('from');
+  }
+
+  if (filters.dateRange === 'custom' && filters.customEnd) {
+    params.set('to', filters.customEnd.toISOString());
+  } else {
+    params.delete('to');
+  }
+
+  // Speakers
+  if (filters.speakers.length > 0) {
+    params.set('speakers', filters.speakers.join(','));
+  } else {
+    params.delete('speakers');
+  }
+
+  // Topics
+  if (filters.topics.length > 0) {
+    params.set('topics', filters.topics.join(','));
+  } else {
+    params.delete('topics');
+  }
+
+  const newUrl = params.toString()
+    ? `${window.location.pathname}?${params.toString()}`
+    : window.location.pathname;
+
+  window.history.replaceState({}, '', newUrl);
+}
+
+/**
+ * Load filters from sessionStorage
+ */
+function loadFiltersFromStorage(): SearchFilters | null {
+  try {
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    if (!stored) return null;
+
+    const parsed = JSON.parse(stored);
+
+    // Restore Date objects from ISO strings
+    return {
+      ...parsed,
+      customStart: parsed.customStart ? new Date(parsed.customStart) : undefined,
+      customEnd: parsed.customEnd ? new Date(parsed.customEnd) : undefined
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save filters to sessionStorage
+ */
+function saveFiltersToStorage(filters: SearchFilters): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(filters));
+  } catch {
+    // Ignore storage errors (e.g., quota exceeded)
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -224,7 +224,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -609,7 +608,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -653,7 +651,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -675,8 +672,7 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.14.tgz",
       "integrity": "sha512-3DB258dhqdsArOI1fIt7cb9RpUOgcDg5hXWVgVHAeqVQ/qxtFy605QKs4gx6mFq3jWsSPqDN8TgSEsqC3OfV9Q==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-tools": {
       "version": "0.2.19",
@@ -1173,7 +1169,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.13.tgz",
       "integrity": "sha512-OZiDAEK/lDB6xy/XzYAyJJkaDqmQ+BCtOEPLqFvxWKUz5JbBmej7IiiRHdtiIOD/twW7O5AxVsfaaGA/V1bNsA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.9",
         "@firebase/logger": "0.4.2",
@@ -1231,7 +1226,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.43.tgz",
       "integrity": "sha512-HM96ZyIblXjAC7TzE8wIk2QhHlSvksYkQ4Ukh1GmEenzkucSNUmUX4QvoKrqeWsLEQ8hdcojABeCV8ybVyZmeg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.10.13",
         "@firebase/component": "0.6.9",
@@ -1244,8 +1238,7 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.2.tgz",
       "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/app/node_modules/idb": {
       "version": "7.1.1",
@@ -1684,7 +1677,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
       "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -2427,7 +2419,6 @@
       "integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.7",
         "ajv": "^8.17.1",
@@ -2813,7 +2804,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3778,7 +3768,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3925,7 +3916,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4074,7 +4064,6 @@
       "integrity": "sha512-rkoPH+RqWopVxDnCBE/ysIdfQ2A7j1eDmW8tCxxrR9nnFBa9jKf86VgsSAzxBd1x+ny0GC4JgiD3SNfRHv3pOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.16",
         "fflate": "^0.8.2",
@@ -4892,7 +4881,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6402,7 +6390,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -6991,7 +6980,6 @@
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -9491,6 +9479,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9580,7 +9569,6 @@
       "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -10702,7 +10690,6 @@
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -10822,7 +10809,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10874,7 +10860,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10940,6 +10925,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10955,6 +10941,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10965,6 +10952,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11282,7 +11270,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11292,7 +11279,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11312,7 +11298,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -11480,8 +11465,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -13000,7 +12984,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13292,7 +13275,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -13368,7 +13350,6 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",
@@ -14051,7 +14032,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/pages/Library.tsx
+++ b/pages/Library.tsx
@@ -3,7 +3,7 @@ import { Conversation } from '../types';
 import { formatTime, cn, createMockConversation } from '../utils';
 import { useConversations } from '../contexts/ConversationContext';
 import { useAuth } from '../contexts/AuthContext';
-import { FileAudio, Calendar, Clock, ChevronRight, UploadCloud, X, Loader2, File as FileIcon, AlertCircle, Trash2, Cloud, CloudOff, RefreshCw, CheckCircle2, Settings, BarChart3 } from 'lucide-react';
+import { FileAudio, Calendar, Clock, ChevronRight, UploadCloud, X, Loader2, File as FileIcon, AlertCircle, Trash2, Cloud, CloudOff, RefreshCw, CheckCircle2, Settings, BarChart3, Search } from 'lucide-react';
 import { Button } from '../components/Button';
 import { UserMenu } from '../components/auth/UserMenu';
 import { ProcessingProgressRow } from '../components/library/ProcessingProgressRow';
@@ -15,9 +15,10 @@ interface LibraryProps {
   onOpen: (id: string) => void;
   onAdminClick: () => void;
   onStatsClick: () => void;
+  onSearchClick: () => void;
 }
 
-export const Library: React.FC<LibraryProps> = ({ onOpen, onAdminClick, onStatsClick }) => {
+export const Library: React.FC<LibraryProps> = ({ onOpen, onAdminClick, onStatsClick, onSearchClick }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [deleteConfirmConv, setDeleteConfirmConv] = useState<Conversation | null>(null);
   const [abortConfirmConv, setAbortConfirmConv] = useState<Conversation | null>(null);
@@ -107,6 +108,14 @@ export const Library: React.FC<LibraryProps> = ({ onOpen, onAdminClick, onStatsC
              <p className="text-slate-500 mt-1">Your transcribed conversations and meetings.</p>
           </div>
           <div className="flex items-center gap-3">
+            <Button
+              variant="ghost"
+              onClick={onSearchClick}
+              className="gap-2"
+            >
+              <Search size={18} />
+              Search
+            </Button>
             <Button
               variant="ghost"
               onClick={onStatsClick}

--- a/pages/Search.tsx
+++ b/pages/Search.tsx
@@ -1,0 +1,182 @@
+import React, { useEffect, useCallback, useState } from 'react';
+import { useConversations } from '../contexts/ConversationContext';
+import { useSearch } from '../hooks/useSearch';
+import { useSearchFilters } from '../hooks/useSearchFilters';
+import { SearchResults } from '../components/search/SearchResults';
+import { FilterSidebar } from '../components/search/FilterSidebar';
+import { FilterBottomSheet } from '../components/search/FilterBottomSheet';
+import { UserMenu } from '../components/auth/UserMenu';
+import { ArrowLeft, Search as SearchIcon, Filter } from 'lucide-react';
+import { Button } from '../components/Button';
+
+interface SearchProps {
+  onBack: () => void;
+  onOpenConversation: (conversationId: string, targetSegmentId?: string) => void;
+  initialQuery?: string;
+  onQueryChange?: (query: string) => void;
+}
+
+/**
+ * Search - Full-text search page
+ *
+ * Allows users to search across all transcript segments with:
+ * - Real-time search with debouncing
+ * - Grouped results by conversation
+ * - Highlighted snippets with context
+ * - Pagination (20 results initially, "Load more" for additional)
+ * - URL synchronization (managed by App component)
+ */
+export const Search: React.FC<SearchProps> = ({
+  onBack,
+  onOpenConversation,
+  initialQuery = '',
+  onQueryChange
+}) => {
+  const { conversations, isLoaded } = useConversations();
+  const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
+
+  // Filter state
+  const {
+    filters,
+    setDateRange,
+    setCustomDateRange,
+    toggleSpeaker,
+    toggleTopic,
+    clearAll,
+    activeFilterCount
+  } = useSearchFilters();
+
+  // Search with filters
+  const {
+    query,
+    setQuery,
+    results,
+    isLoading,
+    hasMore,
+    loadMore,
+    speakerOptions,
+    topicOptions
+  } = useSearch({
+    conversations,
+    initialQuery,
+    resultsPerPage: 20,
+    filters
+  });
+
+  // Notify parent of query changes (for URL sync)
+  useEffect(() => {
+    if (onQueryChange) {
+      onQueryChange(query);
+    }
+  }, [query, onQueryChange]);
+
+  const handleOpenInViewer = useCallback((conversationId: string, segmentId: string) => {
+    onOpenConversation(conversationId, segmentId);
+  }, [onOpenConversation]);
+
+  // Loading state for conversation data
+  if (!isLoaded) {
+    return (
+      <div className="h-screen w-screen flex items-center justify-center bg-slate-50">
+        <p className="text-slate-400">Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 p-6 md:p-12">
+      {/* Mobile filter bottom sheet */}
+      <FilterBottomSheet
+        isOpen={isFilterSheetOpen}
+        onClose={() => setIsFilterSheetOpen(false)}
+        filters={filters}
+        activeFilterCount={activeFilterCount}
+        speakerOptions={speakerOptions}
+        topicOptions={topicOptions}
+        onDateRangeChange={setDateRange}
+        onCustomDateChange={setCustomDateRange}
+        onToggleSpeaker={toggleSpeaker}
+        onToggleTopic={toggleTopic}
+        onClearAll={clearAll}
+      />
+
+      {/* Main content */}
+      <div className="max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <Button
+            variant="ghost"
+            onClick={onBack}
+            className="gap-2"
+          >
+            <ArrowLeft size={18} />
+            Back to Library
+          </Button>
+          <UserMenu />
+        </div>
+
+        {/* Search Input */}
+        <div className="mb-8">
+          <div className="flex items-center justify-between mb-4">
+            <h1 className="text-2xl font-bold text-slate-900">Search Conversations</h1>
+            {/* Mobile filter button */}
+            <Button
+              variant="outline"
+              onClick={() => setIsFilterSheetOpen(true)}
+              className="md:hidden gap-2"
+            >
+              <Filter size={16} />
+              Filters
+              {activeFilterCount > 0 && (
+                <span className="ml-1 px-1.5 py-0.5 bg-blue-500 text-white text-xs rounded-full">
+                  {activeFilterCount}
+                </span>
+              )}
+            </Button>
+          </div>
+          <div className="relative">
+            <SearchIcon className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400" size={20} />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search across all transcripts..."
+              autoFocus
+              className="w-full pl-12 pr-4 py-3 rounded-lg border border-slate-200 focus:border-blue-400 focus:ring-2 focus:ring-blue-100 outline-none transition-all text-slate-900 placeholder:text-slate-400"
+            />
+          </div>
+        </div>
+
+        {/* Results with sidebar layout */}
+        <div className="flex gap-6 items-start">
+          {/* Desktop filter sidebar */}
+          <div className="hidden md:block flex-shrink-0">
+            <FilterSidebar
+              filters={filters}
+              activeFilterCount={activeFilterCount}
+              speakerOptions={speakerOptions}
+              topicOptions={topicOptions}
+              onDateRangeChange={setDateRange}
+              onCustomDateChange={setCustomDateRange}
+              onToggleSpeaker={toggleSpeaker}
+              onToggleTopic={toggleTopic}
+              onClearAll={clearAll}
+            />
+          </div>
+
+          {/* Results */}
+          <div className="flex-1 bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+            <SearchResults
+              results={results}
+              searchQuery={query}
+              isLoading={isLoading}
+              hasMore={hasMore}
+              onLoadMore={loadMore}
+              onOpenInViewer={handleOpenInViewer}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/pages/Viewer.tsx
+++ b/pages/Viewer.tsx
@@ -17,6 +17,7 @@ import { HelpCircle } from 'lucide-react';
 interface ViewerProps {
   onBack: () => void;
   onStatsClick?: () => void;
+  targetSegmentId?: string;
 }
 
 /**
@@ -34,7 +35,7 @@ interface ViewerProps {
  *
  * This went from 516 lines to ~130 lines. Much easier to reason about.
  */
-export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick }) => {
+export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegmentId }) => {
   const { activeConversation, updateConversation, getAudioUrl } = useConversations();
 
   // Bail if no active conversation (shouldn't happen, but TypeScript safety)
@@ -110,6 +111,26 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick }) => {
 
   // Auto-scroll to active segment during playback
   useAutoScroll(isPlaying, activeSegmentIndex, conversation.segments);
+
+  // Scroll to target segment if provided (from search deep-link)
+  useEffect(() => {
+    if (targetSegmentId) {
+      // Small delay to ensure DOM is ready
+      const timer = setTimeout(() => {
+        const el = document.getElementById(`segment-${targetSegmentId}`);
+        if (el) {
+          el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          // Briefly highlight the target segment
+          el.classList.add('ring-2', 'ring-blue-400', 'bg-blue-50');
+          setTimeout(() => {
+            el.classList.remove('ring-2', 'ring-blue-400', 'bg-blue-50');
+          }, 2000);
+        }
+      }, 300);
+
+      return () => clearTimeout(timer);
+    }
+  }, [targetSegmentId]);
 
   // Keyboard shortcuts (Space, ←/→, J/K, ?, Escape)
   const {

--- a/services/searchService.ts
+++ b/services/searchService.ts
@@ -1,0 +1,282 @@
+import { Conversation, Segment } from '../types';
+import { extractSnippet } from '../utils/textHighlight';
+import { SearchFilters } from '../hooks/useSearchFilters';
+
+/**
+ * searchService - Client-side full-text search within conversations
+ *
+ * Searches across all conversation segments and returns ranked results
+ * grouped by conversation. No Firestore indexes required since this runs
+ * entirely client-side on already-loaded conversation data.
+ */
+
+export interface SegmentMatch {
+  segmentId: string;
+  conversationId: string;
+  segment: Segment;
+  snippet: string;
+  matchCount: number; // Number of times the search term appears in this segment
+}
+
+export interface ConversationSearchResult {
+  conversationId: string;
+  conversation: Conversation;
+  matches: SegmentMatch[];
+  totalMatches: number;
+}
+
+export interface SearchResults {
+  results: ConversationSearchResult[];
+  totalResults: number;
+}
+
+/**
+ * Searches all conversations for segments matching the query
+ *
+ * @param conversations - All conversations to search
+ * @param query - Search query string
+ * @param contextChars - Characters of context around matches (default 50)
+ * @returns Search results grouped by conversation
+ */
+export function searchConversations(
+  conversations: Conversation[],
+  query: string,
+  contextChars: number = 50
+): SearchResults {
+  const trimmedQuery = query.trim();
+
+  // Empty query returns no results
+  if (!trimmedQuery) {
+    return { results: [], totalResults: 0 };
+  }
+
+  const conversationResults: ConversationSearchResult[] = [];
+  let totalResults = 0;
+
+  for (const conversation of conversations) {
+    // Skip incomplete conversations
+    if (conversation.status !== 'complete') {
+      continue;
+    }
+
+    const matches: SegmentMatch[] = [];
+
+    for (const segment of conversation.segments) {
+      const matchCount = countMatches(segment.text, trimmedQuery);
+
+      if (matchCount > 0) {
+        matches.push({
+          segmentId: segment.segmentId,
+          conversationId: conversation.conversationId,
+          segment,
+          snippet: extractSnippet(segment.text, trimmedQuery, contextChars),
+          matchCount
+        });
+        totalResults++;
+      }
+    }
+
+    // Only include conversations with matches
+    if (matches.length > 0) {
+      const totalMatches = matches.reduce((sum, m) => sum + m.matchCount, 0);
+      conversationResults.push({
+        conversationId: conversation.conversationId,
+        conversation,
+        matches,
+        totalMatches
+      });
+    }
+  }
+
+  // Sort conversations by total match count (most relevant first)
+  conversationResults.sort((a, b) => b.totalMatches - a.totalMatches);
+
+  return {
+    results: conversationResults,
+    totalResults
+  };
+}
+
+/**
+ * Counts how many times a search term appears in text (case-insensitive)
+ */
+function countMatches(text: string, searchTerm: string): number {
+  const lowerText = text.toLowerCase();
+  const lowerTerm = searchTerm.toLowerCase();
+  let count = 0;
+  let pos = 0;
+
+  while ((pos = lowerText.indexOf(lowerTerm, pos)) !== -1) {
+    count++;
+    pos += lowerTerm.length;
+  }
+
+  return count;
+}
+
+/**
+ * Paginates search results
+ *
+ * @param results - All search results
+ * @param limit - Number of segment matches to return (default 20)
+ * @param offset - Number of matches to skip (default 0)
+ * @returns Paginated results
+ */
+export function paginateResults(
+  results: SearchResults,
+  limit: number = 20,
+  offset: number = 0
+): SearchResults {
+  // Flatten all matches across conversations
+  const allMatches: { convResult: ConversationSearchResult; match: SegmentMatch }[] = [];
+
+  for (const convResult of results.results) {
+    for (const match of convResult.matches) {
+      allMatches.push({ convResult, match });
+    }
+  }
+
+  // Paginate the flat list
+  const paginatedMatches = allMatches.slice(offset, offset + limit);
+
+  // Re-group by conversation
+  const conversationMap = new Map<string, ConversationSearchResult>();
+
+  for (const { convResult, match } of paginatedMatches) {
+    if (!conversationMap.has(convResult.conversationId)) {
+      conversationMap.set(convResult.conversationId, {
+        conversationId: convResult.conversationId,
+        conversation: convResult.conversation,
+        matches: [],
+        totalMatches: convResult.totalMatches // Keep original total for display
+      });
+    }
+
+    conversationMap.get(convResult.conversationId)!.matches.push(match);
+  }
+
+  return {
+    results: Array.from(conversationMap.values()),
+    totalResults: results.totalResults
+  };
+}
+
+/**
+ * Filters search results based on user-selected filters
+ *
+ * Applies date range, speaker, and topic filters to search results.
+ * Filters are AND-ed together (all must pass).
+ *
+ * @param results - Search results to filter
+ * @param filters - Active filters
+ * @param conversations - Full conversation data (for accessing conversation.createdAt)
+ * @returns Filtered results
+ */
+export function filterSearchResults(
+  results: SearchResults,
+  filters: SearchFilters,
+  conversations: Conversation[]
+): SearchResults {
+  // Build conversation ID -> conversation map for quick lookups
+  const conversationMap = new Map(
+    conversations.map(conv => [conv.conversationId, conv])
+  );
+
+  const filteredConversationResults: ConversationSearchResult[] = [];
+  let totalResults = 0;
+
+  for (const convResult of results.results) {
+    const conversation = conversationMap.get(convResult.conversationId);
+    if (!conversation) continue;
+
+    // Date range filter (applies to entire conversation)
+    if (!passesDateFilter(conversation, filters)) {
+      continue;
+    }
+
+    // Speaker and topic filters (apply to individual segments)
+    const filteredMatches = convResult.matches.filter(match => {
+      const passesSpeaker = passesSpeakerFilter(match, filters);
+      const passesTopic = passesTopicFilter(conversation, match, filters);
+      return passesSpeaker && passesTopic;
+    });
+
+    // Only include conversations that still have matches after filtering
+    if (filteredMatches.length > 0) {
+      const totalMatches = filteredMatches.reduce((sum, m) => sum + m.matchCount, 0);
+      filteredConversationResults.push({
+        conversationId: convResult.conversationId,
+        conversation: convResult.conversation,
+        matches: filteredMatches,
+        totalMatches
+      });
+      totalResults += filteredMatches.length;
+    }
+  }
+
+  // Re-sort by total match count
+  filteredConversationResults.sort((a, b) => b.totalMatches - a.totalMatches);
+
+  return {
+    results: filteredConversationResults,
+    totalResults
+  };
+}
+
+/**
+ * Check if conversation passes date range filter
+ */
+function passesDateFilter(conversation: Conversation, filters: SearchFilters): boolean {
+  if (filters.dateRange === 'all') return true;
+
+  const createdAt = new Date(conversation.createdAt);
+  const now = new Date();
+
+  switch (filters.dateRange) {
+    case '7d':
+      return createdAt >= new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    case '30d':
+      return createdAt >= new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    case '90d':
+      return createdAt >= new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+    case 'custom':
+      if (filters.customStart && createdAt < filters.customStart) return false;
+      if (filters.customEnd && createdAt > filters.customEnd) return false;
+      return true;
+    default:
+      return true;
+  }
+}
+
+/**
+ * Check if segment match passes speaker filter
+ */
+function passesSpeakerFilter(match: SegmentMatch, filters: SearchFilters): boolean {
+  // No speaker filter = pass all
+  if (filters.speakers.length === 0) return true;
+
+  // Check if segment's speaker is in the filter list
+  return filters.speakers.includes(match.segment.speakerId);
+}
+
+/**
+ * Check if segment match passes topic filter
+ *
+ * A segment passes if it falls within any of the selected topics' segment ranges.
+ */
+function passesTopicFilter(
+  conversation: Conversation,
+  match: SegmentMatch,
+  filters: SearchFilters
+): boolean {
+  // No topic filter = pass all
+  if (filters.topics.length === 0) return true;
+
+  const segmentIndex = match.segment.index;
+
+  // Check if segment falls within any selected topic's range
+  return conversation.topics.some(topic => {
+    if (!filters.topics.includes(topic.topicId)) return false;
+    return segmentIndex >= topic.startIndex && segmentIndex <= topic.endIndex;
+  });
+}

--- a/utils/textHighlight.ts
+++ b/utils/textHighlight.ts
@@ -1,0 +1,98 @@
+/**
+ * textHighlight - Utilities for highlighting search matches in text
+ *
+ * Handles case-insensitive search term highlighting with context windows
+ * for snippets. Used for search result previews and in-transcript highlighting.
+ */
+
+export interface HighlightedSegment {
+  text: string;
+  isMatch: boolean;
+}
+
+/**
+ * Splits text into segments with matches highlighted
+ *
+ * Example: highlightMatches("The quick brown fox", "quick")
+ * Returns: [{text: "The ", isMatch: false}, {text: "quick", isMatch: true}, {text: " brown fox", isMatch: false}]
+ */
+export function highlightMatches(text: string, searchTerm: string): HighlightedSegment[] {
+  if (!searchTerm.trim()) {
+    return [{ text, isMatch: false }];
+  }
+
+  const segments: HighlightedSegment[] = [];
+  const regex = new RegExp(`(${escapeRegex(searchTerm)})`, 'gi');
+  const parts = text.split(regex);
+
+  for (const part of parts) {
+    if (part) {
+      const isMatch = regex.test(part);
+      // Reset regex after test (stateful regex gotcha)
+      regex.lastIndex = 0;
+      segments.push({
+        text: part,
+        isMatch: isMatch || part.toLowerCase() === searchTerm.toLowerCase()
+      });
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Extracts a snippet with context around the first match
+ *
+ * @param text - Full text to extract from
+ * @param searchTerm - Term to search for
+ * @param contextChars - Characters of context before/after match (default 50)
+ * @returns Snippet with "..." prefix/suffix if truncated
+ */
+export function extractSnippet(
+  text: string,
+  searchTerm: string,
+  contextChars: number = 50
+): string {
+  if (!searchTerm.trim()) {
+    // No search term - return start of text
+    return text.length > contextChars * 2
+      ? text.slice(0, contextChars * 2) + '...'
+      : text;
+  }
+
+  // Find first match (case-insensitive)
+  const lowerText = text.toLowerCase();
+  const lowerTerm = searchTerm.toLowerCase();
+  const matchIndex = lowerText.indexOf(lowerTerm);
+
+  if (matchIndex === -1) {
+    // No match found - shouldn't happen but handle gracefully
+    return text.length > contextChars * 2
+      ? text.slice(0, contextChars * 2) + '...'
+      : text;
+  }
+
+  // Calculate snippet boundaries
+  const start = Math.max(0, matchIndex - contextChars);
+  const end = Math.min(text.length, matchIndex + searchTerm.length + contextChars);
+
+  let snippet = text.slice(start, end);
+
+  // Add ellipsis if truncated
+  if (start > 0) {
+    snippet = '...' + snippet;
+  }
+  if (end < text.length) {
+    snippet = snippet + '...';
+  }
+
+  return snippet;
+}
+
+/**
+ * Escapes special regex characters in user input
+ * Prevents regex injection from search terms like "hello (world)"
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## Summary
- Add desktop filter sidebar (300px) with collapsible date range, speaker, and topic sections
- Add mobile bottom sheet with drag-to-dismiss gesture (swipe down >80px to close)
- Implement live filter updates - results and counts update immediately on filter change
- Add URL query param sync for shareable filtered search links
- Add sessionStorage persistence for filter state when navigating away and returning
- Add "Clear all" button to reset filters and update URL

## Technical Details
- New `useSearchFilters` hook manages filter state with URL/sessionStorage sync
- Extended `searchService.ts` with `filterSearchResults()` for client-side filtering
- Touch gesture handling uses React touch events with CSS transform feedback
- Speaker/topic counts derived from filtered results for accuracy
- No new dependencies - uses native HTML date inputs instead of Flowbite Datepicker

## Test plan
- [ ] **Desktop sidebar**: Verify 300px sticky sidebar with collapsible sections
- [ ] **Mobile bottom sheet**: Verify sheet opens via "Filters (N)" button
- [ ] **Drag-to-dismiss**: On mobile, swipe down >80px to close sheet
- [ ] **Date range filter**: Test All Time, Last 7/30/90 Days, and Custom Range
- [ ] **Speaker/topic filters**: Verify checkboxes filter results and counts update
- [ ] **URL sharing**: Copy URL with filters, open in new tab, verify filters restore
- [ ] **Browser navigation**: Use back/forward buttons, verify filter state restores
- [ ] **Session persistence**: Navigate away from /search, return, verify filters persist
- [ ] **Clear all**: Click "Clear All", verify filters reset and URL updates