### PR TITLE
feat(chunking): add chunk merge system for large file uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Next chunk loads previous context to maintain diarization continuity
   - Firestore transactions ensure atomic status updates even with concurrent chunk tasks
   - Resumable execution: failed/pending chunks can be retried with correct state bootstrap
+- **Chunk Merge System** - Automatic reassembly of chunked transcripts into a unified document
+  - Segments deduplicated in overlap regions using "later chunk wins" strategy
+  - Timestamps normalized from chunk-local to original audio timeline for accurate playback sync
+  - Speakers, terms, topics, and people merged deterministically across all chunks
+  - Cloud Task-based merge job with `mergeTaskEnqueued` guard to prevent duplicate merges
+  - Conversation status transitions: `chunking` → `merging` → `complete`
 
 ### Changed
 - **Queue-Driven Transcription Architecture** - Large audio files (46MB+) now process reliably without timeouts

--- a/docs/explanation/chunk-merge.md
+++ b/docs/explanation/chunk-merge.md
@@ -1,0 +1,274 @@
+# Chunk Merge Architecture
+
+This document explains the chunk merge system - the final step in processing large audio files (>30 minutes). After all chunks have been processed individually, the merge layer stitches them back together into a single coherent conversation.
+
+## Overview
+
+The chunk merge system is part of the large file upload flow:
+
+```
+Audio Upload → Chunking → Chunk Processing → Chunk Merge → Complete
+                ↓              ↓                  ↓
+           (30s overlap)  (WhisperX + Gemini)  (Deduplicate)
+```
+
+**Purpose**: Transform multiple chunk artifacts into a single merged conversation document with no duplicates or gaps.
+
+## System Architecture
+
+### Data Flow
+
+```
+conversations/{id}/chunks/*  → mergeChunks() → conversations/{id}
+         ↓                           ↓                    ↓
+   ChunkArtifacts           Deduplicate & Merge     Final Conversation
+```
+
+### Components
+
+1. **Chunk Artifacts** (`conversations/{id}/chunks/{chunkIndex}`)
+   - Firestore subcollection storing per-chunk results
+   - Each artifact contains: segments, speakers, terms, topics, people
+   - Includes overlap boundaries for deduplication
+
+2. **Merge Worker** (`functions/src/chunkMerge.ts`)
+   - Cloud Function invoked by Cloud Tasks
+   - Loads all chunk artifacts
+   - Deduplicates segments in overlap regions
+   - Merges speakers, terms, topics, people
+   - Writes final conversation document
+
+3. **Merge Trigger** (`processTranscription.ts`)
+   - Checks if all chunks complete after each chunk finishes
+   - Enqueues merge task atomically (guard flag prevents duplicates)
+   - Updates conversation status to 'merging'
+
+## Status Transitions
+
+```
+processing → chunking → merging → complete
+                ↓           ↓
+           (chunks enqueued) (merge enqueued)
+```
+
+- **processing**: Initial audio upload (before chunking decision)
+- **chunking**: Chunks created, tasks enqueued, processing in progress
+- **merging**: All chunks complete, merge task running
+- **complete**: Merge complete, final conversation ready
+
+## Deduplication Strategy
+
+### Problem
+
+Chunks have 30-second overlaps for speaker continuity. Without deduplication, we'd have duplicate segments:
+
+```
+Chunk 0: [0s────────────────15s]──[15s──18s]
+                             ↑  overlap  ↑
+Chunk 1:                    [15s──18s]──[18s────────30s]
+```
+
+Segments in the overlap region (15s-18s) appear in **both chunks**.
+
+### Solution: Preferred Chunk Logic
+
+For each segment, we determine which chunk "owns" it:
+
+```typescript
+const preferredChunk = getPreferredChunkForTimestamp(segment.startMs, chunks);
+if (preferredChunk === artifact.chunkIndex) {
+  // This chunk owns this segment - include it
+  mergedSegments.push(segment);
+}
+```
+
+**Rule**: The **later chunk** (higher index) owns segments in the overlap region.
+
+**Why?** Ensures deterministic, consistent deduplication. Each segment is attributed to exactly one chunk.
+
+### Example
+
+```
+Chunk 0 segments:
+  [0ms─5000ms]   ← kept (chunk 0 owns)
+  [5000ms─10000ms]  ← kept (chunk 0 owns)
+  [15000ms─18000ms] ← DROPPED (chunk 1 owns overlap)
+
+Chunk 1 segments:
+  [15000ms─18000ms] ← kept (chunk 1 owns overlap)
+  [18000ms─25000ms] ← kept (chunk 1 owns)
+
+Merged result:
+  [0ms─5000ms, 5000ms─10000ms, 15000ms─18000ms, 18000ms─25000ms]
+  ↑ no duplicates, no gaps
+```
+
+## Merging Other Data
+
+### Speakers
+
+Simple union - speaker IDs should be consistent across chunks (context propagation ensures this):
+
+```typescript
+for (const [speakerId, speaker] of Object.entries(artifact.speakers)) {
+  if (!mergedSpeakers[speakerId]) {
+    mergedSpeakers[speakerId] = speaker;
+  }
+}
+```
+
+### Terms & Occurrences
+
+- **Terms**: Deduplicate by `termId` (Gemini generates deterministic IDs)
+- **Term Occurrences**: Only include if the referenced segment was kept
+
+```typescript
+for (const occurrence of artifact.termOccurrences) {
+  if (seenSegmentIds.has(occurrence.segmentId)) {
+    mergedTermOccurrences.push(occurrence);
+  }
+}
+```
+
+### Topics
+
+Deduplicate by `topicId`, sort by `startIndex`:
+
+```typescript
+for (const topic of artifact.topics) {
+  if (!seenTopicIds.has(topic.topicId)) {
+    mergedTopics.push(topic);
+  }
+}
+mergedTopics.sort((a, b) => a.startIndex - b.startIndex);
+```
+
+### People
+
+Deduplicate by `personId`:
+
+```typescript
+for (const person of artifact.people) {
+  if (!seenPersonIds.has(person.personId)) {
+    mergedPeople.push(person);
+  }
+}
+```
+
+## Idempotency
+
+The merge operation is idempotent - safe to run multiple times:
+
+```typescript
+if (chunkingMeta.mergedAt) {
+  console.log('Already merged, skipping');
+  return;
+}
+```
+
+**Why idempotency matters**:
+- Cloud Tasks may retry failed merges
+- Manual reruns during debugging
+- Prevents data corruption from duplicate merges
+
+## Error Handling
+
+### Validation
+
+Before merging, we validate:
+
+1. **Conversation exists**: `throw new Error('Conversation not found')`
+2. **Chunking metadata present**: `throw new Error('No chunking metadata')`
+3. **All chunks present**: `throw new Error('Missing chunks: expected X, found Y')`
+
+### Failure Recovery
+
+If merge fails:
+
+1. Status updated to `'failed'` with error message
+2. Cloud Tasks retries with exponential backoff
+3. Manual retry possible (idempotency ensures safety)
+
+### Monitoring
+
+Key log events:
+
+```
+[ChunkMerge] Starting merge process
+[ChunkMerge] Loaded chunk artifacts: { chunkCount, totalSegments }
+[ChunkMerge] Segment deduplication complete: { duplicatesRemoved }
+[ChunkMerge] ✅ Merge complete: { finalCounts, durationMs }
+```
+
+## Security
+
+### Firestore Rules
+
+```javascript
+match /conversations/{conversationId}/chunks/{chunkIndex} {
+  // Users can read chunks for their own conversations
+  allow read: if isAuthenticated()
+    && get(.../conversations/$(conversationId)).data.userId == request.auth.uid;
+
+  // Only Cloud Functions can write chunks
+  allow write: if false;
+}
+```
+
+Chunk artifacts are read-only from the client - only Cloud Functions can create/modify them.
+
+## Performance Considerations
+
+### Memory Usage
+
+- Loads all chunk artifacts into memory
+- For very large files (multiple GB), this could be substantial
+- Current limit: 512MiB function memory (sufficient for ~1000 chunks)
+
+### Processing Time
+
+- O(n) where n = total segments across all chunks
+- Typical: <1 second for 100 segments
+- Timeout: 10 minutes (generous buffer)
+
+### Cost Optimization
+
+Merge is cheaper than chunk processing:
+- No LLM calls (Gemini already ran on chunks)
+- Pure data transformation
+- Fast execution (<1s typically)
+
+## Future Improvements
+
+### 1. Parallel Segment Processing
+
+Current implementation processes segments sequentially. Could parallelize with worker threads for very large merges.
+
+### 2. Streaming Merge
+
+For extremely large files, stream chunk artifacts instead of loading all into memory.
+
+### 3. Progressive Merge
+
+Start merging early chunks while later chunks still processing (reduces time to first view).
+
+### 4. Speaker Re-identification
+
+Currently, speaker IDs are preserved from chunks. Future: use voice embeddings to re-identify speakers across chunks (handles speaker ID mismatches).
+
+## Related Documentation
+
+- [Chunking Overview](./chunking.md) - How audio is split into chunks
+- [Context Propagation](./chunk-context.md) - How data flows between chunks
+- [Chunk Bounds](./chunk-bounds.md) - Timestamp math for overlap regions
+- [How-To: Deploy Functions](../how-to/deploy.md) - Deploying the merge function
+
+## Key Takeaways
+
+1. **Chunk artifacts** store intermediate results in `conversations/{id}/chunks/*`
+2. **Merge trigger** fires atomically when all chunks complete
+3. **Deduplication** uses "preferred chunk" logic (later chunk wins in overlaps)
+4. **Idempotency** ensures safe retries and manual reruns
+5. **Status flow**: `chunking → merging → complete`
+
+The merge layer is the final step that transforms chunked processing back into a seamless user experience.

--- a/firestore.rules
+++ b/firestore.rules
@@ -29,7 +29,7 @@ service cloud.firestore {
       return data.keys().hasAll(['conversationId', 'userId', 'title', 'createdAt', 'status'])
         && data.userId is string
         && data.title is string
-        && data.status in ['processing', 'needs_review', 'complete', 'failed'];
+        && data.status in ['processing', 'chunking', 'merging', 'needs_review', 'complete', 'failed', 'aborted'];
     }
 
     // Users collection - profile data
@@ -75,6 +75,16 @@ service cloud.firestore {
         // Note: update not allowed - messages are immutable once created
         allow delete: if isAuthenticated()
           && get(/databases/$(database)/documents/conversations/$(conversationId)).data.userId == request.auth.uid;
+      }
+
+      // Chunks subcollection - intermediate artifacts during chunk processing
+      match /chunks/{chunkIndex} {
+        // Users can read chunks for their own conversations
+        allow read: if isAuthenticated()
+          && get(/databases/$(database)/documents/conversations/$(conversationId)).data.userId == request.auth.uid;
+
+        // Only Cloud Functions can write chunks
+        allow write: if false;
       }
     }
 

--- a/functions/.agent_process/scripts/after_edit/validate-04_large_file_upload_02_01_splitting.sh
+++ b/functions/.agent_process/scripts/after_edit/validate-04_large_file_upload_02_01_splitting.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCOPE=${1:-04_large_file_upload_02_01_splitting}
+ITERATION=${2:-iteration_01}
+
+printf "[%s-validation] scope=%s iteration=%s\n" "$SCOPE" "$SCOPE" "$ITERATION"
+
+printf "[%s-validation] TypeScript compilation check...\n" "$SCOPE"
+cd functions && npx tsc --noEmit && cd ..
+printf "[%s-validation] TypeScript: PASS\n" "$SCOPE"
+
+printf "[%s-validation] Running functions build...\n" "$SCOPE"
+cd functions && npm run build && cd ..
+printf "[%s-validation] Build: PASS\n" "$SCOPE"
+
+printf "[%s-validation] Complete.\n" "$SCOPE"

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -17,8 +17,11 @@
         "undici": "^6.21.0"
       },
       "devDependencies": {
+        "@types/jest": "^30.0.0",
         "@types/node": "^20.17.12",
         "firebase-functions-test": "^3.4.0",
+        "jest": "^30.2.0",
+        "ts-jest": "^29.4.6",
         "typescript": "^5.7.2"
       },
       "engines": {
@@ -1546,6 +1549,7 @@
       "integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.2.0",
@@ -1573,6 +1577,7 @@
       "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -1938,6 +1943,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
       }
     },
     "node_modules/@types/jsonwebtoken": {
@@ -2488,6 +2504,7 @@
       "integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "30.2.0",
         "@types/babel__core": "^7.20.5",
@@ -2705,6 +2722,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -4049,6 +4079,28 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5016,6 +5068,7 @@
       "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -5396,6 +5449,13 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -5474,6 +5534,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -5601,6 +5668,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -5647,6 +5724,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -6953,6 +7037,85 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.3",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -7001,12 +7164,27 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/undici": {
@@ -7223,6 +7401,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -26,8 +26,11 @@
     "undici": "^6.21.0"
   },
   "devDependencies": {
+    "@types/jest": "^30.0.0",
     "@types/node": "^20.17.12",
     "firebase-functions-test": "^3.4.0",
+    "jest": "^30.2.0",
+    "ts-jest": "^29.4.6",
     "typescript": "^5.7.2"
   },
   "private": true

--- a/functions/src/__tests__/chunkMerge.test.ts
+++ b/functions/src/__tests__/chunkMerge.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Tests for chunk merging logic
+ *
+ * Validates:
+ * - Segment deduplication in overlap regions
+ * - Speaker mapping reconciliation
+ * - Term/topic/person merging with deterministic IDs
+ * - Idempotency (already merged = no-op)
+ */
+
+import { ChunkArtifact } from '../types';
+
+// Mock Firestore - track the update payload
+let lastUpdatePayload: Record<string, unknown> | null = null;
+const mockGet = jest.fn();
+const mockUpdate = jest.fn((payload: Record<string, unknown>) => {
+  lastUpdatePayload = payload;
+  return Promise.resolve();
+});
+const mockQueryGet = jest.fn();
+
+// Each call to doc() returns an object with update/get/collection methods
+// We capture the update calls via lastUpdatePayload
+const mockDocFn = jest.fn(() => ({
+  get: mockGet,
+  update: mockUpdate,
+  collection: jest.fn(() => ({
+    orderBy: jest.fn(() => ({
+      get: mockQueryGet
+    }))
+  }))
+}));
+
+const mockFirestore = {
+  collection: jest.fn(() => ({
+    doc: mockDocFn
+  }))
+};
+
+// Mock the db instance before importing chunkMerge
+jest.mock('../index', () => ({
+  db: mockFirestore
+}));
+
+// Import after mocking
+import { mergeChunks } from '../chunkMerge';
+
+describe('chunkMerge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    lastUpdatePayload = null;
+  });
+
+  describe('mergeChunks', () => {
+    it('should handle idempotency - skip if already merged', async () => {
+      const conversationId = 'test-conv-123';
+
+      // Mock conversation with mergedAt already set
+      mockGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          chunkingMetadata: {
+            totalChunks: 2,
+            mergedAt: '2024-01-01T00:00:00.000Z'
+          }
+        })
+      });
+
+      await mergeChunks(conversationId);
+
+      // Should check idempotency and return early
+      expect(mockGet).toHaveBeenCalledTimes(1);
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should deduplicate segments in overlap regions with chunk-local timestamps', async () => {
+      const conversationId = 'test-conv-123';
+
+      // Mock conversation without mergedAt
+      mockGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          userId: 'user-123',
+          chunkingMetadata: {
+            totalChunks: 2,
+            originalStoragePath: 'audio/original.mp3',
+            originalDurationMs: 60000
+          }
+        })
+      });
+
+      // Mock chunk artifacts with CHUNK-LOCAL timestamps (start at 0 for each chunk)
+      // This is what Gemini actually produces - timestamps relative to chunk audio start
+      //
+      // Original audio layout:
+      //   Chunk 0: covers 0-15000ms of original, with 3s overlap into chunk 1's region
+      //   Chunk 1: covers 15000-30000ms of original, with 3s overlap back into chunk 0's region
+      //
+      // Chunk 0 audio file contains: 0-18000ms of original (logical + overlap after)
+      // Chunk 1 audio file contains: 12000-30000ms of original (overlap before + logical)
+      //
+      // Gemini timestamps are relative to chunk audio file start (always 0)
+      const chunk0: ChunkArtifact = {
+        conversationId,
+        userId: 'user-123',
+        chunkIndex: 0,
+        totalChunks: 2,
+        segments: [
+          // All timestamps are chunk-local (relative to chunk audio start)
+          { segmentId: 'seg-0', index: 0, speakerId: 'spk-0', startMs: 0, endMs: 5000, text: 'First segment' },
+          { segmentId: 'seg-1', index: 1, speakerId: 'spk-0', startMs: 5000, endMs: 10000, text: 'Second segment' },
+          { segmentId: 'seg-2', index: 2, speakerId: 'spk-1', startMs: 10000, endMs: 15000, text: 'Third segment' },
+          // Overlap region - chunk-local 15000-18000ms = original 15000-18000ms
+          // Since chunk0 has no overlapBefore, chunk-local == original for this chunk
+          { segmentId: 'seg-3-dup', index: 3, speakerId: 'spk-1', startMs: 15000, endMs: 18000, text: 'Overlap segment from chunk 0' }
+        ],
+        speakers: { 'spk-0': { speakerId: 'spk-0', displayName: 'Speaker 0', colorIndex: 0 } },
+        terms: {},
+        termOccurrences: [],
+        topics: [],
+        people: [],
+        chunkBounds: {
+          startMs: 0,
+          endMs: 15000,
+          overlapBeforeMs: 0,
+          overlapAfterMs: 3000
+        },
+        emittedContext: {} as ChunkArtifact['emittedContext'],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        storagePath: 'chunks/test/0.mp3'
+      };
+
+      const chunk1: ChunkArtifact = {
+        conversationId,
+        userId: 'user-123',
+        chunkIndex: 1,
+        totalChunks: 2,
+        segments: [
+          // CRITICAL: These timestamps start at 0 (chunk-local), NOT at original timeline position!
+          // Chunk 1 audio starts at original 12000ms (15000 - 3000 overlap)
+          // So chunk-local 0ms = original 12000ms
+          //
+          // Overlap region - chunk-local 0-6000ms maps to original 12000-18000ms
+          // This chunk owns the overlap (higher index) so seg-3 should survive
+          { segmentId: 'seg-3', index: 0, speakerId: 'spk-1', startMs: 0, endMs: 6000, text: 'Overlap segment from chunk 1' },
+          // chunk-local 6000ms = original 18000ms, chunk-local 13000ms = original 25000ms
+          { segmentId: 'seg-4', index: 1, speakerId: 'spk-1', startMs: 6000, endMs: 13000, text: 'Fourth segment' },
+          // chunk-local 13000ms = original 25000ms, chunk-local 18000ms = original 30000ms
+          { segmentId: 'seg-5', index: 2, speakerId: 'spk-0', startMs: 13000, endMs: 18000, text: 'Fifth segment' }
+        ],
+        speakers: { 'spk-1': { speakerId: 'spk-1', displayName: 'Speaker 1', colorIndex: 1 } },
+        terms: {},
+        termOccurrences: [],
+        topics: [],
+        people: [],
+        chunkBounds: {
+          startMs: 15000,
+          endMs: 30000,
+          overlapBeforeMs: 3000,
+          overlapAfterMs: 0
+        },
+        emittedContext: {} as ChunkArtifact['emittedContext'],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        storagePath: 'chunks/test/1.mp3'
+      };
+
+      mockQueryGet.mockResolvedValueOnce({
+        empty: false,
+        docs: [
+          { data: () => chunk0 },
+          { data: () => chunk1 }
+        ]
+      });
+
+      await mergeChunks(conversationId);
+
+      // Verify update was called with merged data
+      expect(mockUpdate).toHaveBeenCalled();
+
+      // lastUpdatePayload should contain the final update with segments
+      expect(lastUpdatePayload).not.toBeNull();
+      const segments = lastUpdatePayload!.segments as Array<{ segmentId: string; index: number; startMs: number; endMs: number }>;
+
+      // Should have 6 segments:
+      // - seg-0, seg-1, seg-2 from chunk 0 (non-overlapping region)
+      // - seg-3 from chunk 1 (chunk 1 wins overlap, seg-3-dup dropped)
+      // - seg-4, seg-5 from chunk 1
+      expect(segments).toHaveLength(6);
+
+      // Verify seg-3 is from chunk 1 (has the correct text)
+      const seg3 = segments.find(s => s.segmentId === 'seg-3');
+      expect(seg3).toBeDefined();
+
+      // Verify seg-3-dup was dropped
+      const seg3dup = segments.find(s => s.segmentId === 'seg-3-dup');
+      expect(seg3dup).toBeUndefined();
+
+      // Verify timestamps were normalized to original timeline
+      // seg-3 had chunk-local startMs=0, should now be 12000 (chunk1.startMs - chunk1.overlapBeforeMs)
+      expect(seg3!.startMs).toBe(12000);
+      expect(seg3!.endMs).toBe(18000);
+
+      // seg-5 had chunk-local startMs=13000, should now be 25000 (12000 + 13000)
+      const seg5 = segments.find(s => s.segmentId === 'seg-5');
+      expect(seg5!.startMs).toBe(25000);
+      expect(seg5!.endMs).toBe(30000);
+
+      // Segments should be reindexed sequentially
+      segments.forEach((seg, idx) => {
+        expect(seg.index).toBe(idx);
+      });
+    });
+
+    it('should merge speakers from all chunks', async () => {
+      const conversationId = 'test-conv-123';
+
+      mockGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          userId: 'user-123',
+          chunkingMetadata: {
+            totalChunks: 2,
+            originalStoragePath: 'audio/original.mp3',
+            originalDurationMs: 60000
+          }
+        })
+      });
+
+      const chunk0: ChunkArtifact = {
+        conversationId,
+        userId: 'user-123',
+        chunkIndex: 0,
+        totalChunks: 2,
+        segments: [
+          { segmentId: 'seg-0', index: 0, speakerId: 'spk-0', startMs: 0, endMs: 10000, text: 'Test' }
+        ],
+        speakers: {
+          'spk-0': { speakerId: 'spk-0', displayName: 'Alice', colorIndex: 0 }
+        },
+        terms: {},
+        termOccurrences: [],
+        topics: [],
+        people: [],
+        chunkBounds: { startMs: 0, endMs: 10000, overlapBeforeMs: 0, overlapAfterMs: 0 },
+        emittedContext: {} as ChunkArtifact['emittedContext'],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        storagePath: 'chunks/test/0.mp3'
+      };
+
+      const chunk1: ChunkArtifact = {
+        conversationId,
+        userId: 'user-123',
+        chunkIndex: 1,
+        totalChunks: 2,
+        segments: [
+          // Chunk-local timestamps: 0ms in chunk 1 = 10000ms in original
+          { segmentId: 'seg-1', index: 0, speakerId: 'spk-1', startMs: 0, endMs: 10000, text: 'Test' }
+        ],
+        speakers: {
+          'spk-1': { speakerId: 'spk-1', displayName: 'Bob', colorIndex: 1 }
+        },
+        terms: {},
+        termOccurrences: [],
+        topics: [],
+        people: [],
+        chunkBounds: { startMs: 10000, endMs: 20000, overlapBeforeMs: 0, overlapAfterMs: 0 },
+        emittedContext: {} as ChunkArtifact['emittedContext'],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        storagePath: 'chunks/test/1.mp3'
+      };
+
+      mockQueryGet.mockResolvedValueOnce({
+        empty: false,
+        docs: [
+          { data: () => chunk0 },
+          { data: () => chunk1 }
+        ]
+      });
+
+      await mergeChunks(conversationId);
+
+      // lastUpdatePayload should contain the final update with speakers
+      expect(lastUpdatePayload).not.toBeNull();
+      const speakers = lastUpdatePayload!.speakers as Record<string, { displayName: string }>;
+
+      // Should have both speakers merged from all chunks
+      expect(Object.keys(speakers)).toHaveLength(2);
+      expect(speakers['spk-0'].displayName).toBe('Alice');
+      expect(speakers['spk-1'].displayName).toBe('Bob');
+    });
+
+    it('should merge terms and filter term occurrences for kept segments', async () => {
+      const conversationId = 'test-conv-123';
+
+      mockGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          userId: 'user-123',
+          chunkingMetadata: {
+            totalChunks: 2,
+            originalStoragePath: 'audio/original.mp3',
+            originalDurationMs: 60000
+          }
+        })
+      });
+
+      const chunk0: ChunkArtifact = {
+        conversationId,
+        userId: 'user-123',
+        chunkIndex: 0,
+        totalChunks: 2,
+        segments: [
+          { segmentId: 'seg-0', index: 0, speakerId: 'spk-0', startMs: 0, endMs: 10000, text: 'Kubernetes cluster' }
+        ],
+        speakers: {},
+        terms: {
+          'term-1': { termId: 'term-1', key: 'kubernetes', display: 'Kubernetes', definition: 'Container orchestration', aliases: ['k8s'] }
+        },
+        termOccurrences: [
+          { occurrenceId: 'occ-1', termId: 'term-1', segmentId: 'seg-0', startChar: 0, endChar: 10 }
+        ],
+        topics: [],
+        people: [],
+        chunkBounds: { startMs: 0, endMs: 10000, overlapBeforeMs: 0, overlapAfterMs: 0 },
+        emittedContext: {} as ChunkArtifact['emittedContext'],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        storagePath: 'chunks/test/0.mp3'
+      };
+
+      const chunk1: ChunkArtifact = {
+        conversationId,
+        userId: 'user-123',
+        chunkIndex: 1,
+        totalChunks: 2,
+        segments: [
+          // Chunk-local timestamps: 0ms in chunk 1 = 10000ms in original (chunkBounds.startMs - overlapBeforeMs)
+          { segmentId: 'seg-1', index: 0, speakerId: 'spk-0', startMs: 0, endMs: 10000, text: 'Docker containers' }
+        ],
+        speakers: {},
+        terms: {
+          'term-2': { termId: 'term-2', key: 'docker', display: 'Docker', definition: 'Container platform', aliases: [] }
+        },
+        termOccurrences: [
+          { occurrenceId: 'occ-2', termId: 'term-2', segmentId: 'seg-1', startChar: 0, endChar: 6 }
+        ],
+        topics: [],
+        people: [],
+        chunkBounds: { startMs: 10000, endMs: 20000, overlapBeforeMs: 0, overlapAfterMs: 0 },
+        emittedContext: {} as ChunkArtifact['emittedContext'],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        storagePath: 'chunks/test/1.mp3'
+      };
+
+      mockQueryGet.mockResolvedValueOnce({
+        empty: false,
+        docs: [
+          { data: () => chunk0 },
+          { data: () => chunk1 }
+        ]
+      });
+
+      await mergeChunks(conversationId);
+
+      // lastUpdatePayload should contain the final update with terms
+      expect(lastUpdatePayload).not.toBeNull();
+      const terms = lastUpdatePayload!.terms as Record<string, { key: string }>;
+      const termOccurrences = lastUpdatePayload!.termOccurrences as Array<unknown>;
+
+      // Should have both terms
+      expect(Object.keys(terms)).toHaveLength(2);
+      expect(terms['term-1'].key).toBe('kubernetes');
+      expect(terms['term-2'].key).toBe('docker');
+
+      // Should have both occurrences (both segments kept)
+      expect(termOccurrences).toHaveLength(2);
+    });
+
+    it('should throw error if conversation not found', async () => {
+      mockGet.mockResolvedValueOnce({
+        exists: false
+      });
+
+      await expect(mergeChunks('nonexistent')).rejects.toThrow('Conversation nonexistent not found');
+    });
+
+    it('should throw error if no chunking metadata', async () => {
+      mockGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          userId: 'user-123'
+          // No chunkingMetadata
+        })
+      });
+
+      await expect(mergeChunks('test-conv')).rejects.toThrow('No chunking metadata');
+    });
+
+    it('should throw error if missing chunks', async () => {
+      mockGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          userId: 'user-123',
+          chunkingMetadata: {
+            totalChunks: 3,
+            originalStoragePath: 'audio/original.mp3'
+          }
+        })
+      });
+
+      // Only return 2 chunks instead of 3
+      mockQueryGet.mockResolvedValueOnce({
+        empty: false,
+        docs: [
+          { data: () => ({ chunkIndex: 0 } as ChunkArtifact) },
+          { data: () => ({ chunkIndex: 1 } as ChunkArtifact) }
+        ]
+      });
+
+      await expect(mergeChunks('test-conv')).rejects.toThrow('Missing chunks: expected 3, found 2');
+    });
+  });
+});

--- a/functions/src/chunkMerge.ts
+++ b/functions/src/chunkMerge.ts
@@ -1,0 +1,351 @@
+/**
+ * Chunk Merge Module
+ *
+ * Stitches together chunk artifacts from conversations/{id}/chunks/* into
+ * a single coherent conversation document. Handles:
+ * - Segment deduplication in overlap regions
+ * - Speaker ID canonicalization across chunks
+ * - Term/topic/person merging with deterministic IDs
+ * - Idempotency (safe to run multiple times)
+ *
+ * Triggered by Cloud Tasks after all chunks complete processing.
+ */
+
+import { onRequest } from 'firebase-functions/v2/https';
+import { FieldValue } from 'firebase-admin/firestore';
+import { db } from './index';
+import {
+  ChunkArtifact,
+  Segment,
+  Speaker,
+  Term,
+  TermOccurrence,
+  Topic,
+  Person
+} from './types';
+import { getPreferredChunkForTimestamp, chunkToOriginalTimestamp } from './chunkBounds';
+import { ChunkMetadata } from './chunking';
+
+/**
+ * Merge all chunk artifacts for a conversation into the final document.
+ *
+ * Steps:
+ * 1. Check idempotency (skip if already merged)
+ * 2. Load all chunk artifacts
+ * 3. Deduplicate segments using overlap boundaries
+ * 4. Merge speakers, terms, topics, people
+ * 5. Write final conversation document
+ * 6. Update status to 'complete'
+ *
+ * @throws Error if chunks are missing or invalid
+ */
+export async function mergeChunks(conversationId: string): Promise<void> {
+  console.log('[ChunkMerge] Starting merge process:', { conversationId });
+
+  // Step 1: Check idempotency - if already merged, skip
+  const conversationRef = db.collection('conversations').doc(conversationId);
+  const conversationSnap = await conversationRef.get();
+
+  if (!conversationSnap.exists) {
+    throw new Error(`Conversation ${conversationId} not found`);
+  }
+
+  const conversationData = conversationSnap.data()!;
+  const chunkingMeta = conversationData.chunkingMetadata;
+
+  if (!chunkingMeta) {
+    throw new Error(`No chunking metadata for conversation ${conversationId}`);
+  }
+
+  // Idempotency check - if mergedAt is set, we're done
+  if (chunkingMeta.mergedAt) {
+    console.log('[ChunkMerge] Already merged, skipping:', {
+      conversationId,
+      mergedAt: chunkingMeta.mergedAt
+    });
+    return;
+  }
+
+  // Mark merge as started
+  await conversationRef.update({
+    'chunkingMetadata.mergeStartedAt': new Date().toISOString(),
+    status: 'merging',
+    updatedAt: FieldValue.serverTimestamp()
+  });
+
+  // Step 2: Load all chunk artifacts
+  console.log('[ChunkMerge] Loading chunk artifacts...');
+  const chunksSnap = await conversationRef
+    .collection('chunks')
+    .orderBy('chunkIndex')
+    .get();
+
+  if (chunksSnap.empty) {
+    throw new Error(`No chunk artifacts found for conversation ${conversationId}`);
+  }
+
+  const chunkArtifacts: ChunkArtifact[] = chunksSnap.docs.map(doc => doc.data() as ChunkArtifact);
+
+  // Validate we have all chunks
+  const expectedChunks = chunkingMeta.totalChunks;
+  if (chunkArtifacts.length !== expectedChunks) {
+    throw new Error(
+      `Missing chunks: expected ${expectedChunks}, found ${chunkArtifacts.length}`
+    );
+  }
+
+  console.log('[ChunkMerge] Loaded chunk artifacts:', {
+    conversationId,
+    chunkCount: chunkArtifacts.length,
+    totalSegments: chunkArtifacts.reduce((sum, c) => sum + c.segments.length, 0)
+  });
+
+  // Build chunk metadata array for deduplication helpers
+  const chunkMetadataArray: ChunkMetadata[] = chunkArtifacts.map(artifact => ({
+    chunkIndex: artifact.chunkIndex,
+    totalChunks: artifact.totalChunks,
+    startMs: artifact.chunkBounds.startMs,
+    endMs: artifact.chunkBounds.endMs,
+    overlapBeforeMs: artifact.chunkBounds.overlapBeforeMs,
+    overlapAfterMs: artifact.chunkBounds.overlapAfterMs,
+    chunkStoragePath: artifact.storagePath,
+    originalStoragePath: chunkingMeta.originalStoragePath,
+    durationMs: artifact.chunkBounds.endMs - artifact.chunkBounds.startMs +
+                artifact.chunkBounds.overlapBeforeMs + artifact.chunkBounds.overlapAfterMs
+  }));
+
+  // Step 3: Deduplicate segments using preferred chunk logic
+  //
+  // IMPORTANT: Segment timestamps from Gemini are chunk-local (start at 0 for each chunk).
+  // We must convert them to the original audio timeline before checking which chunk "owns"
+  // them for deduplication. Without this conversion, later chunks would have low timestamps
+  // that make them appear to belong to earlier chunks, causing them to be dropped.
+  console.log('[ChunkMerge] Deduplicating segments...');
+  const mergedSegments: Segment[] = [];
+  const seenSegmentIds = new Set<string>();
+
+  for (const artifact of chunkArtifacts) {
+    // Get the chunk metadata for timestamp conversion
+    const chunkMeta = chunkMetadataArray[artifact.chunkIndex];
+
+    for (const segment of artifact.segments) {
+      // Convert chunk-local timestamp to original audio timeline
+      const originalStartMs = chunkToOriginalTimestamp(segment.startMs, chunkMeta);
+      const originalEndMs = chunkToOriginalTimestamp(segment.endMs, chunkMeta);
+
+      // Check if this segment's original timestamp belongs to this chunk
+      const preferredChunk = getPreferredChunkForTimestamp(originalStartMs, chunkMetadataArray);
+
+      if (preferredChunk === artifact.chunkIndex) {
+        // This chunk "owns" this segment - include it with normalized timestamps
+        if (!seenSegmentIds.has(segment.segmentId)) {
+          mergedSegments.push({
+            ...segment,
+            startMs: originalStartMs,
+            endMs: originalEndMs
+          });
+          seenSegmentIds.add(segment.segmentId);
+        }
+      }
+      // Otherwise, skip (will be included from the preferred chunk)
+    }
+  }
+
+  // Sort segments by index to ensure correct order
+  mergedSegments.sort((a, b) => a.index - b.index);
+
+  // Reindex segments to be sequential (since we may have dropped duplicates)
+  mergedSegments.forEach((seg, idx) => {
+    seg.index = idx;
+  });
+
+  console.log('[ChunkMerge] Segment deduplication complete:', {
+    totalBeforeDedup: chunkArtifacts.reduce((sum, c) => sum + c.segments.length, 0),
+    totalAfterDedup: mergedSegments.length,
+    duplicatesRemoved: chunkArtifacts.reduce((sum, c) => sum + c.segments.length, 0) - mergedSegments.length
+  });
+
+  // Step 4: Merge speakers (simple union - speaker IDs should be consistent across chunks)
+  console.log('[ChunkMerge] Merging speakers...');
+  const mergedSpeakers: Record<string, Speaker> = {};
+
+  for (const artifact of chunkArtifacts) {
+    for (const [speakerId, speaker] of Object.entries(artifact.speakers)) {
+      if (!mergedSpeakers[speakerId]) {
+        mergedSpeakers[speakerId] = speaker;
+      }
+      // If speaker already exists, prefer the one with a display name
+      else if (speaker.displayName && !mergedSpeakers[speakerId].displayName) {
+        mergedSpeakers[speakerId] = speaker;
+      }
+    }
+  }
+
+  // Step 5: Merge terms (deduplicate by termId)
+  console.log('[ChunkMerge] Merging terms...');
+  const mergedTerms: Record<string, Term> = {};
+  const mergedTermOccurrences: TermOccurrence[] = [];
+  const seenOccurrenceIds = new Set<string>();
+
+  for (const artifact of chunkArtifacts) {
+    // Merge terms
+    for (const [termId, term] of Object.entries(artifact.terms)) {
+      if (!mergedTerms[termId]) {
+        mergedTerms[termId] = term;
+      }
+    }
+
+    // Merge term occurrences (only for segments we kept)
+    for (const occurrence of artifact.termOccurrences) {
+      // Only include if the segment was kept after deduplication
+      if (seenSegmentIds.has(occurrence.segmentId) && !seenOccurrenceIds.has(occurrence.occurrenceId)) {
+        mergedTermOccurrences.push(occurrence);
+        seenOccurrenceIds.add(occurrence.occurrenceId);
+      }
+    }
+  }
+
+  // Step 6: Merge topics (deduplicate by topicId, adjust indices)
+  console.log('[ChunkMerge] Merging topics...');
+  const mergedTopics: Topic[] = [];
+  const seenTopicIds = new Set<string>();
+
+  for (const artifact of chunkArtifacts) {
+    for (const topic of artifact.topics) {
+      if (!seenTopicIds.has(topic.topicId)) {
+        mergedTopics.push(topic);
+        seenTopicIds.add(topic.topicId);
+      }
+    }
+  }
+
+  // Sort topics by start index
+  mergedTopics.sort((a, b) => a.startIndex - b.startIndex);
+
+  // Step 7: Merge people (deduplicate by personId)
+  console.log('[ChunkMerge] Merging people...');
+  const mergedPeople: Person[] = [];
+  const seenPersonIds = new Set<string>();
+
+  for (const artifact of chunkArtifacts) {
+    for (const person of artifact.people) {
+      if (!seenPersonIds.has(person.personId)) {
+        mergedPeople.push(person);
+        seenPersonIds.add(person.personId);
+      }
+    }
+  }
+
+  // Step 8: Calculate total duration from last segment
+  const lastSegment = mergedSegments[mergedSegments.length - 1];
+  const durationMs = lastSegment ? lastSegment.endMs : chunkingMeta.originalDurationMs;
+
+  // Step 9: Write final merged data to conversation document
+  console.log('[ChunkMerge] Writing final merged data...');
+  await conversationRef.update({
+    segments: mergedSegments,
+    speakers: mergedSpeakers,
+    terms: mergedTerms,
+    termOccurrences: mergedTermOccurrences,
+    topics: mergedTopics,
+    people: mergedPeople,
+    durationMs,
+    status: 'complete',
+    'chunkingMetadata.mergedAt': new Date().toISOString(),
+    alignmentStatus: 'aligned', // Chunks use WhisperX alignment
+    updatedAt: FieldValue.serverTimestamp()
+  });
+
+  console.log('[ChunkMerge] ✅ Merge complete:', {
+    conversationId,
+    finalCounts: {
+      segments: mergedSegments.length,
+      speakers: Object.keys(mergedSpeakers).length,
+      terms: Object.keys(mergedTerms).length,
+      termOccurrences: mergedTermOccurrences.length,
+      topics: mergedTopics.length,
+      people: mergedPeople.length
+    },
+    durationMs
+  });
+}
+
+/**
+ * Cloud Tasks HTTP handler for processing merge jobs.
+ *
+ * Security: Only accepts requests from Cloud Tasks (x-cloudtasks-taskname header).
+ * Returns 200 on success (Cloud Tasks won't retry).
+ * Returns 500 on failure (Cloud Tasks will retry with backoff).
+ */
+export const processMerge = onRequest(
+  {
+    memory: '512MiB',
+    timeoutSeconds: 600, // 10 minutes (merge can be slow for large files)
+    region: 'us-central1',
+    invoker: 'private' // Only Cloud Tasks can call this
+  },
+  async (req, res) => {
+    // Validate Cloud Tasks header (security check)
+    const taskName = req.headers['x-cloudtasks-taskname'];
+    if (!taskName && process.env.K_SERVICE) { // K_SERVICE is set in Cloud Run
+      console.error('[ProcessMerge] Forbidden: Direct invocation not allowed');
+      res.status(403).send('Forbidden: Direct invocation not allowed');
+      return;
+    }
+
+    console.log('[ProcessMerge] Task started:', {
+      taskName,
+      timestamp: new Date().toISOString()
+    });
+
+    // Parse request payload
+    let conversationId: string;
+    try {
+      const payload = req.body as { conversationId: string };
+
+      if (!payload.conversationId) {
+        throw new Error('Missing required field: conversationId');
+      }
+
+      conversationId = payload.conversationId;
+
+      console.log('[ProcessMerge] Processing merge:', { conversationId });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Invalid request payload';
+      console.error('[ProcessMerge] Invalid payload:', errorMessage);
+      res.status(400).send(`Bad Request: ${errorMessage}`);
+      return;
+    }
+
+    try {
+      // Execute merge
+      await mergeChunks(conversationId);
+
+      console.log('[ProcessMerge] ✅ Task completed successfully:', { conversationId });
+      res.status(200).send('OK');
+
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+      console.error('[ProcessMerge] ❌ Task failed:', {
+        conversationId,
+        error: errorMessage,
+        stack: error instanceof Error ? error.stack : undefined
+      });
+
+      // Update Firestore to mark merge failed
+      try {
+        await db.collection('conversations').doc(conversationId).update({
+          status: 'failed',
+          processingError: `Merge failed: ${errorMessage}`,
+          updatedAt: FieldValue.serverTimestamp()
+        });
+      } catch (updateError) {
+        console.error('[ProcessMerge] Failed to update Firestore status:', updateError);
+      }
+
+      // Return 500 so Cloud Tasks will retry
+      res.status(500).send(`Internal Server Error: ${errorMessage}`);
+    }
+  }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -54,6 +54,7 @@ export const bucket = getStorage().bucket();
 // Export cloud functions
 export { transcribeAudio } from './transcribe';
 export { processTranscription } from './processTranscription';
+export { processMerge } from './chunkMerge';
 export { getSignedAudioUrl } from './getAudioUrl';
 export { chatWithConversation } from './chat';
 


### PR DESCRIPTION
## Summary

Implements automatic reassembly of chunked transcripts into a unified conversation document:

- **Segment Deduplication**: Overlap regions handled with "later chunk wins" strategy
- **Timestamp Normalization**: Chunk-local timestamps converted to original audio timeline for accurate playback sync
- **Metadata Merging**: Speakers, terms, topics, and people merged deterministically across all chunks
- **Cloud Task Integration**: Merge job enqueued automatically when all chunks complete, with `mergeTaskEnqueued` guard preventing duplicates
- **Status Transitions**: Conversation flows through `chunking` → `merging` → `complete`

## Changelog Entry

```markdown
- **Chunk Merge System** - Automatic reassembly of chunked transcripts into a unified document
  - Segments deduplicated in overlap regions using "later chunk wins" strategy
  - Timestamps normalized from chunk-local to original audio timeline for accurate playback sync
  - Speakers, terms, topics, and people merged deterministically across all chunks
  - Cloud Task-based merge job with `mergeTaskEnqueued` guard to prevent duplicate merges
  - Conversation status transitions: `chunking` → `merging` → `complete`
```

## Files Changed

- `functions/src/chunkMerge.ts` - Core merge logic and Cloud Task handler
- `functions/src/__tests__/chunkMerge.test.ts` - 7 unit tests covering idempotency, dedup, speaker/term merging, error handling
- `functions/src/types.ts` - ChunkArtifact interface, extended ChunkingMetadata
- `functions/src/transcribe.ts` - Chunk artifact writing to subcollection
- `functions/src/chunkContext.ts` - markChunkComplete returns allComplete/shouldEnqueueMerge
- `functions/src/processTranscription.ts` - enqueueMergeTask logic
- `functions/src/index.ts` - processMerge export
- `firestore.rules` - chunks subcollection rules
- `docs/explanation/chunk-merge.md` - Developer documentation

## Test Plan

- [x] TypeScript compilation passes
- [x] Jest unit tests (7/7 passing)
- [x] Tests use realistic chunk-local timestamps (starting at 0)
- [x] Deduplication correctly keeps later chunk segments in overlaps
- [x] Timestamps normalized to original audio timeline

---
Scope: `04_large_file_upload_02_03_merge`
Iteration: `iteration_01_a`