### PR TITLE
fix(backend): revert Cloud Function timeout to 540s (max for storage triggers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **Large File Upload Timeouts** - Audio files up to 50MB now process reliably
+- **Large File Upload Timeouts** - Audio files now process more reliably
   - Node.js undici `headersTimeout` extended to 25 minutes (fixes root cause of `HeadersTimeoutError`)
   - Gemini API calls configured with 20-minute SDK-level timeout as additional safeguard
-  - Cloud Function timeout increased from 9 to 60 minutes (fixes 499 Client Closed Request errors)
   - Replicate API calls configured with 3-minute timeout via custom fetch wrapper
   - Gateway errors (502/503/504) now trigger automatic retries in WhisperX transcription
+  - Note: Storage-triggered functions limited to 9 minutes by GCP; very large files may still timeout
 
 ## [1.8.0-beta] - 2026-01-05
 

--- a/functions/src/transcribe.ts
+++ b/functions/src/transcribe.ts
@@ -688,7 +688,7 @@ export const transcribeAudio = onObjectFinalized(
   {
     secrets: [replicateApiToken, huggingfaceAccessToken],
     memory: '1GiB', // Audio processing needs more memory
-    timeoutSeconds: 3600, // 60 minutes (max for 2nd gen functions) - large files need this
+    timeoutSeconds: 540, // 9 minutes (max for event-driven triggers, even 2nd gen)
     region: 'us-central1'
   },
   async (event) => {

--- a/scripts/cleanup-zombie-jobs.js
+++ b/scripts/cleanup-zombie-jobs.js
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+/**
+ * Cleanup zombie processing jobs in Firestore
+ *
+ * Finds conversations stuck in 'processing' status for longer than the threshold
+ * and marks them as 'failed' so users can retry or delete them.
+ *
+ * Usage:
+ *   # Dry run (default) - shows what would be cleaned up
+ *   node scripts/cleanup-zombie-jobs.js
+ *
+ *   # Actually clean up the jobs
+ *   node scripts/cleanup-zombie-jobs.js --execute
+ *
+ *   # Custom threshold (default: 65 minutes)
+ *   node scripts/cleanup-zombie-jobs.js --threshold=30
+ *
+ * Environment:
+ *   Set GOOGLE_APPLICATION_CREDENTIALS to your service account key path
+ *   Or run on a machine with default GCP credentials (Cloud Shell, GCE, etc.)
+ */
+
+import admin from 'firebase-admin';
+
+// Configuration
+const DEFAULT_THRESHOLD_MINUTES = 65; // Slightly > max Cloud Function timeout (60 min)
+const PROJECT_ID = 'audio-transcript-analyzer-01';
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const execute = args.includes('--execute');
+const thresholdArg = args.find(a => a.startsWith('--threshold='));
+const thresholdMinutes = thresholdArg
+  ? parseInt(thresholdArg.split('=')[1], 10)
+  : DEFAULT_THRESHOLD_MINUTES;
+
+// Initialize Firebase Admin
+admin.initializeApp({
+  projectId: PROJECT_ID,
+  // Uses GOOGLE_APPLICATION_CREDENTIALS or default credentials
+});
+
+const db = admin.firestore();
+
+async function findZombieJobs(thresholdMs) {
+  const cutoff = new Date(Date.now() - thresholdMs);
+
+  console.log(`\n🔍 Looking for jobs stuck in 'processing' since before ${cutoff.toISOString()}\n`);
+
+  // Query for processing jobs
+  // Note: Firestore requires an index for compound queries
+  // If this fails, we'll fall back to client-side filtering
+  const snapshot = await db.collection('conversations')
+    .where('status', '==', 'processing')
+    .get();
+
+  const zombies = [];
+
+  for (const doc of snapshot.docs) {
+    const data = doc.data();
+
+    // Get the timestamp to check against
+    const startedAt = data.processingStartedAt?.toDate?.()
+      || data.updatedAt?.toDate?.()
+      || data.createdAt?.toDate?.();
+
+    if (!startedAt) {
+      console.log(`⚠️  ${doc.id}: No timestamp found, skipping`);
+      continue;
+    }
+
+    if (startedAt < cutoff) {
+      zombies.push({
+        id: doc.id,
+        title: data.title || 'Untitled',
+        userId: data.userId,
+        startedAt,
+        progress: data.progress,
+        currentStep: data.currentStep,
+        ageMinutes: Math.round((Date.now() - startedAt.getTime()) / 60000),
+      });
+    }
+  }
+
+  return zombies;
+}
+
+async function cleanupZombies(zombies) {
+  console.log(`\n🧹 Cleaning up ${zombies.length} zombie job(s)...\n`);
+
+  for (const zombie of zombies) {
+    try {
+      await db.collection('conversations').doc(zombie.id).update({
+        status: 'failed',
+        error: 'Processing timed out. Please delete and re-upload, or click Retry.',
+        errorCode: 'ZOMBIE_TIMEOUT',
+        failedAt: admin.firestore.FieldValue.serverTimestamp(),
+        zombieDetectedAt: admin.firestore.FieldValue.serverTimestamp(),
+        lastKnownProgress: zombie.progress,
+        lastKnownStep: zombie.currentStep,
+      });
+
+      console.log(`✅ ${zombie.id} (${zombie.title}) - marked as failed`);
+    } catch (error) {
+      console.error(`❌ ${zombie.id} - failed to update: ${error.message}`);
+    }
+  }
+}
+
+async function main() {
+  const thresholdMs = thresholdMinutes * 60 * 1000;
+
+  console.log('═'.repeat(60));
+  console.log('🧟 Zombie Job Cleanup');
+  console.log('═'.repeat(60));
+  console.log(`Mode: ${execute ? '🔴 EXECUTE (will modify data)' : '🟢 DRY RUN (preview only)'}`);
+  console.log(`Threshold: ${thresholdMinutes} minutes`);
+  console.log(`Project: ${PROJECT_ID}`);
+
+  try {
+    const zombies = await findZombieJobs(thresholdMs);
+
+    if (zombies.length === 0) {
+      console.log('\n✨ No zombie jobs found!\n');
+      process.exit(0);
+    }
+
+    console.log(`\n📋 Found ${zombies.length} zombie job(s):\n`);
+
+    for (const z of zombies) {
+      console.log(`  📄 ${z.id}`);
+      console.log(`     Title: ${z.title}`);
+      console.log(`     User: ${z.userId}`);
+      console.log(`     Age: ${z.ageMinutes} minutes`);
+      console.log(`     Progress: ${z.progress}%`);
+      console.log(`     Step: ${z.currentStep}`);
+      console.log('');
+    }
+
+    if (execute) {
+      await cleanupZombies(zombies);
+      console.log('\n✅ Cleanup complete!\n');
+    } else {
+      console.log('─'.repeat(60));
+      console.log('ℹ️  This was a dry run. To actually clean up these jobs, run:');
+      console.log('   node scripts/cleanup-zombie-jobs.js --execute');
+      console.log('─'.repeat(60));
+    }
+  } catch (error) {
+    console.error('\n❌ Error:', error.message);
+    if (error.code === 'UNAUTHENTICATED' || error.code === 16) {
+      console.error('\n💡 Make sure GOOGLE_APPLICATION_CREDENTIALS is set to your service account key path');
+      console.error('   Or run this from Cloud Shell / a GCE instance with default credentials');
+    }
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Reverts `timeoutSeconds` from 3600 to 540 in `transcribeAudio` function
- Fixes Firebase Deploy failure from PR #81

## Root Cause

Storage-triggered functions (`onObjectFinalized`) have a **maximum timeout of 540 seconds** (9 minutes), even for 2nd gen functions. The 60-minute limit only applies to HTTPS callable functions.

| Trigger Type | 1st Gen Max | 2nd Gen Max |
|--------------|-------------|-------------|
| HTTP callable | 540s | **3600s** |
| Event-driven (Storage, Firestore) | 540s | **540s** |

Source: [Firebase Function Quotas](https://firebase.google.com/docs/functions/quotas#time_limits)

## Impact

Files that need >9 minutes to process will still timeout. To handle these, we need architectural changes:

1. **Audio chunking** (documented in `04-large-file-upload-05-audio-chunking.md`)
2. **Cloud Tasks + HTTP function** - Storage trigger enqueues a Cloud Task that calls an HTTP function (which can run 60 min)

## Also Included

- `scripts/cleanup-zombie-jobs.js` - Manual cleanup script for stuck processing jobs

## Test Plan

- [ ] Firebase Deploy succeeds
- [ ] Existing file processing works