### PR TITLE
chore(release): v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-01-15
+
+### Added
+- **Chat Rate Limit Resilience** - Vertex AI calls now retry automatically with exponential backoff
+  - Handles 429 (RESOURCE_EXHAUSTED), 503 (UNAVAILABLE), and DEADLINE_EXCEEDED errors
+  - Up to 3 retries with 3-second base delay, prevents intermittent chat failures
+
+### Changed
+- **Upgraded Chat Model** - Switched from experimental `gemini-2.0-flash-exp` to stable `gemini-2.5-flash`
+  - More consistent behavior and reduced rate limiting issues
+- **Simplified Citation System** - Chat now uses direct `[segment N]` citation format
+  - Replaced complex dual-format system (`[Segment N]` + `{{SOURCE_n}}` placeholders)
+  - More resilient to LLM output variations
+  - Citations render reliably as clickable timestamp buttons
+
+### Fixed
+- **Comma-Separated Citations** - LLM sometimes outputs `[segment 3, segment 4, segment 9]`
+  - These grouped citations now auto-expand and render as individual timestamp buttons
+  - Previously showed as plain text or in "Additional sources" section
+
 ## [2.3.2] - 2026-01-15
 
 ### Fixed

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -1,5 +1,21 @@
 # What's New
 
+## Version 2.4.0 - January 15, 2026
+
+### ✨ Improvements
+
+**More Reliable Chat**
+- Chat no longer fails intermittently with "resource exhausted" errors
+- If the AI service is temporarily busy, the app now automatically retries instead of showing an error
+- Upgraded to a more stable AI model for consistent responses
+
+**Better Source Citations**
+- Timestamp citations in chat responses now work more reliably
+- When the AI groups multiple sources together like `[segment 3, segment 4, segment 9]`, each one now becomes a separate clickable button
+- Previously, grouped citations would sometimes appear as plain text—now they all render correctly
+
+---
+
 ## Version 2.3.2 - January 15, 2026
 
 ### 🐛 Bug Fixes

--- a/functions/src/chat.ts
+++ b/functions/src/chat.ts
@@ -49,6 +49,45 @@ function getVertexAIClient(): VertexAI {
   return new VertexAI({ project, location });
 }
 
+/**
+ * Retry with exponential backoff for transient Vertex AI errors.
+ * Handles 429 (rate limit), 503 (service unavailable), and similar.
+ */
+async function retryWithBackoff<T>(
+  operation: () => Promise<T>,
+  operationName: string,
+  maxRetries = 3,
+  baseDelayMs = 2000
+): Promise<T> {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      // Retryable errors: rate limits, temporary unavailability
+      const isRetryable = errorMessage.includes('429') ||
+                          errorMessage.includes('RESOURCE_EXHAUSTED') ||
+                          errorMessage.includes('503') ||
+                          errorMessage.includes('UNAVAILABLE') ||
+                          errorMessage.includes('DEADLINE_EXCEEDED');
+
+      if (!isRetryable || attempt === maxRetries) {
+        throw error;
+      }
+
+      const delayMs = baseDelayMs * Math.pow(2, attempt - 1);
+      log.warn(`${operationName} failed (attempt ${attempt}/${maxRetries}), retrying in ${delayMs}ms`, {
+        error: errorMessage,
+        attempt,
+        maxRetries
+      });
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+  throw new Error(`${operationName} failed after ${maxRetries} attempts`);
+}
+
 interface ChatRequest {
   conversationId: string;
   message: string;
@@ -145,15 +184,21 @@ export const chatWithConversation = onCall<ChatRequest>(
 
       // Call Gemini API via Vertex AI
       const vertexAI = getVertexAIClient();
-      const model = vertexAI.getGenerativeModel({ model: 'gemini-2.0-flash-exp' });
+      const model = vertexAI.getGenerativeModel({ model: 'gemini-2.5-flash' });
 
       // Build labels for billing attribution
       const labels = buildGeminiLabels(conversationId, userId, 'chat');
 
-      const result = await model.generateContent({
-        contents: [{ role: 'user', parts: [{ text: prompt }] }],
-        labels
-      });
+      // Wrap in retry logic for transient 429/rate limit errors
+      const result = await retryWithBackoff(
+        () => model.generateContent({
+          contents: [{ role: 'user', parts: [{ text: prompt }] }],
+          labels
+        }),
+        'Gemini chat completion',
+        3,     // maxRetries
+        3000   // 3 second base delay (gives rate limits time to recover)
+      );
       const response = result.response;
       // Vertex AI SDK response structure
       const answerText = response.candidates?.[0]?.content?.parts?.[0]?.text || '';
@@ -163,7 +208,7 @@ export const chatWithConversation = onCall<ChatRequest>(
       const tokenUsage: ChatTokenUsage = {
         inputTokens: usage?.promptTokenCount || 0,
         outputTokens: usage?.candidatesTokenCount || 0,
-        model: 'gemini-2.0-flash-exp'
+        model: 'gemini-2.5-flash'
       };
 
       // Determine if the question is unanswerable

--- a/functions/src/utils/promptBuilder.ts
+++ b/functions/src/utils/promptBuilder.ts
@@ -26,15 +26,13 @@ export function buildChatPrompt(conversation: Conversation, userMessage: string)
   const systemInstructions = `You are a helpful assistant analyzing an audio transcript. Your task is to answer questions based ONLY on the information present in the transcript below.
 
 CRITICAL REQUIREMENTS:
-1. When answering questions, you MUST cite specific segments by their index number
-2. You MUST include the exact timestamp range (startMs and endMs) for each cited segment
-3. If the answer cannot be found in the transcript, say "This topic is not mentioned in the transcript"
-4. Do NOT make assumptions or provide information not explicitly stated in the transcript
-5. When multiple segments support your answer, cite all relevant ones
-6. Format citations like: [Segment 5: 1:23-1:45]
-7. INLINE SOURCE MARKERS: After each statement that cites a segment, add {{SOURCE_n}} where n is the 0-indexed position of that citation in your response (order of first appearance). For example, if you cite [Segment 5] first and [Segment 12] second:
-   "The speaker mentioned X {{SOURCE_0}}. Later they discussed Y {{SOURCE_1}}."
-   If you cite the same segment multiple times, use the same source index each time.
+1. Base your answer ONLY on the transcript content - do not make assumptions
+2. If the answer cannot be found, say "This topic is not mentioned in the transcript"
+3. Cite specific segments using [segment N] format where N is the segment index number
+4. Place citations inline after each relevant statement
+
+EXAMPLE FORMAT:
+"The speaker discussed climate change [segment 5] and mentioned renewable energy solutions [segment 12]. They elaborated on the economic impacts [segment 23] later in the conversation."
 
 TRANSCRIPT CONTEXT:
 ${transcriptContext}

--- a/functions/src/utils/timestampValidation.ts
+++ b/functions/src/utils/timestampValidation.ts
@@ -8,6 +8,7 @@
 import type { Segment } from '../types';
 
 export interface TimestampSource {
+  segmentIndex: number;
   segmentId: string;
   startMs: number;
   endMs: number;
@@ -78,6 +79,7 @@ export function validateTimestampSources(
     // Only include if we found a valid match
     if (matchedSegment) {
       validatedSources.push({
+        segmentIndex: matchedSegment.index,
         segmentId: matchedSegment.segmentId,
         startMs: matchedSegment.startMs,
         endMs: matchedSegment.endMs,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-transcript-analysis-app",
   "private": true,
-  "version": "2.3.2",
+  "version": "2.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/__tests__/components/viewer/MarkdownWithSources.test.tsx
+++ b/src/__tests__/components/viewer/MarkdownWithSources.test.tsx
@@ -15,8 +15,8 @@ describe('MarkdownWithSources', () => {
   };
 
   const mockSources: TimestampSource[] = [
-    { segmentId: 'seg1', startMs: 1000, speaker: 'speaker1' },
-    { segmentId: 'seg2', startMs: 2000, speaker: 'speaker1' }
+    { segmentIndex: 5, segmentId: 'seg1', startMs: 1000, speaker: 'speaker1' },
+    { segmentIndex: 12, segmentId: 'seg2', startMs: 2000, speaker: 'speaker1' }
   ];
 
   const mockCallbacks = {
@@ -149,8 +149,8 @@ describe('MarkdownWithSources', () => {
     expect(quote.parentElement).toHaveClass('border-l-4', 'italic');
   });
 
-  it('should replace {{SOURCE_0}} with TimestampLink', () => {
-    const content = 'Check this source {{SOURCE_0}} for details.';
+  it('should replace [segment N] with TimestampLink', () => {
+    const content = 'Check this source [segment 5] for details.';
 
     render(
       <MarkdownWithSources
@@ -167,8 +167,8 @@ describe('MarkdownWithSources', () => {
     expect(screen.getByText('John Doe')).toBeInTheDocument();
   });
 
-  it('should render first source inline', () => {
-    const content = 'Only using first source {{SOURCE_0}} here.';
+  it('should render source inline when referenced by segment index', () => {
+    const content = 'Only using segment 5 [segment 5] here.';
 
     render(
       <MarkdownWithSources
@@ -180,13 +180,13 @@ describe('MarkdownWithSources', () => {
       />
     );
 
-    // First source should be rendered as TimestampLink
+    // Source should be rendered as TimestampLink
     expect(screen.getByText('0:01')).toBeInTheDocument();
     expect(screen.getByText('John Doe')).toBeInTheDocument();
   });
 
-  it('should handle out-of-range source indices gracefully', () => {
-    const content = 'Bad source {{SOURCE_99}} here.';
+  it('should leave unmatched segment references as-is', () => {
+    const content = 'Unknown segment [segment 99] here.';
 
     render(
       <MarkdownWithSources
@@ -198,12 +198,12 @@ describe('MarkdownWithSources', () => {
       />
     );
 
-    // The text includes the full sentence
-    expect(screen.getByText(/Bad source \[Source unavailable\] here/)).toBeInTheDocument();
+    // Unmatched segments should be left as plain text
+    expect(screen.getByText(/Unknown segment \[segment 99\] here/)).toBeInTheDocument();
   });
 
   it('should render both sources inline when referenced', () => {
-    const content = 'First {{SOURCE_0}} and second {{SOURCE_1}} sources.';
+    const content = 'First [segment 5] and second [segment 12] sources.';
 
     render(
       <MarkdownWithSources
@@ -216,6 +216,25 @@ describe('MarkdownWithSources', () => {
     );
 
     // Both sources should be rendered
+    expect(screen.getByText('0:01')).toBeInTheDocument();
+    expect(screen.getByText('0:02')).toBeInTheDocument();
+  });
+
+  it('should expand comma-separated segment lists', () => {
+    // LLMs sometimes output [segment 5, segment 12] instead of [segment 5] [segment 12]
+    const content = 'Multiple sources [segment 5, segment 12] grouped together.';
+
+    render(
+      <MarkdownWithSources
+        content={content}
+        sources={mockSources}
+        speakers={mockSpeakers}
+        conversationId="test-conv"
+        {...mockCallbacks}
+      />
+    );
+
+    // Both timestamps should be rendered from expanded list
     expect(screen.getByText('0:01')).toBeInTheDocument();
     expect(screen.getByText('0:02')).toBeInTheDocument();
   });
@@ -238,7 +257,7 @@ describe('MarkdownWithSources', () => {
   });
 
   it('should handle multiple inline sources in same paragraph', () => {
-    const content = 'See {{SOURCE_0}} and also {{SOURCE_1}} for context.';
+    const content = 'See [segment 5] and also [segment 12] for context.';
 
     render(
       <MarkdownWithSources
@@ -257,7 +276,7 @@ describe('MarkdownWithSources', () => {
 
   it('should preserve bold formatting around inline sources', () => {
     // The key test: bold should survive source replacement
-    const content = '**Important:** see this {{SOURCE_0}} for proof.';
+    const content = '**Important:** see this [segment 5] for proof.';
 
     render(
       <MarkdownWithSources
@@ -278,7 +297,7 @@ describe('MarkdownWithSources', () => {
   });
 
   it('should preserve links around inline sources', () => {
-    const content = 'Read [the docs](https://example.com) and see {{SOURCE_0}} for details.';
+    const content = 'Read [the docs](https://example.com) and see [segment 5] for details.';
 
     render(
       <MarkdownWithSources
@@ -300,7 +319,7 @@ describe('MarkdownWithSources', () => {
 
   it('should preserve formatting when source is inside bold text', () => {
     // Edge case: source marker directly inside bold
-    const content = '**Bold with source {{SOURCE_0}} inside.**';
+    const content = '**Bold with source [segment 5] inside.**';
 
     render(
       <MarkdownWithSources

--- a/src/components/viewer/MarkdownWithSources.tsx
+++ b/src/components/viewer/MarkdownWithSources.tsx
@@ -27,6 +27,7 @@ import { TimestampLink } from './TimestampLink';
 import { Speaker } from '@/config/types';
 
 export interface TimestampSource {
+  segmentIndex: number;
   segmentId: string;
   startMs: number;
   speaker?: string;
@@ -52,31 +53,58 @@ export interface MarkdownWithSourcesProps {
 }
 
 interface ProcessedContent {
-  /** Content with {{SOURCE_n}} replaced by unique markers */
+  /** Content with [segment N] replaced by unique markers */
   processedContent: string;
-  /** Set of source indices that were consumed */
-  consumedIndices: Set<number>;
+  /** Set of segment indices that were consumed (matched to sources) */
+  consumedSegmentIndices: Set<number>;
+}
+
+/**
+ * Expand comma-separated segment lists into individual references.
+ * e.g. "[segment 3, segment 4, segment 9]" -> "[segment 3] [segment 4] [segment 9]"
+ *
+ * LLMs sometimes output grouped citations - this normalizes them for parsing.
+ */
+function expandSegmentLists(content: string): string {
+  // Match [segment N, segment M, ...] patterns (comma-separated)
+  const listPattern = /\[segment\s+\d+(?:\s*,\s*segment\s+\d+)+\]/gi;
+
+  return content.replace(listPattern, (match) => {
+    const numbers = match.match(/\d+/g);
+    if (numbers) {
+      return numbers.map(n => `[segment ${n}]`).join(' ');
+    }
+    return match;
+  });
 }
 
 /**
  * Pre-process content to track which sources are used inline.
- * Replaces {{SOURCE_n}} with §§SOURCE_n§§ markers (markdown won't process §).
+ * Replaces [segment N] with §§SEGMENT_n§§ markers (markdown won't process §).
+ * Uses segmentIndex to match sources, not array position.
  */
-function preprocessContent(content: string, sourcesCount: number): ProcessedContent {
-  const consumedIndices = new Set<number>();
-  const sourcePattern = /\{\{SOURCE_(\d+)\}\}/g;
+function preprocessContent(content: string, sources: TimestampSource[]): ProcessedContent {
+  const consumedSegmentIndices = new Set<number>();
+  // Build a set of valid segment indices from sources
+  const validSegmentIndices = new Set(sources.map(s => s.segmentIndex));
 
-  const processedContent = content.replace(sourcePattern, (match, indexStr) => {
-    const index = parseInt(indexStr, 10);
-    if (index >= 0 && index < sourcesCount) {
-      consumedIndices.add(index);
-      return `§§SOURCE_${index}§§`;
+  // First expand comma-separated lists: [segment 3, segment 4] -> [segment 3] [segment 4]
+  const expandedContent = expandSegmentLists(content);
+
+  // Pattern matches [segment N] or [Segment N] (case insensitive)
+  const segmentPattern = /\[segment\s+(\d+)\]/gi;
+
+  const processedContent = expandedContent.replace(segmentPattern, (match, indexStr) => {
+    const segmentIndex = parseInt(indexStr, 10);
+    if (validSegmentIndices.has(segmentIndex)) {
+      consumedSegmentIndices.add(segmentIndex);
+      return `§§SEGMENT_${segmentIndex}§§`;
     }
-    // Out of range - replace with placeholder text
-    return '[Source unavailable]';
+    // Segment not in sources - leave as-is (might be invalid citation)
+    return match;
   });
 
-  return { processedContent, consumedIndices };
+  return { processedContent, consumedSegmentIndices };
 }
 
 /**
@@ -84,7 +112,8 @@ function preprocessContent(content: string, sourcesCount: number): ProcessedCont
  * Avoids prop drilling while keeping the transform function pure-ish.
  */
 interface SourceContext {
-  sources: TimestampSource[];
+  /** Map from segment index to source data */
+  sourcesByIndex: Map<number, TimestampSource>;
   speakers: Record<string, Speaker>;
   conversationId: string;
   onSeek?: (timeMs: number) => void;
@@ -93,12 +122,12 @@ interface SourceContext {
 }
 
 /**
- * Recursively transform React children, replacing §§SOURCE_n§§ markers
+ * Recursively transform React children, replacing §§SEGMENT_n§§ markers
  * in text nodes with TimestampLink components while preserving the
  * structure of other elements (bold, links, etc.).
  *
  * The magic here: we only touch text nodes. Everything else passes through
- * unchanged, so <strong>bold text {{SOURCE_0}}</strong> becomes
+ * unchanged, so <strong>bold text [segment 5]</strong> becomes
  * <strong>bold text <TimestampLink/></strong> instead of losing the bold.
  */
 function transformChildren(
@@ -112,7 +141,7 @@ function transformChildren(
 
   // Plain string - split by markers and replace
   if (typeof children === 'string') {
-    if (!children.includes('§§SOURCE_')) {
+    if (!children.includes('§§SEGMENT_')) {
       return children;
     }
     return splitAndReplace(children, ctx, keyPrefix);
@@ -148,7 +177,7 @@ function transformChildren(
 }
 
 /**
- * Split a text string by §§SOURCE_n§§ markers and return an array
+ * Split a text string by §§SEGMENT_n§§ markers and return an array
  * of text fragments and TimestampLink components.
  */
 function splitAndReplace(
@@ -156,15 +185,16 @@ function splitAndReplace(
   ctx: SourceContext,
   keyPrefix: string
 ): React.ReactNode[] {
-  const parts = text.split(/(§§SOURCE_\d+§§)/);
+  const parts = text.split(/(§§SEGMENT_\d+§§)/);
 
   return parts.map((part, idx) => {
-    const sourceMatch = part.match(/^§§SOURCE_(\d+)§§$/);
-    if (sourceMatch) {
-      const sourceIdx = parseInt(sourceMatch[1], 10);
-      const source = ctx.sources[sourceIdx];
+    const segmentMatch = part.match(/^§§SEGMENT_(\d+)§§$/);
+    if (segmentMatch) {
+      const segmentIndex = parseInt(segmentMatch[1], 10);
+      const source = ctx.sourcesByIndex.get(segmentIndex);
       if (!source) {
-        return <span key={`${keyPrefix}-src-${idx}`}>[Source unavailable]</span>;
+        // This shouldn't happen if preprocessContent worked correctly
+        return <span key={`${keyPrefix}-seg-${idx}`}>[segment {segmentIndex}]</span>;
       }
 
       const speaker = source.speaker ? ctx.speakers[source.speaker] : null;
@@ -172,7 +202,7 @@ function splitAndReplace(
 
       return (
         <TimestampLink
-          key={`${keyPrefix}-src-${idx}`}
+          key={`${keyPrefix}-seg-${idx}`}
           segmentId={source.segmentId}
           startMs={source.startMs}
           speakerName={speakerName}
@@ -204,20 +234,29 @@ export const MarkdownWithSources: React.FC<MarkdownWithSourcesProps> = ({
   onHighlight,
   onUnconsumedSources
 }) => {
-  const { processedContent, consumedIndices } = useMemo(
-    () => preprocessContent(content, sources.length),
-    [content, sources.length]
+  // Build map from segment index to source for O(1) lookup
+  const sourcesByIndex = useMemo(() => {
+    const map = new Map<number, TimestampSource>();
+    for (const source of sources) {
+      map.set(source.segmentIndex, source);
+    }
+    return map;
+  }, [sources]);
+
+  const { processedContent, consumedSegmentIndices } = useMemo(
+    () => preprocessContent(content, sources),
+    [content, sources]
   );
 
   // Build source context once for the transform function
   const sourceCtx: SourceContext = useMemo(() => ({
-    sources,
+    sourcesByIndex,
     speakers,
     conversationId,
     onSeek,
     onPlay,
     onHighlight
-  }), [sources, speakers, conversationId, onSeek, onPlay, onHighlight]);
+  }), [sourcesByIndex, speakers, conversationId, onSeek, onPlay, onHighlight]);
 
   // Custom component renderers for markdown elements
   // Uses transformChildren to preserve formatting while replacing source markers
@@ -362,14 +401,23 @@ export const MarkdownWithSources: React.FC<MarkdownWithSourcesProps> = ({
   }), [sourceCtx]);
 
   // Calculate unconsumed sources and notify parent via callback
+  // Filter sources whose segmentIndex wasn't referenced in the content
   const unconsumedSources = useMemo(() => {
-    return sources.filter((_, idx) => !consumedIndices.has(idx));
-  }, [sources, consumedIndices]);
+    return sources.filter(s => !consumedSegmentIndices.has(s.segmentIndex));
+  }, [sources, consumedSegmentIndices]);
 
-  // Notify parent component of unconsumed sources
+  // Track previous unconsumed sources to avoid infinite loops
+  const prevUnconsumedRef = React.useRef<string>('');
+
+  // Notify parent component of unconsumed sources (only when actually changed)
   React.useEffect(() => {
     if (onUnconsumedSources) {
-      onUnconsumedSources(unconsumedSources);
+      // Compare by stringified value to detect actual changes
+      const currentKey = JSON.stringify(unconsumedSources.map(s => s.segmentId));
+      if (currentKey !== prevUnconsumedRef.current) {
+        prevUnconsumedRef.current = currentKey;
+        onUnconsumedSources(unconsumedSources);
+      }
     }
   }, [unconsumedSources, onUnconsumedSources]);
 

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -138,16 +138,15 @@ export function useChat({ conversationId, messageCount, messages = [] }: UseChat
       const response = await sendChatMessage(conversationId, message);
 
       // Convert chatService sources to chatHistoryService format
-      // Backend returns validated sources with speaker (not speakerId)
-      const sources: TimestampSource[] = response.sources
-        .filter(s => s.segmentId && s.startMs !== undefined && s.endMs !== undefined)
-        .map(s => ({
-          segmentId: s.segmentId!,
-          startMs: s.startMs!,
-          endMs: s.endMs!,
-          speaker: s.speaker || 'Unknown',
-          text: s.text || '' // Backend includes text; fallback if missing
-        }));
+      // Backend returns validated sources with all required fields
+      const sources: TimestampSource[] = response.sources.map(s => ({
+        segmentIndex: s.segmentIndex,
+        segmentId: s.segmentId,
+        startMs: s.startMs,
+        endMs: s.endMs,
+        speaker: s.speaker,
+        text: s.text
+      }));
 
       // Add assistant response to Firestore
       const assistantMessageId = await chatHistoryService.addMessage(conversationId, {

--- a/src/services/chatHistoryService.ts
+++ b/src/services/chatHistoryService.ts
@@ -22,6 +22,7 @@ import { db } from '@/config/firebase-config';
  * Chat message timestamp source - links to transcript segment
  */
 export interface TimestampSource {
+  segmentIndex: number;
   segmentId: string;
   startMs: number;
   endMs: number;

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -17,12 +17,12 @@ import { functions } from '@/config/firebase-config';
  */
 export interface TimestampSource {
   segmentIndex: number;
-  segmentId?: string;
-  startMs?: number;
-  endMs?: number;
-  speaker?: string;
-  text?: string;
-  confidence?: 'high' | 'medium' | 'low';
+  segmentId: string;
+  startMs: number;
+  endMs: number;
+  speaker: string;
+  text: string;
+  confidence: 'high' | 'medium' | 'low';
 }
 
 /**


### PR DESCRIPTION
## Release v2.4.0

### Added
- **Chat Rate Limit Resilience** - Vertex AI calls now retry automatically with exponential backoff
  - Handles 429 (RESOURCE_EXHAUSTED), 503 (UNAVAILABLE), and DEADLINE_EXCEEDED errors
  - Up to 3 retries with 3-second base delay, prevents intermittent chat failures

### Changed
- **Upgraded Chat Model** - Switched from experimental `gemini-2.0-flash-exp` to stable `gemini-2.5-flash`
  - More consistent behavior and reduced rate limiting issues
- **Simplified Citation System** - Chat now uses direct `[segment N]` citation format
  - Replaced complex dual-format system (`[Segment N]` + `{{SOURCE_n}}` placeholders)
  - More resilient to LLM output variations
  - Citations render reliably as clickable timestamp buttons

### Fixed
- **Comma-Separated Citations** - LLM sometimes outputs `[segment 3, segment 4, segment 9]`
  - These grouped citations now auto-expand and render as individual timestamp buttons
  - Previously showed as plain text or in "Additional sources" section

## Files Changed
- `functions/src/chat.ts` - Retry logic, model upgrade
- `functions/src/utils/promptBuilder.ts` - Simplified prompt
- `functions/src/utils/timestampValidation.ts` - Added segmentIndex
- `src/components/viewer/MarkdownWithSources.tsx` - [segment N] parsing with comma-list expansion
- Type updates in chatService, chatHistoryService, useChat

---
Tag: `v2.4.0`
Build: `11`