### PR TITLE
fix(chunking): sanitize chunk context before Firestore write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Chunks waiting on a processing predecessor now return 500 without marking themselves as failed
   - Prevents "Chunk N cannot proceed - previous chunk N-1 failed" cascade when chunks race ahead
   - Cloud Tasks retries chunks cleanly without poisoning the chunk status chain
+- **Chunk Context Firestore Write Error** - Fixed undefined value error when saving chunk emitted context
+  - Added `sanitizeForFirestore()` utility that recursively strips undefined values from objects
+  - Fixes "Cannot use undefined as a Firestore value" error in `emittedContext.speakerMap.voiceSignature`
+  - Optional fields like `voiceSignature` and `displayName` in speaker mappings now properly omitted when undefined
 
 ## [1.8.0-beta] - 2026-01-05
 

--- a/functions/src/chunkContext.ts
+++ b/functions/src/chunkContext.ts
@@ -25,6 +25,37 @@ import {
 const MAX_SUMMARY_LENGTH = 512;
 
 // =============================================================================
+// Firestore Utilities
+// =============================================================================
+
+/**
+ * Recursively strip undefined values from an object.
+ * Firestore doesn't allow undefined - it'll throw "Cannot use undefined as a Firestore value".
+ * This sanitizer removes undefined fields entirely (vs setting them to null).
+ */
+export function sanitizeForFirestore<T>(obj: T): T {
+  if (obj === null || obj === undefined) {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(item => sanitizeForFirestore(item)) as T;
+  }
+
+  if (typeof obj === 'object') {
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      if (value !== undefined) {
+        sanitized[key] = sanitizeForFirestore(value);
+      }
+    }
+    return sanitized as T;
+  }
+
+  return obj;
+}
+
+// =============================================================================
 // Context Creation
 // =============================================================================
 


### PR DESCRIPTION
## Summary
- Adds `sanitizeForFirestore()` utility that recursively strips undefined values from objects
- Fixes "Cannot use undefined as a Firestore value" error when saving chunk emitted context
- The error occurred because `voiceSignature` field in speaker mappings is optional and may be undefined

## Root Cause
The `SpeakerMapping` type has optional fields (`voiceSignature`, `displayName`) that can be undefined. When `buildNextContext()` creates the chunk context, these undefined fields get passed to Firestore which rejects them with:
```
Cannot use "undefined" as a Firestore value 
(found in field "emittedContext.speakerMap.`0`.voiceSignature")
```

## Fix
Added a generic `sanitizeForFirestore()` function that recursively removes undefined values from objects and arrays. This is applied to the context before both Firestore writes in `processTranscription.ts`.

## Test plan
- [x] TypeScript compiles successfully
- [ ] Deploy functions and retry failed chunk processing
- [ ] Verify chunks complete without Firestore write errors