### PR TITLE
chore(release): v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-01-13
+
+### Fixed
+- **Stale Progress Display on Retry** - Retrying a failed chunked job now clears previous progress indicators
+  - UI no longer shows stale progress percentages and timeline from the failed attempt
+  - Progress starts fresh from 0% when resuming incomplete chunks
+- **Cancel Timing Window for Small Files** - Cancel requests are now respected even during the brief window between upload completion and task creation
+  - Added abort checkpoint before enqueueing Cloud Tasks for non-chunked files
+  - Previously, a cancel request during this window would be ignored
+
+### Added
+- **taskGeneration Documentation** - Architecture reference now explains the stale task detection mechanism
+  - Documents how `taskGeneration` counter invalidates orphaned Cloud Tasks from previous attempts
+  - Helps developers understand retry safety guarantees
+
 ## [2.0.4] - 2026-01-13
 
 ### Fixed

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -317,6 +317,19 @@ The system provides full job control capabilities allowing users to cancel activ
 - `retryCount` (number): Number of retry attempts (max 3)
 - `lastFailedAt` (ISO timestamp): When the job last failed
 - `lastRetryAt` (ISO timestamp): When retry was last initiated
+- `taskGeneration` (number): Counter incremented on each retry to invalidate stale Cloud Tasks
+
+**Stale Task Detection:**
+
+When a job fails and is retried, orphaned Cloud Tasks from the previous attempt may still be in-flight. Without mitigation, these stale tasks can corrupt the retry by updating progress or status with outdated values.
+
+The `taskGeneration` field solves this:
+1. Each new job starts with `taskGeneration: 1`
+2. Cloud Task payloads include the current `taskGeneration`
+3. On retry, `taskGeneration` is incremented in Firestore
+4. When a task runs, it compares `payload.taskGeneration` vs Firestore's `taskGeneration`
+5. If payload's generation is lower, the task is stale and returns 200 (complete, no-op)
+6. Default: missing `taskGeneration` in payload defaults to 0, so pre-feature tasks are always stale after any retry
 
 **Implementation Files:**
 - `src/services/firestoreService.ts` - `abortProcessing()` client-side abort request

--- a/functions/src/retry.ts
+++ b/functions/src/retry.ts
@@ -148,11 +148,14 @@ export const retryTranscription = onCall<RetryTranscriptionRequest>(
         return chunk;
       });
 
-      // Update conversation: reset to chunking status, clear errors
+      // Update conversation: reset to chunking status, clear errors and stale progress
       // Increment taskGeneration to invalidate any stale Cloud Tasks from previous attempts
+      // Clear processingProgress and processingTimeline to avoid showing stale data from failed attempt
       await conversationRef.update({
         status: 'chunking',
         processingError: FieldValue.delete(),
+        processingProgress: FieldValue.delete(),
+        processingTimeline: FieldValue.delete(),
         abortRequested: FieldValue.delete(),
         retryCount: FieldValue.increment(1),
         taskGeneration: FieldValue.increment(1), // Invalidate stale tasks

--- a/functions/src/transcribe.ts
+++ b/functions/src/transcribe.ts
@@ -1783,6 +1783,9 @@ export const transcribeAudio = onObjectFinalized(
             scheduleDelaySeconds: 5
           });
 
+          // Check for abort before enqueuing task (allows fast cancellation)
+          await checkAbort(conversationId);
+
           const [createdTask] = await tasksClient.createTask({ parent, task });
 
           console.log('[Transcribe] ✅ Task enqueued successfully:', {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-transcript-analysis-app",
   "private": true,
-  "version": "2.0.4",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Release v2.1.0

### Fixed
- **Stale Progress Display on Retry** - Retrying a failed chunked job now clears previous progress indicators
  - UI no longer shows stale progress percentages and timeline from the failed attempt
  - Progress starts fresh from 0% when resuming incomplete chunks
- **Cancel Timing Window for Small Files** - Cancel requests are now respected even during the brief window between upload completion and task creation
  - Added abort checkpoint before enqueueing Cloud Tasks for non-chunked files
  - Previously, a cancel request during this window would be ignored

### Added
- **taskGeneration Documentation** - Architecture reference now explains the stale task detection mechanism
  - Documents how `taskGeneration` counter invalidates orphaned Cloud Tasks from previous attempts
  - Helps developers understand retry safety guarantees

## Changed Files
- `functions/src/retry.ts` - Clear stale progress on chunk resume
- `functions/src/transcribe.ts` - Abort checkpoint before non-chunk task creation
- `docs/reference/architecture.md` - taskGeneration documentation

---
Scope: `04_large_file_upload_03_job_control_recovery`
Iteration: `iteration_01_a`
Tag: `v2.1.0`
Build: `6`