### PR TITLE
fix(version): enable CI tag detection and add build number tracking

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -62,6 +62,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0    # Full history for git describe
+          fetch-tags: true  # Fetch all tags for version detection
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-01-13
+
+### Fixed
+- **CI Version Detection** - GitHub Actions workflow now fetches git tags for accurate version identification
+  - Added `fetch-depth: 0` and `fetch-tags: true` to checkout step
+  - Deployed functions now correctly report their release tag (e.g., `v2.0.0`) instead of commit hash
+- **Build Number Tracking** - Deployments now include `build/N` tag number for artifact correlation
+  - `processedByBuildNumber` field stored in conversation and chunk documents
+  - Cloud Function logs display build number alongside version
+
 ## [2.0.0] - 2026-01-13
 
 ### Added

--- a/functions/scripts/generate-version.js
+++ b/functions/scripts/generate-version.js
@@ -5,9 +5,11 @@
  * This is a BUILD SCRIPT with hardcoded git commands - no user input.
  *
  * Output format:
- * - Clean deploy from tag: "v1.5.0"
+ * - Clean deploy from tag: "v2.0.0"
  * - Clean deploy from commit: "abc1234"
  * - Dirty deploy (uncommitted changes): "abc1234-dirty-20240112T153045"
+ *
+ * Also captures build number from build/N tags for tracking deployable artifacts.
  */
 
 const { execSync } = require('child_process');
@@ -26,6 +28,19 @@ function getGitInfo() {
       version = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
     }
 
+    // Check for build/N tag on current commit
+    let buildNumber = null;
+    try {
+      // Get all tags pointing at HEAD, filter for build/* pattern
+      const tags = execSync('git tag --points-at HEAD', { encoding: 'utf8' }).trim();
+      const buildTag = tags.split('\n').find(tag => tag.startsWith('build/'));
+      if (buildTag) {
+        buildNumber = parseInt(buildTag.replace('build/', ''), 10);
+      }
+    } catch {
+      // No build tag, that's fine
+    }
+
     // Check for uncommitted changes
     const status = execSync('git status --porcelain', { encoding: 'utf8' }).trim();
     const isDirty = status.length > 0;
@@ -39,14 +54,14 @@ function getGitInfo() {
     // Get branch name for context
     const branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
 
-    return { version, branch, isDirty };
+    return { version, branch, isDirty, buildNumber };
   } catch (error) {
     console.warn('Could not get git info:', error.message);
-    return { version: 'unknown', branch: 'unknown', isDirty: false };
+    return { version: 'unknown', branch: 'unknown', isDirty: false, buildNumber: null };
   }
 }
 
-const { version, branch, isDirty } = getGitInfo();
+const { version, branch, isDirty, buildNumber } = getGitInfo();
 
 const content = `// Auto-generated at build time - do not edit manually
 // Generated: ${new Date().toISOString()}
@@ -55,9 +70,11 @@ export const BUILD_VERSION = '${version}';
 export const BUILD_BRANCH = '${branch}';
 export const BUILD_TIMESTAMP = '${new Date().toISOString()}';
 export const IS_DIRTY_BUILD = ${isDirty};
+export const BUILD_NUMBER: number | null = ${buildNumber === null ? 'null' : buildNumber};
 `;
 
 const outputPath = path.join(__dirname, '..', 'src', 'version.ts');
 fs.writeFileSync(outputPath, content);
 
-console.log(`[generate-version] Generated version.ts: ${version} (branch: ${branch}${isDirty ? ', DIRTY' : ''})`);
+const buildInfo = buildNumber !== null ? `, build #${buildNumber}` : '';
+console.log(`[generate-version] Generated version.ts: ${version} (branch: ${branch}${isDirty ? ', DIRTY' : ''}${buildInfo})`);

--- a/functions/src/chunkMerge.ts
+++ b/functions/src/chunkMerge.ts
@@ -42,7 +42,7 @@ import {
   logFallbackTriggered,
   logReconciliationFailed
 } from './logging/reconciliation';
-import { BUILD_VERSION } from './version';
+import { BUILD_VERSION, BUILD_NUMBER } from './version';
 
 // =============================================================================
 // Fallback Handling Helpers
@@ -796,6 +796,7 @@ export async function mergeChunks(conversationId: string): Promise<void> {
     'chunkingMetadata.mergedAt': new Date().toISOString(),
     alignmentStatus: 'aligned', // Chunks use WhisperX alignment
     processedByVersion: BUILD_VERSION, // Track which function version processed this
+    ...(BUILD_NUMBER !== null && { processedByBuildNumber: BUILD_NUMBER }), // Build tag number if present
     updatedAt: FieldValue.serverTimestamp()
   };
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -34,7 +34,7 @@ const agent = new Agent({
 setGlobalDispatcher(agent);
 
 // Import build version info (generated at build time from git)
-import { BUILD_VERSION, BUILD_BRANCH, IS_DIRTY_BUILD } from './version';
+import { BUILD_VERSION, BUILD_BRANCH, IS_DIRTY_BUILD, BUILD_NUMBER } from './version';
 
 console.log('[Undici] Global dispatcher configured:', {
   headersTimeout: `${UNDICI_HEADERS_TIMEOUT_MS / 60_000} minutes`,
@@ -42,7 +42,8 @@ console.log('[Undici] Global dispatcher configured:', {
 });
 
 // Log build version on cold start - helps identify which deployment processed a conversation
-console.log(`[Functions] Build version: ${BUILD_VERSION} (branch: ${BUILD_BRANCH}${IS_DIRTY_BUILD ? ', DIRTY' : ''})`);
+const buildNumStr = BUILD_NUMBER !== null ? `, build #${BUILD_NUMBER}` : '';
+console.log(`[Functions] Build version: ${BUILD_VERSION} (branch: ${BUILD_BRANCH}${IS_DIRTY_BUILD ? ', DIRTY' : ''}${buildNumStr})`);
 
 // =============================================================================
 

--- a/functions/src/processTranscription.ts
+++ b/functions/src/processTranscription.ts
@@ -38,7 +38,7 @@ import {
 } from './chunkContext';
 import { ChunkContext, ProcessingMode, SpeakerSignature } from './types';
 import { ChunkMetadata } from './chunking';
-import { BUILD_VERSION } from './version';
+import { BUILD_VERSION, BUILD_NUMBER } from './version';
 
 /**
  * Enqueue a merge task to Cloud Tasks.
@@ -306,9 +306,10 @@ export const processTranscription = onRequest(
 
         // Build chunk artifact update
         // For parallel mode, include speaker signatures for merge reconciliation
-        const chunkArtifactUpdate: { emittedContext: ChunkContext; chunkSpeakerSignatures?: SpeakerSignature[]; processedByVersion: string } = {
+        const chunkArtifactUpdate: { emittedContext: ChunkContext; chunkSpeakerSignatures?: SpeakerSignature[]; processedByVersion: string; processedByBuildNumber?: number } = {
           emittedContext: sanitizedContext,
-          processedByVersion: BUILD_VERSION // Track which function version processed this chunk
+          processedByVersion: BUILD_VERSION, // Track which function version processed this chunk
+          ...(BUILD_NUMBER !== null && { processedByBuildNumber: BUILD_NUMBER }) // Build tag number if present
         };
 
         // Store speaker signatures for merge-time reconciliation (useful in both modes)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-transcript-analysis-app",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Fixes version tracking so CI deployments correctly identify their version and build number.

### Changes
- **CI workflow**: Add `fetch-depth: 0` and `fetch-tags: true` to checkout step
  - Without this, `git describe --tags` fails in CI (tags not fetched)
- **Version script**: Add `BUILD_NUMBER` export from `build/N` tags
- **Consumers**: Update index.ts, chunkMerge.ts, processTranscription.ts to log/store build number
- **Firestore**: Documents now include `processedByBuildNumber` when available

### Expected behavior after fix

| Deploy Method | BUILD_VERSION | BUILD_NUMBER |
|---------------|---------------|--------------|
| CI release (tagged) | `v2.0.0` | `1` |
| CI commit (untagged) | `abc1234` | `null` |
| Local dirty | `abc1234-dirty-20260113T012345` | `null` |

### Test plan
- [ ] Verify TypeScript compiles
- [ ] Deploy to staging and check Cloud Function logs show version correctly
- [ ] Process a file and verify `processedByBuildNumber` appears in Firestore (when deployed from tagged commit)

---
Infrastructure fix for v2.0.0 version tracking feature.