### PR TITLE
fix(backend): increase timeouts to 20-25 min for large audio files

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -17,11 +17,11 @@
 // Node.js uses undici as the default fetch implementation. Its default
 // headersTimeout (5 minutes) is too short for large audio files sent to
 // Gemini API - Google may take >5 min to start responding for 46MB+ files.
-// We extend this to 15 minutes to prevent HeadersTimeoutError.
+// We extend this to 25 minutes to prevent HeadersTimeoutError.
 import { Agent, setGlobalDispatcher } from 'undici';
 
-const UNDICI_HEADERS_TIMEOUT_MS = 900_000;  // 15 minutes
-const UNDICI_BODY_TIMEOUT_MS = 900_000;     // 15 minutes
+const UNDICI_HEADERS_TIMEOUT_MS = 1_500_000;  // 25 minutes
+const UNDICI_BODY_TIMEOUT_MS = 1_500_000;     // 25 minutes
 
 const agent = new Agent({
   headersTimeout: UNDICI_HEADERS_TIMEOUT_MS,

--- a/functions/src/transcribe.ts
+++ b/functions/src/transcribe.ts
@@ -36,11 +36,11 @@ const huggingfaceAccessToken = defineSecret('HUGGINGFACE_ACCESS_TOKEN');  // For
 // =============================================================================
 
 /**
- * Timeout for Gemini API requests (10 minutes).
- * Large audio files (46MB+) need extra time for upload and processing.
- * The default undici timeout (~5min) is insufficient for these payloads.
+ * Timeout for Gemini API requests (20 minutes).
+ * Large audio files (46MB+) need substantial time for upload and processing.
+ * Google may take 10-15+ minutes to process a 46MB audio file before responding.
  */
-const GEMINI_REQUEST_TIMEOUT_MS = 600_000;
+const GEMINI_REQUEST_TIMEOUT_MS = 1_200_000;
 
 /**
  * Create a Vertex AI client for Gemini API calls.


### PR DESCRIPTION
## Problem

After PR #78, we're now hitting the SDK's AbortController timeout instead of undici's headersTimeout:

```
AbortError: This operation was aborted
    at node:internal/deps/undici/undici:13510:13
```

The 10-minute SDK timeout is still insufficient - Google takes 10-15+ minutes to process 46MB audio files.

## Solution

Increase all timeouts to give Google more time:

| Timeout | Before | After |
|---------|--------|-------|
| SDK AbortController | 10 min | **20 min** |
| undici headersTimeout | 15 min | **25 min** |
| undici bodyTimeout | 15 min | **25 min** |

## Changes

- `functions/src/transcribe.ts` - Increase `GEMINI_REQUEST_TIMEOUT_MS` to 20 min
- `functions/src/index.ts` - Increase undici timeouts to 25 min

## Test plan

- [ ] Deploy to Cloud Functions  
- [ ] Upload a large audio file (~46MB)
- [ ] Verify pre-analysis completes without `AbortError`
- [ ] Monitor logs for actual processing time

## Notes

If 20 minutes is still not enough, we may need to investigate alternative approaches:
- Processing via Cloud Storage URL instead of base64
- Using streaming responses
- Chunking large audio files