### PR TITLE
chore(release): v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-01-15
+
+### Fixed
+- **Block Code Styling in Chat** - Fenced code blocks now properly display with horizontal scrolling
+  - Fixed react-markdown v10 migration issue where block code received inline styling
+  - Code blocks with language specifiers (` ```js `) now correctly have `overflow-x-auto` for long lines
+
 ## [2.3.0] - 2026-01-14
 
 ### Added

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -1,5 +1,16 @@
 # What's New
 
+## Version 2.3.1 - January 15, 2026
+
+### 🐛 Bug Fixes
+
+**Code Blocks Now Display Correctly**
+- Fixed an issue where code blocks in chat responses didn't scroll horizontally
+- Long lines of code now stay readable instead of breaking the layout
+- This was a regression from the v2.3.0 update
+
+---
+
 ## Version 2.3.0 - January 14, 2026
 
 ### ✨ New Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-transcript-analysis-app",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Release v2.3.1

Patch release fixing a regression from v2.3.0.

### Fixed
- **Block Code Styling in Chat** - Fenced code blocks now properly display with horizontal scrolling
  - Fixed react-markdown v10 migration issue where block code received inline styling
  - Code blocks with language specifiers (` ```js `) now correctly have `overflow-x-auto` for long lines

### Files Changed
- `CHANGELOG.md` - Added v2.3.1 entry
- `USER_CHANGELOG.md` - Added user-friendly release notes
- `package.json` - Bumped version to 2.3.1

---
Tag: `v2.3.1`
Build: `9`