### PR TITLE
fix(backend): implement immediate abort via real-time Firestore listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Cancel Processing Now Works Immediately** - Cancel button stops processing without waiting
+  - Real-time Firestore listener detects abort flag instantly (no more checkpoint-only detection)
+  - Long-running Gemini and WhisperX calls abort immediately via `Promise.race()`
+  - Resources consumed before cancel are still tracked in metrics
+
 - **Large File Upload Timeouts** - Audio files up to 50MB now process reliably
   - Node.js undici `headersTimeout` extended to 15 minutes (fixes root cause of `HeadersTimeoutError`)
   - Gemini API calls configured with 10-minute SDK-level timeout as additional safeguard


### PR DESCRIPTION
## Problem

The cancel button doesn't actually stop processing - it just sets a flag that gets checked at checkpoints between operations. If a 20-minute Gemini API call is running, clicking cancel does nothing until that call finishes.

**User experience**: Click cancel → wait 20 minutes → finally see "cancelled" 😤

## Solution

Implement real-time abort detection using a Firestore listener:

```typescript
class AbortManager {
  // Sets up onSnapshot listener that immediately detects abort flag
  private setupListener(): Promise<never> {
    return new Promise((_, reject) => {
      docRef.onSnapshot((snapshot) => {
        if (snapshot.data()?.abortRequested === true) {
          reject(new AbortRequestedError(conversationId));
        }
      });
    });
  }

  // Race any operation against the abort listener
  async raceWithAbort<T>(operation: Promise<T>): Promise<T> {
    return Promise.race([operation, this.abortPromise]);
  }
}
```

Now all long-running operations are wrapped with `abortManager.raceWithAbort()`:
- Gemini pre-analysis
- WhisperX transcription (robust + standard)
- Gemini transcription fallback  
- Gemini transcript analysis
- Gemini speaker identification

**User experience**: Click cancel → see "cancelled" within seconds ✅

## Technical Details

- **Real-time detection**: Firestore `onSnapshot` fires immediately when `abortRequested` changes
- **Promise.race**: Whichever resolves/rejects first wins - abort or API response
- **Resource tracking**: Metrics still recorded for billing accuracy even on abort
- **Cleanup**: `finally` block ensures listener is removed to prevent memory leaks

## Test plan

- [ ] Start processing a large audio file
- [ ] Wait for pre-analysis to begin (shows "Pre-analyzing...")
- [ ] Click cancel button
- [ ] Verify status changes to "Cancelled" within seconds (not 20 minutes)
- [ ] Verify partial metrics are recorded in admin dashboard