### PR TITLE
fix(chunking): prevent chunk cascade failure when predecessor is processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added 20MB file size threshold for chunking (in addition to 30-minute duration threshold)
   - Prevents WhisperX from returning massive JSON responses that exceed parser buffer limits
   - High-quality short audio (e.g., 46MB / 15 minutes) now properly chunks before processing
+- **Chunk Cascade Failure** - Chunks no longer fail in cascade when predecessor is still processing
+  - Chunks waiting on a processing predecessor now return 500 without marking themselves as failed
+  - Prevents "Chunk N cannot proceed - previous chunk N-1 failed" cascade when chunks race ahead
+  - Cloud Tasks retries chunks cleanly without poisoning the chunk status chain
 
 ## [1.8.0-beta] - 2026-01-05
 


### PR DESCRIPTION
## Problem

When Cloud Tasks dispatches all 10 chunks simultaneously, chunks 1-9 race ahead and find their predecessor "still processing". The current code marks them as **failed** before returning 500 for retry, causing a cascade:

```
Chunk 1 waiting on chunk 0 → marks self as FAILED
Chunk 2 sees chunk 1 FAILED → marks self as FAILED
...cascades through chunk 9
```

Even though chunk 0 eventually completes and chunk 1's retry succeeds, chunks 2-9 are already poisoned with "failed" status.

## Solution

Distinguish between "waiting" (retriable) vs "predecessor failed" (permanent):

```typescript
const isWaitingOnProcessing = errorMsg.includes('still processing');

if (isWaitingOnProcessing) {
  // Just retry - don't mark as failed
  res.status(500).send(`Chunk waiting on predecessor - will retry`);
  return;
}

// Only mark as failed if predecessor actually failed
await markChunkFailed(conversationId, chunkIndex, errorMsg);
```

## Test plan

- [ ] Upload a large file that triggers chunking (>30 min or >20MB)
- [ ] Verify chunks 1-9 retry cleanly while chunk 0 processes
- [ ] Confirm no cascade failures in logs
- [ ] Final merge completes successfully