### PR TITLE
fix(backend): configure undici headersTimeout for large file uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Large File Upload Timeouts** - Audio files up to 50MB now process reliably
-  - Gemini API calls configured with 10-minute timeout (prevents `HeadersTimeoutError` on large uploads)
+  - Node.js undici `headersTimeout` extended to 15 minutes (fixes root cause of `HeadersTimeoutError`)
+  - Gemini API calls configured with 10-minute SDK-level timeout as additional safeguard
   - Replicate API calls configured with 3-minute timeout via custom fetch wrapper
   - Gateway errors (502/503/504) now trigger automatic retries in WhisperX transcription
 

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -11,9 +11,11 @@
         "firebase-functions": "^7.0.2",
         "fuzzball": "^2.0.0",
         "jsonrepair": "^3.11.2",
-        "replicate": "^0.29.0"
+        "replicate": "^0.29.0",
+        "undici": "^6.21.0"
       },
       "devDependencies": {
+        "@types/node": "^20.17.12",
         "firebase-functions-test": "^3.4.0",
         "typescript": "^5.7.2"
       },
@@ -1626,9 +1628,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
-      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "version": "20.19.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
+      "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3262,7 +3264,6 @@
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
       "integrity": "sha512-raFIrOyTqREbyXsNkSHyciQLfv8AUZazehPaQS1lZBSCDYW74FYXU0nQZa3qHI4K+hawohlDbywZ4+qce9YNxA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "1.0.8",
@@ -3280,6 +3281,15 @@
       "optionalDependencies": {
         "@google-cloud/firestore": "^7.7.0",
         "@google-cloud/storage": "^7.7.0"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/@types/node": {
+      "version": "22.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
+      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/firebase-functions": {
@@ -6623,6 +6633,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -20,9 +20,11 @@
     "firebase-functions": "^7.0.2",
     "fuzzball": "^2.0.0",
     "jsonrepair": "^3.11.2",
-    "replicate": "^0.29.0"
+    "replicate": "^0.29.0",
+    "undici": "^6.21.0"
   },
   "devDependencies": {
+    "@types/node": "^20.17.12",
     "firebase-functions-test": "^3.4.0",
     "typescript": "^5.7.2"
   },


### PR DESCRIPTION
## Problem

The timeout fix in PR #77 (`requestOptions.timeout`) didn't fully solve the `HeadersTimeoutError` issue for large audio files (46MB+).

**Root cause discovered:** Node.js uses undici as its default fetch implementation. Undici has its own internal `headersTimeout` (default: 5 minutes) that fires independently of the SDK's AbortController timeout. For large audio files, Google may take >5 minutes just to *start* responding - before any headers are sent. The SDK timeout only kicks in after headers are received.

## Solution

Configure undici's global dispatcher at application startup (before any fetch calls) with extended timeouts:

```typescript
import { Agent, setGlobalDispatcher } from 'undici';

const agent = new Agent({
  headersTimeout: 900_000,  // 15 minutes (vs 5 min default)
  bodyTimeout: 900_000,     // 15 minutes
});

setGlobalDispatcher(agent);
```

## Changes

- `functions/src/index.ts` - Configure global undici dispatcher at top of file
- `functions/package.json` - Add explicit `undici` dependency for consistent behavior
- `CHANGELOG.md` - Update entry to mention undici fix

## How it works

1. The undici import and configuration runs FIRST, before Firebase Admin or Vertex AI SDK are imported
2. This sets a global dispatcher that all subsequent `fetch()` calls will use
3. Both Vertex AI SDK and Replicate SDK will now use the extended timeouts
4. Added console log confirms configuration on cold start

## Test plan

- [ ] Deploy to Cloud Functions
- [ ] Upload a large audio file (~46MB)
- [ ] Verify in logs that `[Undici] Global dispatcher configured` message appears
- [ ] Verify pre-analysis completes without `HeadersTimeoutError`
- [ ] Verify full transcription pipeline completes

## Related

- Follows up on PR #77 which added SDK-level timeouts
- Fixes the persistent `HeadersTimeoutError` issue on large uploads