### PR TITLE
fix(backend): increase Cloud Function timeout from 9 to 60 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Large File Upload Timeouts** - Audio files up to 50MB now process reliably
-  - Node.js undici `headersTimeout` extended to 15 minutes (fixes root cause of `HeadersTimeoutError`)
-  - Gemini API calls configured with 10-minute SDK-level timeout as additional safeguard
+  - Node.js undici `headersTimeout` extended to 25 minutes (fixes root cause of `HeadersTimeoutError`)
+  - Gemini API calls configured with 20-minute SDK-level timeout as additional safeguard
+  - Cloud Function timeout increased from 9 to 60 minutes (fixes 499 Client Closed Request errors)
   - Replicate API calls configured with 3-minute timeout via custom fetch wrapper
   - Gateway errors (502/503/504) now trigger automatic retries in WhisperX transcription
 

--- a/functions/src/transcribe.ts
+++ b/functions/src/transcribe.ts
@@ -688,7 +688,7 @@ export const transcribeAudio = onObjectFinalized(
   {
     secrets: [replicateApiToken, huggingfaceAccessToken],
     memory: '1GiB', // Audio processing needs more memory
-    timeoutSeconds: 540, // 9 minutes (max for 1st gen functions)
+    timeoutSeconds: 3600, // 60 minutes (max for 2nd gen functions) - large files need this
     region: 'us-central1'
   },
   async (event) => {


### PR DESCRIPTION
## Summary

- Increased Cloud Function timeout from 540s (9 min) to 3600s (60 min)
- Root cause of **499 Client Closed Request** errors when processing large audio files
- The function was being killed before Gemini API calls could complete

## Root Cause Analysis

Processing flow for 46MB audio file:
1. Gemini pre-analysis started
2. ~10 minutes elapsed
3. **Cloud Function killed at 9 minutes** ← root cause
4. Google servers received 499 "Client Closed Request"
5. SDK timeout (20 min) and undici timeout (25 min) were never reached

## Timeout Stack (after this fix)

| Layer | Timeout | Purpose |
|-------|---------|---------|
| Cloud Function | **60 min** | GCP kills function (was 9 min) |
| undici headersTimeout | 25 min | Node.js fetch headers |
| Gemini SDK timeout | 20 min | AbortController |
| Replicate timeout | 3 min | WhisperX API |

## Test plan

- [ ] Deploy to Firebase: `npx firebase deploy --only functions`
- [ ] Upload 46MB+ audio file
- [ ] Verify processing completes without 499 errors
- [ ] Monitor Cloud Logging for timing