### PR TITLE
chore(release): v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-01-13
+
+### Changed
+- **File Upload Limit** - Increased maximum audio file size from 100MB to 500MB
+  - Handles ~45 minute stereo WAV files at 44.1kHz
+  - Client-side validation now prevents upload attempts before hitting server limit
+  - Clear error message shows file size vs limit when exceeded
+
 ## [2.0.1] - 2026-01-13
 
 ### Fixed

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -1,5 +1,16 @@
 # What's New
 
+## Version 2.0.2 - January 13, 2026
+
+### 🔧 Improvements
+
+**Larger File Uploads**
+- You can now upload audio files up to **500MB** (previously 100MB)
+- Handles longer uncompressed WAV recordings
+- If you try to upload a file that's too large, you'll see a clear error message before the upload even starts
+
+---
+
 ## Version 2.0.0 - January 13, 2026
 
 ### ✨ New Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-transcript-analysis-app",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -324,6 +324,10 @@ export const Library: React.FC<LibraryProps> = ({ onOpen, onAdminClick, onStatsC
 
 // --- Upload Modal Component ---
 
+// 500MB - must match storage.rules limit
+const MAX_FILE_SIZE_BYTES = 500 * 1024 * 1024;
+const MAX_FILE_SIZE_MB = 500;
+
 const UploadModal: React.FC<{ onClose: () => void; onUpload: (conv: Conversation, audioFile?: File) => Promise<void> }> = ({ onClose, onUpload }) => {
   const [isDragging, setIsDragging] = useState(false);
   const [uploadState, setUploadState] = useState<'idle' | 'uploading' | 'saving' | 'done' | 'error'>('idle');
@@ -347,18 +351,26 @@ const UploadModal: React.FC<{ onClose: () => void; onUpload: (conv: Conversation
     setIsDragging(false);
     if (e.dataTransfer.files && e.dataTransfer.files[0]) {
       const file = e.dataTransfer.files[0];
-      if (file.type.startsWith('audio/') || file.type.startsWith('video/')) {
-        setSelectedFile(file);
-        setErrorMessage(null);
-      } else {
+      if (!(file.type.startsWith('audio/') || file.type.startsWith('video/'))) {
         setErrorMessage("Please upload a valid audio or video file.");
+        return;
       }
+      if (file.size > MAX_FILE_SIZE_BYTES) {
+        setErrorMessage(`File too large. Maximum size is ${MAX_FILE_SIZE_MB}MB (yours is ${(file.size / (1024 * 1024)).toFixed(0)}MB).`);
+        return;
+      }
+      setSelectedFile(file);
+      setErrorMessage(null);
     }
   }, []);
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
        const file = e.target.files[0];
+       if (file.size > MAX_FILE_SIZE_BYTES) {
+         setErrorMessage(`File too large. Maximum size is ${MAX_FILE_SIZE_MB}MB (yours is ${(file.size / (1024 * 1024)).toFixed(0)}MB).`);
+         return;
+       }
        setSelectedFile(file);
        setErrorMessage(null);
     }
@@ -441,7 +453,7 @@ const UploadModal: React.FC<{ onClose: () => void; onUpload: (conv: Conversation
                     <UploadCloud size={24} />
                   </div>
                   <p className="font-medium text-slate-900">Click to upload or drag and drop</p>
-                  <p className="text-sm mt-1">MP3, M4A, WAV (Max 100MB)</p>
+                  <p className="text-sm mt-1">MP3, M4A, WAV (Max {MAX_FILE_SIZE_MB}MB)</p>
                 </div>
               )}
             </div>

--- a/storage.rules
+++ b/storage.rules
@@ -17,10 +17,10 @@ service firebase.storage {
       allow read: if isAuthenticated() && request.auth.uid == userId;
 
       // Users can upload audio to their own directory
-      // Limit file size to 100MB and only allow audio types
+      // Limit file size to 500MB and only allow audio types
       allow create: if isAuthenticated()
         && request.auth.uid == userId
-        && request.resource.size < 100 * 1024 * 1024
+        && request.resource.size < 500 * 1024 * 1024
         && request.resource.contentType.matches('audio/.*');
 
       // Users can delete their own audio files


### PR DESCRIPTION
## Release v2.0.2

### Changed
- **File Upload Limit** - Increased maximum audio file size from 100MB to 500MB
  - Handles ~45 minute stereo WAV files at 44.1kHz
  - Client-side validation now prevents upload attempts before hitting server limit
  - Clear error message shows file size vs limit when exceeded

### Files Changed
- `storage.rules` - Server-side limit increased to 500MB
- `src/pages/Library.tsx` - Client-side validation added with `MAX_FILE_SIZE_BYTES` constant
- `package.json` - Version bumped to 2.0.2
- `CHANGELOG.md` - Release notes added
- `USER_CHANGELOG.md` - User-facing release notes added

### Deployment Notes
After merging, deploy storage rules to Firebase:
```bash
npx firebase deploy --only storage
```

---
Tag: `v2.0.2`
Build: `3`