### PR TITLE
fix(chat): restore block code styling with overflow-x-auto

### DIFF
--- a/src/components/viewer/MarkdownWithSources.tsx
+++ b/src/components/viewer/MarkdownWithSources.tsx
@@ -236,17 +236,28 @@ export const MarkdownWithSources: React.FC<MarkdownWithSourcesProps> = ({
       </li>
     ),
 
-    // Inline code - monospace (no source replacement in code)
-    // Note: Block code is handled by the `pre` component below
-    code: ({ children }) => (
-      <code className="bg-slate-100 rounded px-1 py-0.5 text-xs font-mono">
-        {children}
-      </code>
-    ),
+    // Code - inline or block based on className presence
+    // Block code (fenced with ```) gets className="language-xxx"
+    // Inline code (single backticks) has no className
+    code: ({ className, children }) => {
+      const isBlock = className?.startsWith('language-');
+      if (isBlock) {
+        return (
+          <code className="block bg-slate-100 rounded p-2 overflow-x-auto text-xs font-mono my-2">
+            {children}
+          </code>
+        );
+      }
+      return (
+        <code className="bg-slate-100 rounded px-1 py-0.5 text-xs font-mono">
+          {children}
+        </code>
+      );
+    },
 
-    // Pre-formatted blocks
+    // Pre-formatted blocks - minimal wrapper since code handles styling
     pre: ({ children }) => (
-      <pre className="bg-slate-100 rounded p-2 overflow-x-auto text-xs font-mono my-2">
+      <pre className="my-2">
         {children}
       </pre>
     ),


### PR DESCRIPTION
## Summary

Fixes CI test failure in v2.3.0: `MarkdownWithSources > should render block code with proper styling`

## Problem

The react-markdown v10 migration removed the `inline` prop from code components. This broke block code detection, causing fenced code blocks (` ```js ... ``` `) to render with inline styling instead of block styling.

**Expected:** Block code has `overflow-x-auto` for horizontal scrolling
**Actual:** Block code had inline styling (`bg-slate-100 rounded px-1 py-0.5`)

## Fix

Detect block code by checking for `className="language-xxx"` which react-markdown adds to fenced code blocks with language specifiers.

```typescript
code: ({ className, children }) => {
  const isBlock = className?.startsWith('language-');
  if (isBlock) {
    return <code className="...overflow-x-auto...">{children}</code>;
  }
  return <code className="...inline styles...">{children}</code>;
},
```

## Test Plan

- [x] `npm test -- --run src/__tests__/components/viewer/MarkdownWithSources.test.tsx` - 18/18 tests pass
- [x] Pre-commit hooks pass (ESLint, TypeScript, tests)