### PR TITLE
fix(version): skip dirty check in CI environments

### DIFF
--- a/functions/scripts/generate-version.js
+++ b/functions/scripts/generate-version.js
@@ -41,14 +41,19 @@ function getGitInfo() {
       // No build tag, that's fine
     }
 
-    // Check for uncommitted changes
-    const status = execSync('git status --porcelain', { encoding: 'utf8' }).trim();
-    const isDirty = status.length > 0;
+    // Check for uncommitted changes (skip in CI - CI checkouts are clean by definition)
+    const isCI = process.env.CI === 'true';
+    let isDirty = false;
 
-    if (isDirty) {
-      // Add dirty marker with timestamp for manual deploys
-      const timestamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, '');
-      version = `${version}-dirty-${timestamp}`;
+    if (!isCI) {
+      const status = execSync('git status --porcelain', { encoding: 'utf8' }).trim();
+      isDirty = status.length > 0;
+
+      if (isDirty) {
+        // Add dirty marker with timestamp for local deploys
+        const timestamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, '');
+        version = `${version}-dirty-${timestamp}`;
+      }
     }
 
     // Get branch name for context


### PR DESCRIPTION
## Summary

CI checkouts are clean by definition. The dirty check was failing in GitHub Actions due to `npm ci` or other CI-specific file changes.

### Fix
- Check for `CI=true` environment variable (set by GitHub Actions and most CI systems)
- Skip `git status --porcelain` check when in CI
- Local deploys still get dirty detection and timestamp suffix

### Expected behavior after fix

| Environment | BUILD_VERSION |
|-------------|---------------|
| CI (tagged commit) | `v2.0.1` |
| CI (untagged commit) | `abc1234` |
| Local (clean) | `abc1234` |
| Local (dirty) | `abc1234-dirty-20260113T012345` |