### PR TITLE
feat(chunking): add context propagation for speaker continuity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Each chunk processed as separate Cloud Task, staying within Cloud Function time limits
   - Chunk metadata stored in Firestore for downstream merge/deduplication (Scope 5c)
   - New `ProcessingStep.CHUNKING` shows chunking progress in UI
+- **Chunk Context Propagation** - Speaker identity and metadata maintained across chunk boundaries
+  - Each chunk emits a `ChunkContext` with speaker mappings, summary, and extracted IDs
+  - Next chunk loads previous context to maintain diarization continuity
+  - Firestore transactions ensure atomic status updates even with concurrent chunk tasks
+  - Resumable execution: failed/pending chunks can be retried with correct state bootstrap
 
 ### Changed
 - **Queue-Driven Transcription Architecture** - Large audio files (46MB+) now process reliably without timeouts

--- a/functions/src/chunkContext.ts
+++ b/functions/src/chunkContext.ts
@@ -1,0 +1,514 @@
+/**
+ * Chunk Context Management Module
+ *
+ * Handles reading/writing ChunkContext and ChunkStatus atomically using
+ * Firestore transactions. This is critical because multiple chunk tasks
+ * may run concurrently and race conditions could corrupt state.
+ *
+ * The chunk context enables:
+ * 1. Speaker identity continuity across chunk boundaries
+ * 2. Deduplication of terms/topics/people across chunks
+ * 3. Resumable execution (failed chunks can retry with correct state)
+ */
+
+import { db } from './index';
+import { FieldValue, Transaction } from 'firebase-admin/firestore';
+import {
+  ChunkContext,
+  ChunkStatus,
+  ChunkProcessingStatus,
+  ChunkingMetadata,
+  SpeakerMapping
+} from './types';
+
+// Maximum summary length to prevent unbounded growth
+const MAX_SUMMARY_LENGTH = 512;
+
+// =============================================================================
+// Context Creation
+// =============================================================================
+
+/**
+ * Create an empty initial context for the first chunk.
+ * This is the "seed" state before any processing.
+ */
+export function createInitialContext(): ChunkContext {
+  return {
+    emittedByChunkIndex: -1, // Indicates this is the initial seed, not emitted by a real chunk
+    speakerMap: [],
+    previousSummary: '',
+    knownTermIds: [],
+    knownTopicIds: [],
+    knownPersonIds: [],
+    cumulativeSegmentCount: 0,
+    lastProcessedMs: 0
+  };
+}
+
+/**
+ * Create initial chunk statuses for a set of chunks.
+ * All chunks start as 'pending'.
+ */
+export function createInitialChunkStatuses(totalChunks: number): ChunkStatus[] {
+  return Array.from({ length: totalChunks }, (_, i) => ({
+    chunkIndex: i,
+    status: 'pending' as ChunkProcessingStatus,
+    retryCount: 0
+  }));
+}
+
+// =============================================================================
+// Context Reading
+// =============================================================================
+
+/**
+ * Load the chunk context for a specific chunk index.
+ *
+ * For chunk 0, returns the initial empty context.
+ * For chunk N (N > 0), returns the context emitted by chunk N-1.
+ *
+ * Uses a transaction to ensure consistent read with potential updates.
+ *
+ * @throws Error if previous chunk context is missing (indicates incomplete processing)
+ */
+export async function loadChunkContext(
+  conversationId: string,
+  chunkIndex: number
+): Promise<ChunkContext> {
+  const docRef = db.collection('conversations').doc(conversationId);
+
+  return db.runTransaction(async (transaction: Transaction) => {
+    const doc = await transaction.get(docRef);
+
+    if (!doc.exists) {
+      throw new Error(`Conversation ${conversationId} not found`);
+    }
+
+    const data = doc.data();
+    const chunkingMeta = data?.chunkingMetadata as ChunkingMetadata | undefined;
+
+    // For the first chunk, return initial context
+    if (chunkIndex === 0) {
+      console.log('[ChunkContext] First chunk - using initial empty context');
+      return createInitialContext();
+    }
+
+    // For subsequent chunks, we need the context from the previous chunk
+    const previousChunkIndex = chunkIndex - 1;
+
+    if (!chunkingMeta?.chunkContexts) {
+      throw new Error(`No chunk contexts found for conversation ${conversationId}`);
+    }
+
+    const previousContext = chunkingMeta.chunkContexts.find(
+      ctx => ctx.emittedByChunkIndex === previousChunkIndex
+    );
+
+    if (!previousContext) {
+      // Check if previous chunk is still processing or failed
+      const previousStatus = chunkingMeta.chunkStatuses?.find(
+        s => s.chunkIndex === previousChunkIndex
+      );
+
+      if (previousStatus?.status === 'processing') {
+        throw new Error(
+          `Chunk ${chunkIndex} waiting on chunk ${previousChunkIndex} which is still processing`
+        );
+      } else if (previousStatus?.status === 'failed') {
+        throw new Error(
+          `Chunk ${chunkIndex} cannot proceed - previous chunk ${previousChunkIndex} failed: ${previousStatus.error}`
+        );
+      } else if (previousStatus?.status === 'pending') {
+        throw new Error(
+          `Chunk ${chunkIndex} cannot proceed - previous chunk ${previousChunkIndex} is still pending`
+        );
+      }
+
+      throw new Error(
+        `Context from chunk ${previousChunkIndex} not found for conversation ${conversationId}`
+      );
+    }
+
+    console.log('[ChunkContext] Loaded context from previous chunk:', {
+      conversationId,
+      chunkIndex,
+      previousChunkIndex,
+      speakerCount: previousContext.speakerMap.length,
+      cumulativeSegments: previousContext.cumulativeSegmentCount
+    });
+
+    return previousContext;
+  });
+}
+
+// =============================================================================
+// Status Updates
+// =============================================================================
+
+/**
+ * Mark a chunk as "processing" atomically.
+ * Updates the chunk status and increments retry count if this is a retry.
+ *
+ * Uses transaction to prevent race conditions between concurrent chunk tasks.
+ */
+export async function markChunkProcessing(
+  conversationId: string,
+  chunkIndex: number
+): Promise<void> {
+  const docRef = db.collection('conversations').doc(conversationId);
+
+  await db.runTransaction(async (transaction: Transaction) => {
+    const doc = await transaction.get(docRef);
+
+    if (!doc.exists) {
+      throw new Error(`Conversation ${conversationId} not found`);
+    }
+
+    const data = doc.data();
+    const chunkingMeta = data?.chunkingMetadata as ChunkingMetadata | undefined;
+
+    if (!chunkingMeta) {
+      throw new Error(`No chunking metadata for conversation ${conversationId}`);
+    }
+
+    // Find and update the chunk status
+    const statuses = [...chunkingMeta.chunkStatuses];
+    const statusIndex = statuses.findIndex(s => s.chunkIndex === chunkIndex);
+
+    if (statusIndex === -1) {
+      throw new Error(`Chunk ${chunkIndex} not found in statuses for ${conversationId}`);
+    }
+
+    const currentStatus = statuses[statusIndex];
+
+    // Increment retry count if this was previously failed or processing
+    const isRetry = currentStatus.status === 'failed' || currentStatus.status === 'processing';
+
+    statuses[statusIndex] = {
+      ...currentStatus,
+      status: 'processing',
+      startedAt: new Date().toISOString(),
+      error: undefined, // Clear previous error
+      retryCount: isRetry ? (currentStatus.retryCount || 0) + 1 : currentStatus.retryCount || 0
+    };
+
+    transaction.update(docRef, {
+      'chunkingMetadata.chunkStatuses': statuses,
+      updatedAt: FieldValue.serverTimestamp()
+    });
+
+    console.log('[ChunkContext] Marked chunk as processing:', {
+      conversationId,
+      chunkIndex,
+      isRetry,
+      retryCount: statuses[statusIndex].retryCount
+    });
+  });
+}
+
+/**
+ * Mark a chunk as completed and save its emitted context.
+ *
+ * This is the critical operation for context propagation - it:
+ * 1. Updates the chunk status to 'complete'
+ * 2. Stores the context this chunk emitted for the next chunk
+ * 3. Increments the completedChunks counter
+ *
+ * Uses transaction to ensure atomicity.
+ */
+export async function markChunkComplete(
+  conversationId: string,
+  chunkIndex: number,
+  emittedContext: ChunkContext
+): Promise<void> {
+  const docRef = db.collection('conversations').doc(conversationId);
+
+  await db.runTransaction(async (transaction: Transaction) => {
+    const doc = await transaction.get(docRef);
+
+    if (!doc.exists) {
+      throw new Error(`Conversation ${conversationId} not found`);
+    }
+
+    const data = doc.data();
+    const chunkingMeta = data?.chunkingMetadata as ChunkingMetadata | undefined;
+
+    if (!chunkingMeta) {
+      throw new Error(`No chunking metadata for conversation ${conversationId}`);
+    }
+
+    // Update chunk status
+    const statuses = [...chunkingMeta.chunkStatuses];
+    const statusIndex = statuses.findIndex(s => s.chunkIndex === chunkIndex);
+
+    if (statusIndex === -1) {
+      throw new Error(`Chunk ${chunkIndex} not found in statuses`);
+    }
+
+    statuses[statusIndex] = {
+      ...statuses[statusIndex],
+      status: 'complete',
+      completedAt: new Date().toISOString()
+    };
+
+    // Add context to the contexts array
+    // First, filter out any existing context from this chunk (in case of retry)
+    const contexts = chunkingMeta.chunkContexts.filter(
+      ctx => ctx.emittedByChunkIndex !== chunkIndex
+    );
+    contexts.push(emittedContext);
+
+    // Sort by chunk index for easier debugging
+    contexts.sort((a, b) => a.emittedByChunkIndex - b.emittedByChunkIndex);
+
+    // Calculate completed count
+    const completedCount = statuses.filter(s => s.status === 'complete').length;
+
+    transaction.update(docRef, {
+      'chunkingMetadata.chunkStatuses': statuses,
+      'chunkingMetadata.chunkContexts': contexts,
+      'chunkingMetadata.completedChunks': completedCount,
+      updatedAt: FieldValue.serverTimestamp()
+    });
+
+    console.log('[ChunkContext] Marked chunk complete:', {
+      conversationId,
+      chunkIndex,
+      completedCount,
+      totalChunks: chunkingMeta.totalChunks,
+      isAllComplete: completedCount === chunkingMeta.totalChunks
+    });
+  });
+}
+
+/**
+ * Mark a chunk as failed with error details.
+ *
+ * This allows the resume logic to identify failed chunks for retry.
+ */
+export async function markChunkFailed(
+  conversationId: string,
+  chunkIndex: number,
+  error: string
+): Promise<void> {
+  const docRef = db.collection('conversations').doc(conversationId);
+
+  await db.runTransaction(async (transaction: Transaction) => {
+    const doc = await transaction.get(docRef);
+
+    if (!doc.exists) {
+      throw new Error(`Conversation ${conversationId} not found`);
+    }
+
+    const data = doc.data();
+    const chunkingMeta = data?.chunkingMetadata as ChunkingMetadata | undefined;
+
+    if (!chunkingMeta) {
+      throw new Error(`No chunking metadata for conversation ${conversationId}`);
+    }
+
+    const statuses = [...chunkingMeta.chunkStatuses];
+    const statusIndex = statuses.findIndex(s => s.chunkIndex === chunkIndex);
+
+    if (statusIndex === -1) {
+      throw new Error(`Chunk ${chunkIndex} not found in statuses`);
+    }
+
+    statuses[statusIndex] = {
+      ...statuses[statusIndex],
+      status: 'failed',
+      completedAt: new Date().toISOString(),
+      error
+    };
+
+    transaction.update(docRef, {
+      'chunkingMetadata.chunkStatuses': statuses,
+      updatedAt: FieldValue.serverTimestamp()
+    });
+
+    console.log('[ChunkContext] Marked chunk failed:', {
+      conversationId,
+      chunkIndex,
+      error: error.substring(0, 200) // Truncate for logging
+    });
+  });
+}
+
+// =============================================================================
+// Resume Logic
+// =============================================================================
+
+/**
+ * Get chunks that need processing (pending or failed).
+ *
+ * Used by resume logic to determine which chunk tasks to re-enqueue.
+ * Returns chunks sorted by index to maintain processing order.
+ */
+export async function getResumableChunks(
+  conversationId: string
+): Promise<{ pending: number[]; failed: number[]; processing: number[] }> {
+  const doc = await db.collection('conversations').doc(conversationId).get();
+
+  if (!doc.exists) {
+    throw new Error(`Conversation ${conversationId} not found`);
+  }
+
+  const data = doc.data();
+  const chunkingMeta = data?.chunkingMetadata as ChunkingMetadata | undefined;
+
+  if (!chunkingMeta) {
+    return { pending: [], failed: [], processing: [] };
+  }
+
+  const pending: number[] = [];
+  const failed: number[] = [];
+  const processing: number[] = [];
+
+  for (const status of chunkingMeta.chunkStatuses) {
+    switch (status.status) {
+      case 'pending':
+        pending.push(status.chunkIndex);
+        break;
+      case 'failed':
+        failed.push(status.chunkIndex);
+        break;
+      case 'processing':
+        processing.push(status.chunkIndex);
+        break;
+    }
+  }
+
+  // Sort for predictable ordering
+  pending.sort((a, b) => a - b);
+  failed.sort((a, b) => a - b);
+  processing.sort((a, b) => a - b);
+
+  console.log('[ChunkContext] Resumable chunks:', {
+    conversationId,
+    pending,
+    failed,
+    processing
+  });
+
+  return { pending, failed, processing };
+}
+
+/**
+ * Check if all chunks are complete.
+ */
+export async function isAllChunksComplete(conversationId: string): Promise<boolean> {
+  const doc = await db.collection('conversations').doc(conversationId).get();
+
+  if (!doc.exists) {
+    return false;
+  }
+
+  const data = doc.data();
+  const chunkingMeta = data?.chunkingMetadata as ChunkingMetadata | undefined;
+
+  if (!chunkingMeta) {
+    return false;
+  }
+
+  return chunkingMeta.completedChunks === chunkingMeta.totalChunks;
+}
+
+// =============================================================================
+// Context Building Helpers
+// =============================================================================
+
+/**
+ * Sanitize and truncate a summary string.
+ * Removes any potentially sensitive content and caps length.
+ */
+export function sanitizeSummary(summary: string): string {
+  // Remove potential secrets (API keys, tokens, etc.)
+  const sanitized = summary
+    .replace(/\b[A-Za-z0-9]{32,}\b/g, '[REDACTED]') // Long alphanumeric strings
+    .replace(/sk-[A-Za-z0-9]+/g, '[REDACTED]') // API key patterns
+    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*\S+/gi, '[REDACTED]');
+
+  // Truncate to max length, ending at a word boundary if possible
+  if (sanitized.length <= MAX_SUMMARY_LENGTH) {
+    return sanitized;
+  }
+
+  const truncated = sanitized.substring(0, MAX_SUMMARY_LENGTH);
+  const lastSpace = truncated.lastIndexOf(' ');
+
+  if (lastSpace > MAX_SUMMARY_LENGTH * 0.8) {
+    return truncated.substring(0, lastSpace) + '...';
+  }
+
+  return truncated + '...';
+}
+
+/**
+ * Merge speaker mappings from current chunk into existing map.
+ *
+ * When a new chunk discovers speakers, we need to either:
+ * 1. Map them to existing canonical IDs (if they match known speakers)
+ * 2. Create new canonical IDs (if they're new speakers)
+ *
+ * This is a simplified implementation - real speaker matching would use
+ * voice embeddings. For now, we just preserve the mappings as-is.
+ */
+export function mergeSpeakerMappings(
+  existing: SpeakerMapping[],
+  newMappings: SpeakerMapping[]
+): SpeakerMapping[] {
+  const merged = [...existing];
+
+  for (const newMapping of newMappings) {
+    // Check if we already have a mapping for this original ID
+    const existingIndex = merged.findIndex(m => m.originalId === newMapping.originalId);
+
+    if (existingIndex === -1) {
+      merged.push(newMapping);
+    } else {
+      // Update with any new information (e.g., display name discovered later)
+      merged[existingIndex] = {
+        ...merged[existingIndex],
+        displayName: newMapping.displayName || merged[existingIndex].displayName,
+        voiceSignature: newMapping.voiceSignature || merged[existingIndex].voiceSignature
+      };
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Build the next context from current processing results.
+ *
+ * Call this at the end of chunk processing to create the context
+ * that will be passed to the next chunk.
+ */
+export function buildNextContext(
+  previousContext: ChunkContext,
+  chunkIndex: number,
+  params: {
+    speakerMappings: SpeakerMapping[];
+    chunkSummary: string;
+    newTermIds: string[];
+    newTopicIds: string[];
+    newPersonIds: string[];
+    segmentsProcessed: number;
+    lastTimestampMs: number;
+  }
+): ChunkContext {
+  return {
+    emittedByChunkIndex: chunkIndex,
+    speakerMap: mergeSpeakerMappings(previousContext.speakerMap, params.speakerMappings),
+    previousSummary: sanitizeSummary(
+      previousContext.previousSummary
+        ? `${previousContext.previousSummary} | ${params.chunkSummary}`
+        : params.chunkSummary
+    ),
+    knownTermIds: [...new Set([...previousContext.knownTermIds, ...params.newTermIds])],
+    knownTopicIds: [...new Set([...previousContext.knownTopicIds, ...params.newTopicIds])],
+    knownPersonIds: [...new Set([...previousContext.knownPersonIds, ...params.newPersonIds])],
+    cumulativeSegmentCount: previousContext.cumulativeSegmentCount + params.segmentsProcessed,
+    lastProcessedMs: params.lastTimestampMs
+  };
+}

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -110,3 +110,117 @@ export interface ProcessingTimeline {
   completedAt?: string;
   durationMs?: number;
 }
+
+// =============================================================================
+// Chunked Processing Types
+// =============================================================================
+
+/**
+ * Status of individual chunk processing.
+ * Used to track progress and enable resumable execution.
+ */
+export type ChunkProcessingStatus = 'pending' | 'processing' | 'complete' | 'failed';
+
+/**
+ * Status entry for a single chunk in the processing pipeline.
+ * Tracks lifecycle timestamps and any errors for resume logic.
+ */
+export interface ChunkStatus {
+  /** Zero-indexed chunk number */
+  chunkIndex: number;
+  /** Current processing state */
+  status: ChunkProcessingStatus;
+  /** When processing started (ISO timestamp) */
+  startedAt?: string;
+  /** When processing completed (ISO timestamp) */
+  completedAt?: string;
+  /** Error message if status is 'failed' */
+  error?: string;
+  /** Number of retry attempts for this chunk */
+  retryCount?: number;
+}
+
+/**
+ * Speaker identity mapping preserved across chunk boundaries.
+ * Maps pyannote speaker IDs to consistent identities.
+ */
+export interface SpeakerMapping {
+  /** Original speaker ID from current chunk (e.g., "SPEAKER_00") */
+  originalId: string;
+  /** Canonical speaker ID used across all chunks */
+  canonicalId: string;
+  /** Inferred display name if known */
+  displayName?: string;
+  /** Voice signature hint for matching (future use) */
+  voiceSignature?: string;
+}
+
+/**
+ * Context passed between chunk processing tasks.
+ * Enables diarization continuity and resumable execution.
+ *
+ * This is the state machine's "carry forward" data - each chunk
+ * reads the previous context and emits a new one for the next chunk.
+ */
+export interface ChunkContext {
+  /** Which chunk this context was emitted by (for validation) */
+  emittedByChunkIndex: number;
+  /** Speaker mappings discovered so far */
+  speakerMap: SpeakerMapping[];
+  /** Short summary of content processed so far (max ~512 chars, sanitized) */
+  previousSummary: string;
+  /** Terms extracted from previous chunks (for deduplication) */
+  knownTermIds: string[];
+  /** Topic IDs from previous chunks */
+  knownTopicIds: string[];
+  /** Person IDs from previous chunks */
+  knownPersonIds: string[];
+  /** Total segments processed so far (for index continuity) */
+  cumulativeSegmentCount: number;
+  /** Timestamp of last processed audio (ms in original) for continuity */
+  lastProcessedMs: number;
+}
+
+/**
+ * Firestore-stored chunking metadata with status tracking.
+ * Extended from the original chunkMetadata to include context propagation.
+ */
+export interface ChunkingMetadata {
+  /** Whether chunking was applied */
+  chunkingEnabled: boolean;
+  /** Total number of chunks */
+  totalChunks: number;
+  /** Number of chunks that completed successfully */
+  completedChunks: number;
+  /** Per-chunk status array */
+  chunkStatuses: ChunkStatus[];
+  /** Per-chunk context sequence (chunkContexts[i] = context emitted by chunk i) */
+  chunkContexts: ChunkContext[];
+  /** When chunking was initiated (ISO timestamp) */
+  chunkedAt: string;
+  /** Original audio duration (ms) */
+  originalDurationMs: number;
+  /** Original audio storage path */
+  originalStoragePath: string;
+}
+
+/**
+ * Result returned by the transcription pipeline for chunk context propagation.
+ * Contains the data needed to build the next chunk's context.
+ */
+export interface ChunkPipelineResult {
+  /** Speaker mappings discovered in this chunk (originalId → canonicalId) */
+  speakerMappings: SpeakerMapping[];
+  /** Short summary of content processed (will be sanitized/truncated) */
+  summary: string;
+  /** Term IDs extracted in this chunk */
+  termIds: string[];
+  /** Topic IDs extracted in this chunk */
+  topicIds: string[];
+  /** Person IDs extracted in this chunk */
+  personIds: string[];
+  /** Number of segments processed in this chunk */
+  segmentCount: number;
+  /** Last timestamp processed in this chunk (ms) */
+  lastTimestampMs: number;
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -134,3 +134,117 @@ export interface ProcessingTimeline {
   completedAt?: string; // ISO timestamp
   durationMs?: number;
 }
+
+// =============================================================================
+// Chunked Processing Types
+// =============================================================================
+
+/**
+ * Status of individual chunk processing.
+ * Used to track progress and enable resumable execution.
+ */
+export type ChunkProcessingStatus = 'pending' | 'processing' | 'complete' | 'failed';
+
+/**
+ * Status entry for a single chunk in the processing pipeline.
+ * Tracks lifecycle timestamps and any errors for resume logic.
+ */
+export interface ChunkStatus {
+  /** Zero-indexed chunk number */
+  chunkIndex: number;
+  /** Current processing state */
+  status: ChunkProcessingStatus;
+  /** When processing started (ISO timestamp) */
+  startedAt?: string;
+  /** When processing completed (ISO timestamp) */
+  completedAt?: string;
+  /** Error message if status is 'failed' */
+  error?: string;
+  /** Number of retry attempts for this chunk */
+  retryCount?: number;
+}
+
+/**
+ * Speaker identity mapping preserved across chunk boundaries.
+ * Maps pyannote speaker IDs to consistent identities.
+ */
+export interface SpeakerMapping {
+  /** Original speaker ID from current chunk (e.g., "SPEAKER_00") */
+  originalId: string;
+  /** Canonical speaker ID used across all chunks */
+  canonicalId: string;
+  /** Inferred display name if known */
+  displayName?: string;
+  /** Voice signature hint for matching (future use) */
+  voiceSignature?: string;
+}
+
+/**
+ * Context passed between chunk processing tasks.
+ * Enables diarization continuity and resumable execution.
+ *
+ * This is the state machine's "carry forward" data - each chunk
+ * reads the previous context and emits a new one for the next chunk.
+ */
+export interface ChunkContext {
+  /** Which chunk this context was emitted by (for validation) */
+  emittedByChunkIndex: number;
+  /** Speaker mappings discovered so far */
+  speakerMap: SpeakerMapping[];
+  /** Short summary of content processed so far (max ~512 chars, sanitized) */
+  previousSummary: string;
+  /** Terms extracted from previous chunks (for deduplication) */
+  knownTermIds: string[];
+  /** Topic IDs from previous chunks */
+  knownTopicIds: string[];
+  /** Person IDs from previous chunks */
+  knownPersonIds: string[];
+  /** Total segments processed so far (for index continuity) */
+  cumulativeSegmentCount: number;
+  /** Timestamp of last processed audio (ms in original) for continuity */
+  lastProcessedMs: number;
+}
+
+/**
+ * Firestore-stored chunking metadata with status tracking.
+ * Extended from the original chunkMetadata to include context propagation.
+ */
+export interface ChunkingMetadata {
+  /** Whether chunking was applied */
+  chunkingEnabled: boolean;
+  /** Total number of chunks */
+  totalChunks: number;
+  /** Number of chunks that completed successfully */
+  completedChunks: number;
+  /** Per-chunk status array */
+  chunkStatuses: ChunkStatus[];
+  /** Per-chunk context sequence (chunkContexts[i] = context emitted by chunk i) */
+  chunkContexts: ChunkContext[];
+  /** When chunking was initiated (ISO timestamp) */
+  chunkedAt: string;
+  /** Original audio duration (ms) */
+  originalDurationMs: number;
+  /** Original audio storage path */
+  originalStoragePath: string;
+}
+
+/**
+ * Result returned by the transcription pipeline for chunk context propagation.
+ * Contains the data needed to build the next chunk's context.
+ */
+export interface ChunkPipelineResult {
+  /** Speaker mappings discovered in this chunk (originalId → canonicalId) */
+  speakerMappings: SpeakerMapping[];
+  /** Short summary of content processed (will be sanitized/truncated) */
+  summary: string;
+  /** Term IDs extracted in this chunk */
+  termIds: string[];
+  /** Topic IDs extracted in this chunk */
+  topicIds: string[];
+  /** Person IDs extracted in this chunk */
+  personIds: string[];
+  /** Number of segments processed in this chunk */
+  segmentCount: number;
+  /** Last timestamp processed in this chunk (ms) */
+  lastTimestampMs: number;
+}


### PR DESCRIPTION
## Summary

- Add chunk context state machine for maintaining speaker diarization continuity across chunk boundaries
- Implement `ChunkPipelineResult` type for structured pipeline return data
- Thread real speaker mappings, summary text, and entity IDs through `buildNextContext`
- Enable resumable execution with per-chunk status tracking in Firestore

## Changelog Entry

```markdown
- **Chunk Context Propagation** - Speaker identity and metadata maintained across chunk boundaries
  - Each chunk emits a `ChunkContext` with speaker mappings, summary, and extracted IDs
  - Next chunk loads previous context to maintain diarization continuity
  - Firestore transactions ensure atomic status updates even with concurrent chunk tasks
  - Resumable execution: failed/pending chunks can be retried with correct state bootstrap
```

## Test Plan

- [x] TypeScript compilation passes (functions + frontend)
- [x] ESLint passes (0 errors)
- [x] Prettier formatting passes
- [x] Pre-commit hooks pass

---
Scope: `04_large_file_upload_02_02_context`
Iteration: `iteration_01_a`