### PR TITLE
feat(speaker-reconciliation): add quality-weighted embedding similarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Quality-Weighted Speaker Reconciliation** - Speaker matching across chunks now considers audio quality signals
+  - Embedding similarity weighted by composite quality score: `cosine * sqrt(quality_A * quality_B)`
+  - Quality derived from WhisperX word confidence, timing consistency, and speaker overlap detection
+  - Low-quality speakers (< 0.3 threshold) excluded from reconciliation graph to prevent false merges
+  - Reduces speaker misidentification in noisy audio or sections with overlapping speech
+
 ## [2.5.0] - 2026-01-19
 
 ### Added

--- a/docs/reference/cloud-functions-flow.md
+++ b/docs/reference/cloud-functions-flow.md
@@ -10,7 +10,7 @@ The application uses **10 Cloud Functions** to handle audio processing, chat, an
 |----------|---------|--------|---------|---------|
 | `transcribeAudio` | Storage `onObjectFinalized` | 2GiB | 9 min | Entry point for uploads, chunks large files |
 | `processTranscription` | Cloud Tasks HTTP | 2GiB | 60 min | Process each chunk via Gemini + WhisperX |
-| `processMerge` | Cloud Tasks HTTP | 512MiB | 10 min | Stitch chunks, reconcile speakers |
+| `processMerge` | Cloud Tasks HTTP | 1GiB | 10 min | Stitch chunks, reconcile speakers |
 | `processReprocessing` | Cloud Tasks HTTP | 512MiB | 10 min | Fallback: re-chunk in sequential mode |
 | `chatWithConversation` | HTTPS Callable | 512MiB | 10 min | LLM chat with timestamp citations |
 | `retryTranscription` | HTTPS Callable | 512MiB | 60 sec | Resume or restart failed jobs |

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -50,11 +50,11 @@
       ]
     },
     {
-      "collectionGroup": "_userEvents",
+      "collectionGroup": "_user_events",
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "userId", "order": "ASCENDING" },
-        { "fieldPath": "timestamp", "order": "DESCENDING" }
+        { "fieldPath": "timestamp", "order": "ASCENDING" }
       ]
     }
   ],

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,10 @@
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
-    "logs": "firebase functions:log"
+    "logs": "firebase functions:log",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "engines": {
     "node": "20"

--- a/functions/src/__tests__/speakerQuality.test.ts
+++ b/functions/src/__tests__/speakerQuality.test.ts
@@ -1,0 +1,554 @@
+/**
+ * Tests for Speaker Quality Assessment Module
+ */
+
+import {
+  computeSNRProxy,
+  computeClarityScore,
+  detectOverlapContamination,
+  computeCompositeQuality,
+  computeWeightedSimilarity,
+  computeSpeakerQualityMapFromWhisperXSegments,
+  WhisperXSegmentForQuality,
+} from '../speakerQuality';
+
+describe('computeSNRProxy', () => {
+  it('should return 1.0 for empty confidence array', () => {
+    expect(computeSNRProxy([])).toBe(1.0);
+  });
+
+  it('should compute mean of word confidences', () => {
+    const confidences = [0.9, 0.8, 0.7];
+    const expected = (0.9 + 0.8 + 0.7) / 3;
+    expect(computeSNRProxy(confidences)).toBeCloseTo(expected, 5);
+  });
+
+  it('should handle perfect confidence', () => {
+    const confidences = [1.0, 1.0, 1.0, 1.0];
+    expect(computeSNRProxy(confidences)).toBe(1.0);
+  });
+
+  it('should handle low confidence audio', () => {
+    const confidences = [0.3, 0.2, 0.4, 0.3];
+    const expected = (0.3 + 0.2 + 0.4 + 0.3) / 4;
+    expect(computeSNRProxy(confidences)).toBeCloseTo(expected, 5);
+  });
+
+  it('should handle single word segment', () => {
+    expect(computeSNRProxy([0.85])).toBe(0.85);
+  });
+});
+
+describe('computeClarityScore', () => {
+  it('should return 1.0 for empty timing array', () => {
+    expect(computeClarityScore([], '')).toBe(1.0);
+  });
+
+  it('should give high score to consistent timing with no fillers', () => {
+    const timings = [
+      { start: 0.0, end: 0.5 },
+      { start: 0.55, end: 1.0 },
+      { start: 1.05, end: 1.5 },
+    ];
+    const text = 'Hello there friend';
+    const score = computeClarityScore(timings, text);
+    expect(score).toBeGreaterThan(0.8);
+  });
+
+  it('should penalize timing gaps', () => {
+    const timingsGood = [
+      { start: 0.0, end: 0.5 },
+      { start: 0.55, end: 1.0 },
+    ];
+    const timingsBad = [
+      { start: 0.0, end: 0.5 },
+      { start: 1.0, end: 1.5 }, // 500ms gap
+    ];
+    const text = 'Hello there';
+
+    const scoreGood = computeClarityScore(timingsGood, text);
+    const scoreBad = computeClarityScore(timingsBad, text);
+
+    expect(scoreGood).toBeGreaterThan(scoreBad);
+  });
+
+  it('should penalize filler words', () => {
+    const timings = [
+      { start: 0.0, end: 0.5 },
+      { start: 0.55, end: 1.0 },
+      { start: 1.05, end: 1.5 },
+    ];
+    const textClean = 'I think we should proceed';
+    const textFilled = 'Um like I think basically';
+
+    const scoreClean = computeClarityScore(timings, textClean);
+    const scoreFilled = computeClarityScore(timings, textFilled);
+
+    expect(scoreClean).toBeGreaterThan(scoreFilled);
+  });
+
+  it('should detect multi-word fillers', () => {
+    const timings = [
+      { start: 0.0, end: 0.5 },
+      { start: 0.55, end: 1.0 },
+    ];
+    const text = 'You know I mean sort of';
+    const score = computeClarityScore(timings, text);
+
+    // Should be penalized for multiple multi-word fillers
+    expect(score).toBeLessThan(0.8);
+  });
+
+  it('should be case-insensitive for filler detection', () => {
+    const timings = [{ start: 0.0, end: 0.5 }];
+    const textLower = 'um actually';
+    const textUpper = 'Um Actually';
+
+    const scoreLower = computeClarityScore(timings, textLower);
+    const scoreUpper = computeClarityScore(timings, textUpper);
+
+    expect(scoreLower).toBeCloseTo(scoreUpper, 5);
+  });
+
+  it('should handle punctuation in filler matching', () => {
+    const timings = [{ start: 0.0, end: 0.5 }];
+    const text = 'Um, like, you know.';
+    const score = computeClarityScore(timings, text);
+
+    // Should still detect fillers despite punctuation
+    expect(score).toBeLessThan(0.7);
+  });
+});
+
+describe('detectOverlapContamination', () => {
+  it('should return false for empty transitions', () => {
+    expect(detectOverlapContamination([])).toBe(false);
+  });
+
+  it('should return false for few transitions', () => {
+    const transitions = [
+      { timeMs: 0 },
+      { timeMs: 5000 },
+    ];
+    expect(detectOverlapContamination(transitions)).toBe(false);
+  });
+
+  it('should detect excessive transitions in 10-second window', () => {
+    // More than 2 transitions in 10 seconds = contaminated
+    const transitions = [
+      { timeMs: 0 },
+      { timeMs: 2000 },
+      { timeMs: 4000 },
+      { timeMs: 6000 }, // 4 transitions in 6 seconds
+    ];
+    expect(detectOverlapContamination(transitions)).toBe(true);
+  });
+
+  it('should not flag well-spaced transitions', () => {
+    const transitions = [
+      { timeMs: 0 },
+      { timeMs: 15000 },
+      { timeMs: 30000 },
+    ];
+    expect(detectOverlapContamination(transitions)).toBe(false);
+  });
+
+  it('should detect contamination in middle of segment', () => {
+    const transitions = [
+      { timeMs: 0 },
+      { timeMs: 20000 }, // Fine spacing
+      { timeMs: 25000 }, // Cluster starts here
+      { timeMs: 27000 },
+      { timeMs: 29000 }, // 3 transitions in 4 seconds
+    ];
+    expect(detectOverlapContamination(transitions)).toBe(true);
+  });
+
+  it('should handle unsorted transitions', () => {
+    const transitions = [
+      { timeMs: 6000 },
+      { timeMs: 0 },
+      { timeMs: 4000 },
+      { timeMs: 2000 },
+    ];
+    // Should sort internally and detect contamination
+    expect(detectOverlapContamination(transitions)).toBe(true);
+  });
+
+  it('should allow exactly 2 transitions per window', () => {
+    const transitions = [
+      { timeMs: 0 },
+      { timeMs: 5000 },
+      { timeMs: 20000 }, // New window
+    ];
+    expect(detectOverlapContamination(transitions)).toBe(false);
+  });
+});
+
+describe('computeCompositeQuality', () => {
+  it('should use weighted formula correctly', () => {
+    const snr = 0.8;
+    const clarity = 0.7;
+    const isContaminated = false;
+
+    const expected = (0.4 * snr) + (0.3 * clarity) + (0.3 * 1);
+    const result = computeCompositeQuality(snr, clarity, isContaminated);
+
+    expect(result).toBeCloseTo(expected, 5);
+  });
+
+  it('should penalize contaminated segments', () => {
+    const snr = 0.9;
+    const clarity = 0.8;
+
+    const clean = computeCompositeQuality(snr, clarity, false);
+    const contaminated = computeCompositeQuality(snr, clarity, true);
+
+    expect(contaminated).toBeLessThan(clean);
+    expect(contaminated - clean).toBeCloseTo(-0.3, 5); // 0.3 penalty
+  });
+
+  it('should clamp result to [0, 1] range', () => {
+    // Edge case: all zeros
+    expect(computeCompositeQuality(0, 0, true)).toBeGreaterThanOrEqual(0);
+    expect(computeCompositeQuality(0, 0, true)).toBeLessThanOrEqual(1);
+
+    // Edge case: all ones
+    expect(computeCompositeQuality(1, 1, false)).toBeGreaterThanOrEqual(0);
+    expect(computeCompositeQuality(1, 1, false)).toBeLessThanOrEqual(1);
+  });
+
+  it('should give perfect score for perfect inputs', () => {
+    const result = computeCompositeQuality(1.0, 1.0, false);
+    expect(result).toBe(1.0);
+  });
+
+  it('should weight SNR most heavily', () => {
+    // High SNR, low others
+    const highSNR = computeCompositeQuality(1.0, 0.5, true);
+    // Low SNR, high others
+    const lowSNR = computeCompositeQuality(0.5, 1.0, false);
+
+    // SNR has 0.4 weight, so high SNR should score better despite contamination
+    expect(highSNR).toBeCloseTo(0.4 + 0.15 + 0, 5);
+    expect(lowSNR).toBeCloseTo(0.2 + 0.3 + 0.3, 5);
+    expect(lowSNR).toBeGreaterThan(highSNR); // In this case, other factors win
+  });
+});
+
+describe('computeWeightedSimilarity', () => {
+  it('should not modify similarity when both qualities are perfect', () => {
+    const cosine = 0.85;
+    const result = computeWeightedSimilarity(cosine, 1.0, 1.0);
+    expect(result).toBe(cosine);
+  });
+
+  it('should attenuate similarity when one quality is low', () => {
+    const cosine = 0.9;
+    const highQuality = computeWeightedSimilarity(cosine, 1.0, 1.0);
+    const lowQuality = computeWeightedSimilarity(cosine, 1.0, 0.5);
+
+    expect(lowQuality).toBeLessThan(highQuality);
+  });
+
+  it('should use geometric mean of qualities', () => {
+    const cosine = 0.8;
+    const qualityA = 0.9;
+    const qualityB = 0.7;
+
+    const expected = cosine * Math.sqrt(qualityA * qualityB);
+    const result = computeWeightedSimilarity(cosine, qualityA, qualityB);
+
+    expect(result).toBeCloseTo(expected, 5);
+  });
+
+  it('should heavily penalize if both qualities are low', () => {
+    const cosine = 0.95; // High similarity
+    const result = computeWeightedSimilarity(cosine, 0.3, 0.3);
+
+    // sqrt(0.3 * 0.3) = 0.3, so result should be 0.95 * 0.3 = 0.285
+    expect(result).toBeCloseTo(0.285, 5);
+    expect(result).toBeLessThan(0.5); // Significantly reduced
+  });
+
+  it('should handle zero quality', () => {
+    const cosine = 0.8;
+    const result = computeWeightedSimilarity(cosine, 0.0, 1.0);
+
+    // sqrt(0 * 1) = 0
+    expect(result).toBe(0);
+  });
+
+  it('should be symmetric in quality arguments', () => {
+    const cosine = 0.7;
+    const result1 = computeWeightedSimilarity(cosine, 0.6, 0.8);
+    const result2 = computeWeightedSimilarity(cosine, 0.8, 0.6);
+
+    expect(result1).toBeCloseTo(result2, 5);
+  });
+
+  it('should preserve negative similarities', () => {
+    // Cosine can be negative for very dissimilar vectors
+    const cosine = -0.5;
+    const result = computeWeightedSimilarity(cosine, 0.8, 0.8);
+
+    expect(result).toBeLessThan(0);
+    expect(result).toBeCloseTo(-0.5 * 0.8, 5);
+  });
+});
+
+describe('Integration: Quality Floor Filtering', () => {
+  it('should exclude segments below quality floor (0.3)', () => {
+    // Segment with composite quality < 0.3
+    const snr = 0.2;
+    const clarity = 0.3;
+    const isContaminated = true;
+
+    const quality = computeCompositeQuality(snr, clarity, isContaminated);
+
+    expect(quality).toBeLessThan(0.3);
+    // This segment should be excluded from reconciliation
+  });
+
+  it('should include segments at or above quality floor', () => {
+    const snr = 0.5;
+    const clarity = 0.5;
+    const isContaminated = false;
+
+    const quality = computeCompositeQuality(snr, clarity, isContaminated);
+
+    expect(quality).toBeGreaterThanOrEqual(0.3);
+    // This segment should be included in reconciliation
+  });
+
+  it('should handle edge case at exactly 0.3', () => {
+    // Construct inputs that yield exactly 0.3
+    // 0.4*snr + 0.3*clarity + 0.3*overlap = 0.3
+    // If snr=0.5, clarity=0.5, contaminated=true:
+    // 0.4*0.5 + 0.3*0.5 + 0.3*0 = 0.2 + 0.15 + 0 = 0.35 (above floor)
+
+    // If snr=0.25, clarity=0.5, contaminated=true:
+    // 0.4*0.25 + 0.3*0.5 + 0.3*0 = 0.1 + 0.15 + 0 = 0.25 (below floor)
+
+    const aboveFloor = computeCompositeQuality(0.5, 0.5, true);
+    const belowFloor = computeCompositeQuality(0.25, 0.5, true);
+
+    expect(aboveFloor).toBeGreaterThan(0.3);
+    expect(belowFloor).toBeLessThan(0.3);
+  });
+});
+
+describe('computeSpeakerQualityMapFromWhisperXSegments', () => {
+  it('should return empty map for empty segments', () => {
+    const result = computeSpeakerQualityMapFromWhisperXSegments([]);
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it('should compute quality for single speaker with word scores', () => {
+    const segments: WhisperXSegmentForQuality[] = [
+      {
+        text: 'Hello world',
+        start: 0,
+        end: 2,
+        speaker: 'SPEAKER_00',
+        words: [
+          { word: 'Hello', start: 0, end: 0.5, score: 0.9 },
+          { word: 'world', start: 0.6, end: 1.0, score: 0.85 },
+        ],
+      },
+    ];
+
+    const result = computeSpeakerQualityMapFromWhisperXSegments(segments);
+
+    expect(result).toHaveProperty('SPEAKER_00');
+    expect(result['SPEAKER_00'].snrProxy).toBeCloseTo((0.9 + 0.85) / 2, 3);
+    expect(result['SPEAKER_00'].compositeScore).toBeGreaterThan(0);
+    expect(result['SPEAKER_00'].isContaminated).toBe(false);
+  });
+
+  it('should aggregate across multiple segments for same speaker', () => {
+    const segments: WhisperXSegmentForQuality[] = [
+      {
+        text: 'First part',
+        start: 0,
+        end: 1,
+        speaker: 'SPEAKER_00',
+        words: [
+          { word: 'First', start: 0, end: 0.4, score: 0.8 },
+          { word: 'part', start: 0.5, end: 1.0, score: 0.8 },
+        ],
+      },
+      {
+        text: 'Second part',
+        start: 5,
+        end: 6,
+        speaker: 'SPEAKER_00',
+        words: [
+          { word: 'Second', start: 5, end: 5.4, score: 0.9 },
+          { word: 'part', start: 5.5, end: 6.0, score: 0.9 },
+        ],
+      },
+    ];
+
+    const result = computeSpeakerQualityMapFromWhisperXSegments(segments);
+
+    expect(result).toHaveProperty('SPEAKER_00');
+    // SNR should be mean of all 4 word scores
+    expect(result['SPEAKER_00'].snrProxy).toBeCloseTo((0.8 + 0.8 + 0.9 + 0.9) / 4, 3);
+  });
+
+  it('should compute separate quality for multiple speakers', () => {
+    const segments: WhisperXSegmentForQuality[] = [
+      {
+        text: 'Speaker one talks',
+        start: 0,
+        end: 2,
+        speaker: 'SPEAKER_00',
+        words: [
+          { word: 'Speaker', start: 0, end: 0.4, score: 0.95 },
+          { word: 'one', start: 0.5, end: 0.8, score: 0.95 },
+          { word: 'talks', start: 0.9, end: 1.2, score: 0.95 },
+        ],
+      },
+      {
+        text: 'Speaker two mumbles um like',
+        start: 3,
+        end: 5,
+        speaker: 'SPEAKER_01',
+        words: [
+          { word: 'Speaker', start: 3, end: 3.3, score: 0.4 },
+          { word: 'two', start: 3.4, end: 3.6, score: 0.4 },
+          { word: 'mumbles', start: 3.7, end: 4.0, score: 0.3 },
+          { word: 'um', start: 4.1, end: 4.2, score: 0.3 },
+          { word: 'like', start: 4.3, end: 4.5, score: 0.3 },
+        ],
+      },
+    ];
+
+    const result = computeSpeakerQualityMapFromWhisperXSegments(segments);
+
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result).toHaveProperty('SPEAKER_00');
+    expect(result).toHaveProperty('SPEAKER_01');
+
+    // SPEAKER_00 should have higher quality (high scores, no fillers)
+    expect(result['SPEAKER_00'].snrProxy).toBeGreaterThan(result['SPEAKER_01'].snrProxy);
+    expect(result['SPEAKER_00'].compositeScore).toBeGreaterThan(result['SPEAKER_01'].compositeScore);
+  });
+
+  it('should detect overlap contamination from rapid speaker transitions', () => {
+    // Rapid back-and-forth in 10-second window triggers contamination
+    const segments: WhisperXSegmentForQuality[] = [
+      { text: 'A1', start: 0, end: 1, speaker: 'SPEAKER_00' },
+      { text: 'B1', start: 1.5, end: 2.5, speaker: 'SPEAKER_01' },
+      { text: 'A2', start: 3, end: 4, speaker: 'SPEAKER_00' },
+      { text: 'B2', start: 4.5, end: 5.5, speaker: 'SPEAKER_01' },
+      { text: 'A3', start: 6, end: 7, speaker: 'SPEAKER_00' },
+    ];
+
+    const result = computeSpeakerQualityMapFromWhisperXSegments(segments);
+
+    // Both speakers should be marked as contaminated due to rapid transitions
+    expect(result['SPEAKER_00'].isContaminated).toBe(true);
+    expect(result['SPEAKER_01'].isContaminated).toBe(true);
+  });
+
+  it('should handle segments without speaker label', () => {
+    const segments: WhisperXSegmentForQuality[] = [
+      {
+        text: 'Unknown speaker',
+        start: 0,
+        end: 1,
+        // No speaker field
+        words: [
+          { word: 'Unknown', start: 0, end: 0.4, score: 0.7 },
+          { word: 'speaker', start: 0.5, end: 1.0, score: 0.7 },
+        ],
+      },
+    ];
+
+    const result = computeSpeakerQualityMapFromWhisperXSegments(segments);
+
+    expect(result).toHaveProperty('UNKNOWN');
+    expect(result['UNKNOWN'].snrProxy).toBeCloseTo(0.7, 3);
+  });
+
+  it('should handle segments without word scores (default to 1.0)', () => {
+    const segments: WhisperXSegmentForQuality[] = [
+      {
+        text: 'No word scores here',
+        start: 0,
+        end: 1,
+        speaker: 'SPEAKER_00',
+        words: [
+          { word: 'No', start: 0, end: 0.2 },  // No score field
+          { word: 'word', start: 0.25, end: 0.4 },
+          { word: 'scores', start: 0.45, end: 0.6 },
+          { word: 'here', start: 0.65, end: 0.8 },
+        ],
+      },
+    ];
+
+    const result = computeSpeakerQualityMapFromWhisperXSegments(segments);
+
+    // Without word scores, SNR defaults to 1.0 (computeSNRProxy returns 1.0 for empty array)
+    expect(result['SPEAKER_00'].snrProxy).toBe(1.0);
+  });
+
+  it('should apply locked composite formula correctly', () => {
+    // Construct a scenario where we can predict the composite score
+    // Clean speaker with high confidence words
+    const segments: WhisperXSegmentForQuality[] = [
+      {
+        text: 'Perfect audio quality here',
+        start: 0,
+        end: 2,
+        speaker: 'SPEAKER_00',
+        words: [
+          { word: 'Perfect', start: 0, end: 0.4, score: 1.0 },
+          { word: 'audio', start: 0.45, end: 0.8, score: 1.0 },
+          { word: 'quality', start: 0.85, end: 1.2, score: 1.0 },
+          { word: 'here', start: 1.25, end: 1.5, score: 1.0 },
+        ],
+      },
+    ];
+
+    const result = computeSpeakerQualityMapFromWhisperXSegments(segments);
+
+    // SNR = 1.0 (all perfect scores)
+    // Clarity = high (no gaps, no fillers)
+    // Contamination = false (single speaker)
+    // Formula: 0.4*snr + 0.3*clarity + 0.3*(1-overlap)
+    // With all perfect: 0.4*1 + 0.3*1 + 0.3*1 = 1.0
+    expect(result['SPEAKER_00'].compositeScore).toBeCloseTo(1.0, 1);
+    expect(result['SPEAKER_00'].isContaminated).toBe(false);
+  });
+
+  it('should produce low quality for noisy audio with fillers', () => {
+    const segments: WhisperXSegmentForQuality[] = [
+      {
+        text: 'Um like basically you know',
+        start: 0,
+        end: 3,
+        speaker: 'SPEAKER_00',
+        words: [
+          { word: 'Um', start: 0, end: 0.3, score: 0.3 },
+          { word: 'like', start: 0.5, end: 0.8, score: 0.35 },
+          { word: 'basically', start: 1.2, end: 1.8, score: 0.25 },  // Gap before this
+          { word: 'you', start: 2.3, end: 2.5, score: 0.3 },         // Another gap
+          { word: 'know', start: 2.6, end: 2.9, score: 0.3 },
+        ],
+      },
+    ];
+
+    const result = computeSpeakerQualityMapFromWhisperXSegments(segments);
+
+    // Low SNR from poor word scores
+    expect(result['SPEAKER_00'].snrProxy).toBeLessThan(0.4);
+    // Low clarity from gaps and fillers
+    expect(result['SPEAKER_00'].clarityScore).toBeLessThan(0.7);
+    // Composite should be below high quality threshold (0.7)
+    // With SNR ~0.3, clarity ~0.5, no contamination: 0.4*0.3 + 0.3*0.5 + 0.3*1 = 0.12 + 0.15 + 0.3 = 0.57
+    expect(result['SPEAKER_00'].compositeScore).toBeLessThan(0.6);
+  });
+});

--- a/functions/src/__tests__/speakerQualityIntegration.test.ts
+++ b/functions/src/__tests__/speakerQualityIntegration.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Integration tests for quality-weighted speaker reconciliation
+ */
+
+import { reconcileSpeakersWithEmbeddings } from '../speakerReconciliationEmbeddings';
+import { ChunkArtifact, SpeakerQuality } from '../types';
+
+describe('Quality-Weighted Speaker Reconciliation Integration', () => {
+  // Helper to create a minimal chunk artifact with embeddings and quality
+  function createChunkArtifact(
+    chunkIndex: number,
+    speakers: Array<{ id: string; embedding: number[]; quality: number }>
+  ): ChunkArtifact {
+    const artifact: ChunkArtifact = {
+      conversationId: 'test-conversation',
+      userId: 'test-user',
+      chunkIndex,
+      totalChunks: 2,
+      segments: [],
+      speakers: {},
+      terms: {},
+      termOccurrences: [],
+      topics: [],
+      people: [],
+      chunkBounds: {
+        startMs: chunkIndex * 60000,
+        endMs: (chunkIndex + 1) * 60000,
+        overlapBeforeMs: 0,
+        overlapAfterMs: 0,
+      },
+      emittedContext: {
+        emittedByChunkIndex: chunkIndex,
+        speakerMap: [],
+        previousSummary: '',
+        knownTermIds: [],
+        knownTopicIds: [],
+        knownPersonIds: [],
+        cumulativeSegmentCount: 0,
+        lastProcessedMs: (chunkIndex + 1) * 60000,
+      },
+      createdAt: new Date().toISOString(),
+      storagePath: `test/chunk${chunkIndex}.mp3`,
+      speakerEmbeddings: {},
+      speakerQuality: {},
+    };
+
+    // Add speakers with embeddings and quality
+    for (const speaker of speakers) {
+      artifact.speakerEmbeddings![speaker.id] = speaker.embedding;
+
+      // Construct SpeakerQuality based on composite score
+      const quality: SpeakerQuality = {
+        snrProxy: speaker.quality,
+        clarityScore: speaker.quality,
+        isContaminated: speaker.quality < 0.5,
+        compositeScore: speaker.quality,
+      };
+      artifact.speakerQuality![speaker.id] = quality;
+    }
+
+    return artifact;
+  }
+
+  // Helper to create a normalized embedding vector
+  function createEmbedding(values: number[]): number[] {
+    // Pad to 256 dimensions if needed
+    const padded = [...values];
+    while (padded.length < 256) {
+      padded.push(0);
+    }
+    // Normalize to unit length
+    const norm = Math.sqrt(padded.reduce((sum, v) => sum + v * v, 0));
+    return padded.map(v => v / norm);
+  }
+
+  it('should exclude low-quality segments below quality floor (0.3)', () => {
+    const chunk0 = createChunkArtifact(0, [
+      {
+        id: 'SPEAKER_00',
+        embedding: createEmbedding([1, 0.5, 0.3]), // High-quality speaker
+        quality: 0.8,
+      },
+    ]);
+
+    const chunk1 = createChunkArtifact(1, [
+      {
+        id: 'SPEAKER_00',
+        embedding: createEmbedding([1, 0.5, 0.3]), // Same speaker
+        quality: 0.2, // Below quality floor (0.3)
+      },
+    ]);
+
+    const result = reconcileSpeakersWithEmbeddings([chunk0, chunk1]);
+
+    // The low-quality speaker in chunk1 should be excluded
+    // Only chunk0's speaker should be in the result
+    expect(result.speakerIdMap.size).toBe(1);
+    expect(result.speakerIdMap.has('SPEAKER_00_chunk0')).toBe(true);
+    expect(result.speakerIdMap.has('SPEAKER_00_chunk1')).toBe(false);
+  });
+
+  it('should weight similarity by quality scores', () => {
+    // Create two speakers with identical embeddings but different quality
+    const embedding = createEmbedding([1, 0, 0]);
+
+    const chunk0 = createChunkArtifact(0, [
+      { id: 'SPEAKER_00', embedding, quality: 1.0 }, // Perfect quality
+    ]);
+
+    const chunk1 = createChunkArtifact(1, [
+      { id: 'SPEAKER_00', embedding, quality: 0.5 }, // Medium quality
+    ]);
+
+    const result = reconcileSpeakersWithEmbeddings([chunk0, chunk1]);
+
+    // Despite identical embeddings, quality weighting affects cluster confidence
+    // Both speakers should still be merged (cosine=1.0, weighted=0.707)
+    expect(result.speakerIdMap.size).toBe(2);
+
+    // Both should map to same canonical ID
+    const canonical0 = result.speakerIdMap.get('SPEAKER_00_chunk0');
+    const canonical1 = result.speakerIdMap.get('SPEAKER_00_chunk1');
+    expect(canonical0).toBe(canonical1);
+
+    // Cluster confidence should reflect quality weighting
+    // sqrt(1.0 * 0.5) = 0.707, so weighted similarity = 1.0 * 0.707 = 0.707
+    expect(result.clusterDetails).toHaveLength(1);
+    expect(result.clusterDetails[0].confidence).toBeCloseTo(0.707, 2);
+  });
+
+  it('should prevent false merges when quality is low', () => {
+    // Two different speakers with somewhat similar embeddings
+    const embedding1 = createEmbedding([1, 0.2, 0]);
+    const embedding2 = createEmbedding([0.9, 0.3, 0.1]);
+
+    const chunk0 = createChunkArtifact(0, [
+      { id: 'SPEAKER_00', embedding: embedding1, quality: 0.4 }, // Low quality
+    ]);
+
+    const chunk1 = createChunkArtifact(1, [
+      { id: 'SPEAKER_00', embedding: embedding2, quality: 0.4 }, // Low quality
+    ]);
+
+    const result = reconcileSpeakersWithEmbeddings([chunk0, chunk1]);
+
+    // With quality weighting, the similarity should be reduced
+    // If unweighted cosine similarity is ~0.85, weighted would be ~0.85 * 0.4 = 0.34
+    // This should fall below the SIMILARITY_THRESHOLD (0.70)
+    expect(result.speakerIdMap.size).toBe(2);
+
+    // Check if they were kept separate or merged
+    const canonical0 = result.speakerIdMap.get('SPEAKER_00_chunk0');
+    const canonical1 = result.speakerIdMap.get('SPEAKER_00_chunk1');
+
+    // They should be kept separate due to quality-weighted similarity < threshold
+    if (canonical0 === canonical1) {
+      // If they merged, confidence should be low
+      expect(result.overallConfidence).toBeLessThan(0.6);
+    } else {
+      // If they stayed separate, we have 2 clusters
+      expect(result.clusterDetails).toHaveLength(2);
+    }
+  });
+
+  it('should handle mix of quality levels gracefully', () => {
+    const embedding = createEmbedding([1, 0, 0]);
+
+    const chunk0 = createChunkArtifact(0, [
+      { id: 'SPEAKER_00', embedding, quality: 1.0 }, // High quality
+      { id: 'SPEAKER_01', embedding: createEmbedding([0, 1, 0]), quality: 0.9 },
+    ]);
+
+    const chunk1 = createChunkArtifact(1, [
+      { id: 'SPEAKER_00', embedding, quality: 0.25 }, // Below floor - excluded
+      { id: 'SPEAKER_01', embedding: createEmbedding([0, 1, 0]), quality: 0.8 },
+    ]);
+
+    const result = reconcileSpeakersWithEmbeddings([chunk0, chunk1]);
+
+    // chunk1 SPEAKER_00 should be excluded (quality 0.25 < 0.3)
+    // chunk0 SPEAKER_00 should be present
+    // Both SPEAKER_01 instances should be merged
+    expect(result.speakerIdMap.size).toBe(3); // chunk0: 2, chunk1: 1
+
+    expect(result.speakerIdMap.has('SPEAKER_00_chunk0')).toBe(true);
+    expect(result.speakerIdMap.has('SPEAKER_00_chunk1')).toBe(false); // Excluded
+
+    // SPEAKER_01 should be merged
+    const speaker01_chunk0 = result.speakerIdMap.get('SPEAKER_01_chunk0');
+    const speaker01_chunk1 = result.speakerIdMap.get('SPEAKER_01_chunk1');
+    expect(speaker01_chunk0).toBe(speaker01_chunk1);
+  });
+
+  it('should work when quality data is missing (backward compatibility)', () => {
+    // Create chunk artifacts without speakerQuality field
+    const chunk0 = createChunkArtifact(0, [
+      { id: 'SPEAKER_00', embedding: createEmbedding([1, 0, 0]), quality: 1.0 },
+    ]);
+    const chunk1 = createChunkArtifact(1, [
+      { id: 'SPEAKER_00', embedding: createEmbedding([1, 0, 0]), quality: 1.0 },
+    ]);
+
+    // Remove quality data to simulate old chunks
+    delete chunk0.speakerQuality;
+    delete chunk1.speakerQuality;
+
+    const result = reconcileSpeakersWithEmbeddings([chunk0, chunk1]);
+
+    // Should default to quality=1.0 and merge successfully
+    expect(result.speakerIdMap.size).toBe(2);
+
+    const canonical0 = result.speakerIdMap.get('SPEAKER_00_chunk0');
+    const canonical1 = result.speakerIdMap.get('SPEAKER_00_chunk1');
+    expect(canonical0).toBe(canonical1);
+  });
+
+  it('should handle empty chunks gracefully', () => {
+    const chunk0 = createChunkArtifact(0, []);
+    const chunk1 = createChunkArtifact(1, [
+      { id: 'SPEAKER_00', embedding: createEmbedding([1, 0, 0]), quality: 0.8 },
+    ]);
+
+    const result = reconcileSpeakersWithEmbeddings([chunk0, chunk1]);
+
+    // Only chunk1's speaker should be present
+    expect(result.speakerIdMap.size).toBe(1);
+    expect(result.speakerIdMap.has('SPEAKER_00_chunk1')).toBe(true);
+  });
+});

--- a/functions/src/alignment.ts
+++ b/functions/src/alignment.ts
@@ -79,6 +79,7 @@ export interface Word {
   start: number;  // seconds
   end: number;    // seconds
   index: number;
+  score?: number; // WhisperX confidence score [0-1], if available
 }
 
 export interface Segment {
@@ -1473,6 +1474,7 @@ export interface WhisperXSegment {
   start: number;  // seconds
   end: number;    // seconds
   speaker?: string;  // May have speaker diarization (e.g., "SPEAKER_00")
+  words?: Word[];    // Word-level alignments with optional confidence scores
 }
 
 /**
@@ -1940,8 +1942,34 @@ function parseWhisperXOutput(output: unknown): {
       const end = typeof segObj.end === 'number' ? segObj.end : 0.0;
       const speaker = typeof segObj.speaker === 'string' ? segObj.speaker : undefined;
 
+      // Parse word-level data if present
+      let words: Word[] | undefined;
+      if (Array.isArray(segObj.words)) {
+        words = [];
+        for (let i = 0; i < segObj.words.length; i++) {
+          const wordObj = segObj.words[i];
+          if (typeof wordObj === 'object' && wordObj !== null) {
+            const w = wordObj as Record<string, unknown>;
+            const word = typeof w.word === 'string' ? w.word : '';
+            const wordStart = typeof w.start === 'number' ? w.start : 0.0;
+            const wordEnd = typeof w.end === 'number' ? w.end : 0.0;
+            const score = typeof w.score === 'number' ? w.score : undefined;
+
+            if (word.trim()) {
+              words.push({
+                word: word.trim(),
+                start: wordStart,
+                end: wordEnd,
+                index: i,
+                score
+              });
+            }
+          }
+        }
+      }
+
       if (text.trim()) {
-        segments.push({ text: text.trim(), start, end, speaker });
+        segments.push({ text: text.trim(), start, end, speaker, words });
       }
     }
   }

--- a/functions/src/chunkMerge.ts
+++ b/functions/src/chunkMerge.ts
@@ -888,7 +888,7 @@ export async function mergeChunks(conversationId: string): Promise<void> {
  */
 export const processMerge = onRequest(
   {
-    memory: '512MiB',
+    memory: '1GiB',  // Increased from 512MiB to reduce fragmentation during speaker reconciliation
     timeoutSeconds: 600, // 10 minutes (merge can be slow for large files)
     region: 'us-central1',
     invoker: 'private' // Only Cloud Tasks can call this

--- a/functions/src/speakerQuality.ts
+++ b/functions/src/speakerQuality.ts
@@ -1,0 +1,320 @@
+/**
+ * Speaker Quality Assessment Module
+ *
+ * Computes quality scores for speaker segments to reduce false merges from
+ * low-quality audio. Quality is computed from WhisperX word-level confidence,
+ * timing consistency, and speaker overlap detection.
+ */
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Common filler words that reduce clarity score */
+const FILLER_WORDS = new Set([
+  'um', 'uh', 'like', 'you know', 'basically', 'actually',
+  'literally', 'sort of', 'kind of', 'i mean'
+]);
+
+/** Window size for overlap contamination detection (milliseconds) */
+const OVERLAP_WINDOW_MS = 10000; // 10 seconds
+
+/** Maximum acceptable speaker transitions per window */
+const MAX_TRANSITIONS_PER_WINDOW = 2;
+
+/** Minimum timing gap that counts as inconsistency (milliseconds) */
+const MIN_TIMING_GAP_MS = 200; // 200ms
+
+// ============================================================================
+// Quality Score Components
+// ============================================================================
+
+/**
+ * Compute SNR proxy from WhisperX word-level confidence scores.
+ * Higher confidence = cleaner audio with less noise.
+ *
+ * @param wordConfidences - Array of word confidence scores [0-1]
+ * @returns Mean confidence as SNR proxy [0-1]
+ */
+export function computeSNRProxy(wordConfidences: number[]): number {
+  if (wordConfidences.length === 0) {
+    // No word scores available - assume neutral quality
+    return 1.0;
+  }
+
+  // Simple mean - Whisper already calibrates confidence to noise levels
+  const sum = wordConfidences.reduce((acc, conf) => acc + conf, 0);
+  return sum / wordConfidences.length;
+}
+
+/**
+ * Compute clarity score from timing consistency and filler word detection.
+ * Inconsistent timing suggests disfluent speech or transcription errors.
+ *
+ * @param wordTimings - Array of word timing objects with start/end in seconds
+ * @param text - Full text of the segment
+ * @returns Clarity score [0-1]
+ */
+export function computeClarityScore(
+  wordTimings: Array<{ start: number; end: number }>,
+  text: string
+): number {
+  if (wordTimings.length === 0) {
+    // No timing data - assume neutral clarity
+    return 1.0;
+  }
+
+  // Component 1: Timing consistency
+  // Count gaps between consecutive words
+  let gapCount = 0;
+  for (let i = 0; i < wordTimings.length - 1; i++) {
+    const gapMs = (wordTimings[i + 1].start - wordTimings[i].end) * 1000;
+    if (gapMs > MIN_TIMING_GAP_MS) {
+      gapCount++;
+    }
+  }
+
+  // Normalize: fewer gaps = higher consistency
+  const timingConsistency = Math.max(0, 1 - (gapCount / wordTimings.length));
+
+  // Component 2: Filler word penalty
+  // Tokenize text (simple whitespace split, case-insensitive)
+  const words = text.toLowerCase().split(/\s+/);
+  let fillerCount = 0;
+
+  for (const word of words) {
+    // Clean punctuation for matching
+    const cleanWord = word.replace(/[.,!?;:]/g, '');
+    if (FILLER_WORDS.has(cleanWord)) {
+      fillerCount++;
+    }
+  }
+
+  // Check for multi-word fillers ("you know", "sort of", etc.)
+  const textLower = text.toLowerCase();
+  for (const filler of FILLER_WORDS) {
+    if (filler.includes(' ')) {
+      // Count occurrences of multi-word filler
+      const regex = new RegExp(filler.replace(/\s+/g, '\\s+'), 'g');
+      const matches = textLower.match(regex);
+      if (matches) {
+        fillerCount += matches.length;
+      }
+    }
+  }
+
+  // Normalize: fewer fillers = higher clarity
+  const fillerPenalty = Math.max(0, 1 - (fillerCount / Math.max(1, words.length)));
+
+  // Combine: equal weight to timing and filler detection
+  return (timingConsistency * 0.5) + (fillerPenalty * 0.5);
+}
+
+/**
+ * Detect overlap contamination from rapid speaker transitions.
+ * Segments with multiple overlapping speakers are unreliable for reconciliation.
+ *
+ * @param speakerTransitions - Array of speaker change timestamps in milliseconds
+ * @returns True if segment has excessive speaker overlap
+ */
+export function detectOverlapContamination(
+  speakerTransitions: Array<{ timeMs: number }>
+): boolean {
+  if (speakerTransitions.length === 0) {
+    return false;
+  }
+
+  // Sort transitions by time
+  const sorted = [...speakerTransitions].sort((a, b) => a.timeMs - b.timeMs);
+
+  // Count transitions in each window
+  for (let i = 0; i < sorted.length; i++) {
+    const windowStart = sorted[i].timeMs;
+    const windowEnd = windowStart + OVERLAP_WINDOW_MS;
+
+    let transitionsInWindow = 0;
+    for (let j = i; j < sorted.length && sorted[j].timeMs < windowEnd; j++) {
+      transitionsInWindow++;
+    }
+
+    if (transitionsInWindow > MAX_TRANSITIONS_PER_WINDOW) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Compute composite quality score from individual components.
+ * Uses weighted formula: 0.4*snr + 0.3*clarity + 0.3*(1-overlap_penalty)
+ *
+ * @param snr - SNR proxy from word confidences [0-1]
+ * @param clarity - Clarity score from timing/filler analysis [0-1]
+ * @param isContaminated - Whether segment has overlap contamination
+ * @returns Composite quality score [0-1]
+ */
+export function computeCompositeQuality(
+  snr: number,
+  clarity: number,
+  isContaminated: boolean
+): number {
+  // Overlap penalty: contaminated segments get 0, clean segments get 1
+  const overlapScore = isContaminated ? 0 : 1;
+
+  // Weighted combination - SNR is most important for embedding quality
+  const composite = (0.4 * snr) + (0.3 * clarity) + (0.3 * overlapScore);
+
+  // Clamp to [0, 1] range
+  return Math.max(0, Math.min(1, composite));
+}
+
+/**
+ * Compute quality-weighted similarity between two speakers.
+ * Lower quality segments contribute less to similarity score.
+ *
+ * @param cosine - Raw cosine similarity [-1, 1]
+ * @param qualityA - Quality score for speaker A [0-1]
+ * @param qualityB - Quality score for speaker B [0-1]
+ * @returns Weighted similarity, attenuated by quality
+ */
+export function computeWeightedSimilarity(
+  cosine: number,
+  qualityA: number,
+  qualityB: number
+): number {
+  // Geometric mean of qualities - penalizes if either quality is low
+  const qualityWeight = Math.sqrt(qualityA * qualityB);
+
+  // Similarity is attenuated by quality
+  return cosine * qualityWeight;
+}
+
+// ============================================================================
+// WhisperX Integration
+// ============================================================================
+
+/**
+ * WhisperX segment format (subset of what we need for quality computation)
+ */
+export interface WhisperXSegmentForQuality {
+  text: string;
+  start: number;  // seconds
+  end: number;    // seconds
+  speaker?: string;
+  words?: Array<{
+    word: string;
+    start: number;
+    end: number;
+    score?: number;  // WhisperX confidence [0-1]
+  }>;
+}
+
+/**
+ * SpeakerQuality matches the interface in types.ts
+ */
+export interface SpeakerQualityResult {
+  snrProxy: number;
+  clarityScore: number;
+  isContaminated: boolean;
+  compositeScore: number;
+}
+
+/**
+ * Compute per-speaker quality map from WhisperX segments.
+ *
+ * Aggregates all segments for each speaker, extracts quality signals
+ * (SNR proxy from word confidence, clarity from timing/fillers, overlap
+ * from speaker transitions), and computes composite quality scores.
+ *
+ * @param segments - WhisperX segments with optional word-level scores
+ * @returns Map of speaker ID to SpeakerQuality
+ */
+export function computeSpeakerQualityMapFromWhisperXSegments(
+  segments: WhisperXSegmentForQuality[]
+): Record<string, SpeakerQualityResult> {
+  // Accumulate data per speaker
+  const speakerData: Record<string, {
+    wordConfidences: number[];
+    wordTimings: Array<{ start: number; end: number }>;
+    allText: string;
+    transitions: Array<{ timeMs: number }>;
+  }> = {};
+
+  // Track speaker transitions for overlap detection
+  let lastSpeaker: string | null = null;
+
+  for (const segment of segments) {
+    const speakerId = segment.speaker ?? 'UNKNOWN';
+
+    // Initialize speaker data if first time seeing this speaker
+    if (!speakerData[speakerId]) {
+      speakerData[speakerId] = {
+        wordConfidences: [],
+        wordTimings: [],
+        allText: '',
+        transitions: []
+      };
+    }
+
+    const data = speakerData[speakerId];
+
+    // Aggregate text (for filler detection)
+    if (segment.text) {
+      data.allText += (data.allText ? ' ' : '') + segment.text;
+    }
+
+    // Aggregate word-level data
+    if (segment.words && segment.words.length > 0) {
+      for (const word of segment.words) {
+        // Collect confidence scores (defaulting to 1.0 if missing)
+        if (word.score !== undefined && word.score !== null) {
+          data.wordConfidences.push(word.score);
+        }
+
+        // Collect timings
+        if (word.start !== undefined && word.end !== undefined) {
+          data.wordTimings.push({ start: word.start, end: word.end });
+        }
+      }
+    }
+
+    // Track speaker transitions (for overlap contamination)
+    if (lastSpeaker !== null && lastSpeaker !== speakerId) {
+      // Record transition time in milliseconds
+      const transitionTimeMs = segment.start * 1000;
+      // Both speakers involved in transition get marked
+      data.transitions.push({ timeMs: transitionTimeMs });
+      if (speakerData[lastSpeaker]) {
+        speakerData[lastSpeaker].transitions.push({ timeMs: transitionTimeMs });
+      }
+    }
+    lastSpeaker = speakerId;
+  }
+
+  // Compute quality for each speaker
+  const result: Record<string, SpeakerQualityResult> = {};
+
+  for (const [speakerId, data] of Object.entries(speakerData)) {
+    // SNR proxy from word confidences
+    const snrProxy = computeSNRProxy(data.wordConfidences);
+
+    // Clarity from timing consistency and filler words
+    const clarityScore = computeClarityScore(data.wordTimings, data.allText);
+
+    // Overlap contamination from rapid speaker transitions
+    const isContaminated = detectOverlapContamination(data.transitions);
+
+    // Composite score using the locked formula
+    const compositeScore = computeCompositeQuality(snrProxy, clarityScore, isContaminated);
+
+    result[speakerId] = {
+      snrProxy,
+      clarityScore,
+      isContaminated,
+      compositeScore
+    };
+  }
+
+  return result;
+}

--- a/functions/src/speakerReconciliation.ts
+++ b/functions/src/speakerReconciliation.ts
@@ -94,7 +94,20 @@ const WEIGHTS = {
  * This module only computes confidence - it does not enforce thresholds.
  */
 const THRESHOLDS = {
-  highConfidenceMatch: ReconciliationConfig.HIGH_CONFIDENCE_MATCH   // Pairs above this are merged greedily
+  highConfidenceMatch: ReconciliationConfig.HIGH_CONFIDENCE_MATCH,  // Pairs above this create edges (0.7)
+  /**
+   * Cohesion safeguard threshold: minimum similarity required across all
+   * cross-cluster pairs when merging. Lower than highConfidenceMatch to allow
+   * transitive merges where some pairs are slightly weaker.
+   * 0.7 caused over-fragmentation (24 clusters); 0.6 is more permissive.
+   */
+  cohesionThreshold: 0.6,
+  /**
+   * Singleton cluster confidence: "no evidence" means neutral, not bad.
+   * A speaker appearing in only one chunk has no cross-chunk comparisons,
+   * so we assign 0.75 (neutral-ish) instead of 0.0 which tanks overall confidence.
+   */
+  singletonConfidence: 0.75
 };
 
 /**
@@ -334,16 +347,63 @@ interface SpeakerCluster {
   };
 }
 
+// =============================================================================
+// Union-Find for Transitive Merging
+// =============================================================================
+
 /**
- * Cluster speakers using greedy algorithm.
+ * Union-Find (Disjoint Set Union) for transitive clustering.
+ * Enables A+B+C to merge when A-B and B-C both exceed threshold,
+ * even if we never directly compared A-C.
+ */
+class UnionFind {
+  private parent: number[];
+  private rank: number[];
+
+  constructor(size: number) {
+    this.parent = Array.from({ length: size }, (_, i) => i);
+    this.rank = Array(size).fill(0);
+  }
+
+  find(x: number): number {
+    if (this.parent[x] !== x) {
+      this.parent[x] = this.find(this.parent[x]); // Path compression
+    }
+    return this.parent[x];
+  }
+
+  union(x: number, y: number): void {
+    const rootX = this.find(x);
+    const rootY = this.find(y);
+    if (rootX === rootY) return;
+
+    // Union by rank
+    if (this.rank[rootX] < this.rank[rootY]) {
+      this.parent[rootX] = rootY;
+    } else if (this.rank[rootX] > this.rank[rootY]) {
+      this.parent[rootY] = rootX;
+    } else {
+      this.parent[rootY] = rootX;
+      this.rank[rootX]++;
+    }
+  }
+
+  connected(x: number, y: number): boolean {
+    return this.find(x) === this.find(y);
+  }
+}
+
+/**
+ * Cluster speakers using union-find with cohesion safeguard.
  *
  * Algorithm:
- * 1. Sort pairs by similarity (descending)
- * 2. For each high-confidence pair (>0.7):
- *    - If neither speaker is clustered, create new cluster
- *    - If one speaker is clustered, add other to same cluster
- *    - If both are clustered, skip (already matched)
- * 3. Unclustered speakers become singleton clusters
+ * 1. Build edges: all pairs with similarity ≥ threshold
+ * 2. Union-find: merge transitively (A-B, B-C → A,B,C together)
+ * 3. Cohesion safeguard: before finalizing a merge, check that the minimum
+ *    cross-component similarity is ≥ threshold to avoid "bridge" over-merges
+ *    (e.g., A-B=0.8, B-C=0.8, but A-C=0.3 should NOT merge)
+ * 4. Extract connected components as clusters
+ * 5. Singletons get neutral confidence (0.75)
  *
  * @param signatures - All speaker signatures
  * @param pairs - Similarity pairs (sorted by score descending)
@@ -353,94 +413,143 @@ function clusterSpeakers(
   signatures: SpeakerSignature[],
   pairs: SimilarityPair[]
 ): SpeakerCluster[] {
-  // Track which signature belongs to which cluster
-  const sigToClusterId = new Map<SpeakerSignature, number>();
-  const clusters: SpeakerCluster[] = [];
+  const n = signatures.length;
+  if (n === 0) return [];
 
-  // Helper: Get or create cluster for a signature
-  const getClusterId = (sig: SpeakerSignature): number | null => {
-    return sigToClusterId.get(sig) ?? null;
-  };
+  // Build signature index map
+  const sigToIndex = new Map<SpeakerSignature, number>();
+  signatures.forEach((sig, i) => sigToIndex.set(sig, i));
 
-  // Helper: Create a new cluster
-  const createCluster = (sig: SpeakerSignature): number => {
-    const clusterId = clusters.length;
-    clusters.push({
-      signatures: [sig],
-      avgSimilarity: 0.0, // Singleton clusters have no similarity evidence (not 1.0!)
-      evidence: { nameMatches: 0, topicOverlap: 0, termOverlap: 0 }
-    });
-    sigToClusterId.set(sig, clusterId);
-    return clusterId;
-  };
-
-  // Helper: Add signature to existing cluster
-  const addToCluster = (sig: SpeakerSignature, clusterId: number): void => {
-    clusters[clusterId].signatures.push(sig);
-    sigToClusterId.set(sig, clusterId);
-  };
-
-  // Process high-confidence pairs in order (greedy)
+  // Build similarity lookup for cohesion check
+  // Key: "i,j" where i < j, Value: similarity score
+  const similarityLookup = new Map<string, number>();
   for (const pair of pairs) {
-    if (pair.score < THRESHOLDS.highConfidenceMatch) {
-      break; // Pairs are sorted, rest are below threshold
+    const i = sigToIndex.get(pair.sig1)!;
+    const j = sigToIndex.get(pair.sig2)!;
+    const key = i < j ? `${i},${j}` : `${j},${i}`;
+    similarityLookup.set(key, pair.score);
+  }
+
+  const getSimilarity = (i: number, j: number): number => {
+    if (i === j) return 1.0;
+    const key = i < j ? `${i},${j}` : `${j},${i}`;
+    return similarityLookup.get(key) ?? 0.0;
+  };
+
+  // Initialize union-find
+  const uf = new UnionFind(n);
+
+  // Build edge list for pairs above threshold
+  const edges: { i: number; j: number; pair: SimilarityPair }[] = [];
+  for (const pair of pairs) {
+    if (pair.score < THRESHOLDS.highConfidenceMatch) break; // Sorted descending
+    const i = sigToIndex.get(pair.sig1)!;
+    const j = sigToIndex.get(pair.sig2)!;
+    edges.push({ i, j, pair });
+  }
+
+  console.log('[Reconciliation] Building transitive clusters:', {
+    signatureCount: n,
+    edgeCount: edges.length,
+    threshold: THRESHOLDS.highConfidenceMatch
+  });
+
+  // Process edges with cohesion safeguard
+  // We union if the minimum similarity across the would-be merged component
+  // stays above threshold. This is an approximation of complete-linkage.
+  for (const { i, j } of edges) {
+    const rootI = uf.find(i);
+    const rootJ = uf.find(j);
+    if (rootI === rootJ) continue; // Already connected
+
+    // Collect members of both components
+    const membersI: number[] = [];
+    const membersJ: number[] = [];
+    for (let k = 0; k < n; k++) {
+      if (uf.find(k) === rootI) membersI.push(k);
+      if (uf.find(k) === rootJ) membersJ.push(k);
     }
 
-    const cluster1 = getClusterId(pair.sig1);
-    const cluster2 = getClusterId(pair.sig2);
+    // Cohesion check: minimum cross-component similarity
+    let minCrossSim = 1.0;
+    for (const mi of membersI) {
+      for (const mj of membersJ) {
+        const sim = getSimilarity(mi, mj);
+        if (sim < minCrossSim) minCrossSim = sim;
+      }
+    }
 
-    if (cluster1 === null && cluster2 === null) {
-      // Neither clustered - create new cluster with both
-      const clusterId = createCluster(pair.sig1);
-      addToCluster(pair.sig2, clusterId);
-
-      // Update cluster evidence
-      clusters[clusterId].evidence.nameMatches += pair.evidence.nameScore > 0 ? 1 : 0;
-      clusters[clusterId].evidence.topicOverlap += pair.evidence.topicOverlap;
-      clusters[clusterId].evidence.termOverlap += pair.evidence.termOverlap;
-      clusters[clusterId].avgSimilarity = pair.score;
-
-    } else if (cluster1 !== null && cluster2 === null) {
-      // sig1 clustered, sig2 not - add sig2 to sig1's cluster
-      addToCluster(pair.sig2, cluster1);
-
-      // Update average similarity
-      const cluster = clusters[cluster1];
-      const pairCount = cluster.signatures.length - 1; // Exclude the new signature
-      cluster.avgSimilarity = (cluster.avgSimilarity * pairCount + pair.score) / (pairCount + 1);
-      cluster.evidence.nameMatches += pair.evidence.nameScore > 0 ? 1 : 0;
-      cluster.evidence.topicOverlap += pair.evidence.topicOverlap;
-      cluster.evidence.termOverlap += pair.evidence.termOverlap;
-
-    } else if (cluster1 === null && cluster2 !== null) {
-      // sig2 clustered, sig1 not - add sig1 to sig2's cluster
-      addToCluster(pair.sig1, cluster2);
-
-      // Update average similarity
-      const cluster = clusters[cluster2];
-      const pairCount = cluster.signatures.length - 1;
-      cluster.avgSimilarity = (cluster.avgSimilarity * pairCount + pair.score) / (pairCount + 1);
-      cluster.evidence.nameMatches += pair.evidence.nameScore > 0 ? 1 : 0;
-      cluster.evidence.topicOverlap += pair.evidence.topicOverlap;
-      cluster.evidence.termOverlap += pair.evidence.termOverlap;
-
-    } else if (cluster1 === cluster2) {
-      // Already in same cluster - skip
-      continue;
-
-    } else {
-      // Both in different clusters - don't merge (avoid cluster merging complexity)
-      // This is a simplification; in practice, we'd merge clusters here
-      continue;
+    // Only merge if all cross-pairs meet cohesion threshold (complete-linkage style)
+    // Using cohesionThreshold (0.6) instead of highConfidenceMatch (0.7) to allow
+    // transitive merges where some pairs are slightly weaker but still valid
+    if (minCrossSim >= THRESHOLDS.cohesionThreshold) {
+      uf.union(i, j);
     }
   }
 
-  // Add unclustered signatures as singletons
-  for (const sig of signatures) {
-    if (!sigToClusterId.has(sig)) {
-      createCluster(sig);
+  // Extract clusters from union-find
+  const componentMembers = new Map<number, number[]>();
+  for (let i = 0; i < n; i++) {
+    const root = uf.find(i);
+    if (!componentMembers.has(root)) {
+      componentMembers.set(root, []);
     }
+    componentMembers.get(root)!.push(i);
   }
+
+  // Build cluster objects with proper confidence
+  const clusters: SpeakerCluster[] = [];
+  for (const members of componentMembers.values()) {
+    const clusterSigs = members.map(i => signatures[i]);
+
+    // Compute average pairwise similarity within cluster
+    let totalSim = 0;
+    let pairCount = 0;
+    let nameMatches = 0;
+    let topicOverlap = 0;
+    let termOverlap = 0;
+
+    for (let a = 0; a < members.length; a++) {
+      for (let b = a + 1; b < members.length; b++) {
+        const sim = getSimilarity(members[a], members[b]);
+        totalSim += sim;
+        pairCount++;
+
+        // Accumulate evidence from matching pairs
+        const key = members[a] < members[b]
+          ? `${members[a]},${members[b]}`
+          : `${members[b]},${members[a]}`;
+        for (const pair of pairs) {
+          const pi = sigToIndex.get(pair.sig1)!;
+          const pj = sigToIndex.get(pair.sig2)!;
+          const pairKey = pi < pj ? `${pi},${pj}` : `${pj},${pi}`;
+          if (pairKey === key) {
+            if (pair.evidence.nameScore > 0) nameMatches++;
+            topicOverlap += pair.evidence.topicOverlap;
+            termOverlap += pair.evidence.termOverlap;
+            break;
+          }
+        }
+      }
+    }
+
+    // Singleton clusters get neutral confidence
+    const avgSimilarity = pairCount > 0
+      ? totalSim / pairCount
+      : THRESHOLDS.singletonConfidence;
+
+    clusters.push({
+      signatures: clusterSigs,
+      avgSimilarity,
+      evidence: { nameMatches, topicOverlap, termOverlap }
+    });
+  }
+
+  console.log('[Reconciliation] Transitive clustering complete:', {
+    inputSignatures: n,
+    outputClusters: clusters.length,
+    clusterSizes: clusters.map(c => c.signatures.length)
+  });
 
   return clusters;
 }

--- a/functions/src/speakerReconciliationEmbeddings.ts
+++ b/functions/src/speakerReconciliationEmbeddings.ts
@@ -12,6 +12,7 @@
  */
 
 import { ChunkArtifact } from './types';
+import { computeWeightedSimilarity } from './speakerQuality';
 
 // ============================================================================
 // Types
@@ -44,6 +45,7 @@ interface EmbeddingEntry {
   speakerId: string;
   originalId: string;     // "SPEAKER_00_chunk0"
   embedding: number[];
+  quality: number;        // Composite quality score [0-1]
 }
 
 // ============================================================================
@@ -54,11 +56,32 @@ export const EmbeddingReconciliationConfig = {
   /** Cosine similarity threshold for clustering (0.65-0.75 typical) */
   SIMILARITY_THRESHOLD: 0.70,
 
+  /**
+   * Cohesion safeguard threshold: minimum similarity required across all
+   * cross-cluster pairs when merging. Lower than SIMILARITY_THRESHOLD to allow
+   * transitive merges where some pairs are slightly weaker.
+   * 0.7 caused over-fragmentation (24 clusters); 0.6 is more permissive.
+   */
+  COHESION_THRESHOLD: 0.60,
+
   /** Minimum embedding dimension (wespeaker uses 256) */
   MIN_EMBEDDING_DIM: 256,
 
   /** Confidence threshold below which we trigger fallback */
   CONFIDENCE_THRESHOLD: 0.60,
+
+  /**
+   * Singleton cluster confidence: "no evidence" means neutral, not bad.
+   * A speaker appearing in only one chunk has no cross-chunk comparisons,
+   * so we assign 0.75 (neutral-ish) instead of 0.5 which tanks overall confidence.
+   */
+  SINGLETON_CONFIDENCE: 0.75,
+
+  /**
+   * Quality floor: segments below this quality threshold are excluded
+   * from reconciliation to prevent low-quality audio from causing false merges.
+   */
+  QUALITY_FLOOR: 0.3,
 };
 
 // ============================================================================
@@ -95,10 +118,8 @@ export function reconcileSpeakersWithEmbeddings(
     embeddingDim: embeddingEntries[0].embedding.length
   });
 
-  // Step 2: Compute pairwise cosine similarity matrix
-  const similarityMatrix = computeCosineSimilarityMatrix(
-    embeddingEntries.map(e => e.embedding)
-  );
+  // Step 2: Compute pairwise quality-weighted cosine similarity matrix
+  const similarityMatrix = computeCosineSimilarityMatrix(embeddingEntries);
 
   // Step 3: Cluster using agglomerative clustering
   const clusterLabels = agglomerativeCluster(
@@ -152,6 +173,7 @@ function collectEmbeddings(chunkArtifacts: ChunkArtifact[]): EmbeddingEntry[] {
 
   for (const artifact of chunkArtifacts) {
     const embeddings = artifact.speakerEmbeddings ?? {};
+    const qualities = artifact.speakerQuality ?? {};
 
     for (const [speakerId, embedding] of Object.entries(embeddings)) {
       // Validate embedding dimension
@@ -160,11 +182,24 @@ function collectEmbeddings(chunkArtifacts: ChunkArtifact[]): EmbeddingEntry[] {
         continue;
       }
 
+      // Get quality score if available, default to 1.0 (neutral quality)
+      const quality = qualities[speakerId]?.compositeScore ?? 1.0;
+
+      // Apply quality floor - skip low-quality segments
+      if (quality < EmbeddingReconciliationConfig.QUALITY_FLOOR) {
+        console.log(
+          `[EmbeddingReconciliation] Excluding ${speakerId} from chunk ${artifact.chunkIndex} ` +
+          `due to low quality: ${quality.toFixed(3)} < ${EmbeddingReconciliationConfig.QUALITY_FLOOR}`
+        );
+        continue;
+      }
+
       entries.push({
         chunkIndex: artifact.chunkIndex,
         speakerId,
         originalId: `${speakerId}_chunk${artifact.chunkIndex}`,
-        embedding
+        embedding,
+        quality
       });
     }
   }
@@ -198,19 +233,27 @@ function cosineSimilarity(a: number[], b: number[]): number {
 }
 
 /**
- * Compute pairwise cosine similarity matrix for all embeddings.
- * Returns NxN matrix where matrix[i][j] = similarity between embedding i and j.
+ * Compute pairwise quality-weighted cosine similarity matrix.
+ * Returns NxN matrix where matrix[i][j] = quality-weighted similarity.
  */
-function computeCosineSimilarityMatrix(embeddings: number[][]): number[][] {
-  const n = embeddings.length;
+function computeCosineSimilarityMatrix(entries: EmbeddingEntry[]): number[][] {
+  const n = entries.length;
   const matrix: number[][] = Array(n).fill(null).map(() => Array(n).fill(0));
 
   for (let i = 0; i < n; i++) {
     matrix[i][i] = 1.0; // Self-similarity
     for (let j = i + 1; j < n; j++) {
-      const sim = cosineSimilarity(embeddings[i], embeddings[j]);
-      matrix[i][j] = sim;
-      matrix[j][i] = sim; // Symmetric
+      const cosine = cosineSimilarity(entries[i].embedding, entries[j].embedding);
+
+      // Apply quality weighting to reduce influence of low-quality segments
+      const weighted = computeWeightedSimilarity(
+        cosine,
+        entries[i].quality,
+        entries[j].quality
+      );
+
+      matrix[i][j] = weighted;
+      matrix[j][i] = weighted; // Symmetric
     }
   }
 
@@ -218,10 +261,15 @@ function computeCosineSimilarityMatrix(embeddings: number[][]): number[][] {
 }
 
 /**
- * Agglomerative clustering using average linkage.
+ * Agglomerative clustering with cohesion safeguard.
  *
  * Starts with each item in its own cluster, then iteratively merges
  * the two most similar clusters until similarity falls below threshold.
+ *
+ * COHESION SAFEGUARD: Before merging two clusters, we check that the
+ * MINIMUM pairwise similarity across all cross-cluster pairs meets the
+ * threshold. This prevents "bridge" over-merges where A-B and B-C are
+ * high but A-C is low.
  *
  * @param similarityMatrix - NxN pairwise similarity matrix
  * @param threshold - Minimum similarity to merge clusters (e.g., 0.70)
@@ -243,9 +291,20 @@ function agglomerativeCluster(
     clusterMembers.set(i, [i]);
   }
 
+  // Use separate cohesion threshold (0.6) for bridge prevention
+  // This is more permissive than the main threshold (0.7) to allow transitive merges
+  const cohesionThreshold = EmbeddingReconciliationConfig.COHESION_THRESHOLD;
+
+  console.log('[EmbeddingReconciliation] Agglomerative clustering with cohesion safeguard:', {
+    itemCount: n,
+    threshold,
+    cohesionThreshold
+  });
+
   // Iteratively merge closest clusters
   while (activeClusters.size > 1) {
-    // Find the two most similar clusters
+    // Find the two most similar clusters (by average linkage)
+    // that also pass the cohesion safeguard (minimum cross-pair ≥ cohesionThreshold)
     let bestSim = -Infinity;
     let bestPair: [number, number] | null = null;
 
@@ -254,19 +313,35 @@ function agglomerativeCluster(
       for (let j = i + 1; j < activeList.length; j++) {
         const c1 = activeList[i];
         const c2 = activeList[j];
-        const sim = averageLinkageSimilarity(
-          clusterMembers.get(c1)!,
-          clusterMembers.get(c2)!,
-          similarityMatrix
-        );
-        if (sim > bestSim) {
-          bestSim = sim;
+        const members1 = clusterMembers.get(c1)!;
+        const members2 = clusterMembers.get(c2)!;
+
+        // Cohesion check: minimum cross-cluster similarity
+        let minCrossSim = Infinity;
+        for (const m1 of members1) {
+          for (const m2 of members2) {
+            if (similarityMatrix[m1][m2] < minCrossSim) {
+              minCrossSim = similarityMatrix[m1][m2];
+            }
+          }
+        }
+
+        // Skip this pair if any cross-pair is below cohesion threshold (bridge prevention)
+        // Using cohesionThreshold (0.6) instead of threshold (0.7) to be more permissive
+        if (minCrossSim < cohesionThreshold) {
+          continue;
+        }
+
+        // Use average linkage for ranking valid pairs
+        const avgSim = averageLinkageSimilarity(members1, members2, similarityMatrix);
+        if (avgSim > bestSim) {
+          bestSim = avgSim;
           bestPair = [c1, c2];
         }
       }
     }
 
-    // Stop if best similarity is below threshold
+    // Stop if no valid pair found (all below threshold or fail cohesion)
     if (bestSim < threshold || !bestPair) {
       break;
     }
@@ -289,6 +364,11 @@ function agglomerativeCluster(
     activeClusters.delete(c2);
     clusterMembers.delete(c2);
   }
+
+  console.log('[EmbeddingReconciliation] Clustering complete:', {
+    finalClusterCount: activeClusters.size,
+    clusterSizes: Array.from(clusterMembers.values()).map(m => m.length)
+  });
 
   // Renumber clusters to be sequential (0, 1, 2, ...)
   const uniqueClusters = [...new Set(clusterAssignment)];
@@ -355,8 +435,8 @@ function buildClusters(
       }
       confidence = count > 0 ? totalSim / count : 1.0;
     } else {
-      // Singleton cluster - lower confidence since we couldn't match anyone
-      confidence = 0.5;
+      // Singleton cluster - neutral confidence since "no evidence" != "bad match"
+      confidence = EmbeddingReconciliationConfig.SINGLETON_CONFIDENCE;
     }
 
     // Compute centroid (average embedding)

--- a/functions/src/transcribe.ts
+++ b/functions/src/transcribe.ts
@@ -48,6 +48,7 @@ import {
   SpeakerSignature,
   ProcessingMode
 } from './types';
+import { computeSpeakerQualityMapFromWhisperXSegments } from './speakerQuality';
 
 // Define secrets (set via: firebase functions:secrets:set <SECRET_NAME>)
 const replicateApiToken = defineSecret('REPLICATE_API_TOKEN');
@@ -984,6 +985,20 @@ export async function executeTranscriptionPipeline(params: TranscriptionPipeline
     // Check for abort after WhisperX
     await checkAbort(conversationId);
 
+    // Compute per-speaker quality scores from WhisperX word-level confidence
+    // This happens BEFORE segment transformation so we have access to raw word scores
+    const speakerQuality = computeSpeakerQualityMapFromWhisperXSegments(whisperxResult.segments);
+    console.debug('[Pipeline] Speaker quality computed:', {
+      speakerCount: Object.keys(speakerQuality).length,
+      scores: Object.entries(speakerQuality).map(([id, q]) => ({
+        speakerId: id,
+        composite: q.compositeScore.toFixed(3),
+        snr: q.snrProxy.toFixed(3),
+        clarity: q.clarityScore.toFixed(3),
+        contaminated: q.isContaminated
+      }))
+    });
+
     // Build segments from WhisperX output
     console.debug('[Pipeline] Building segments from WhisperX...');
     const buildStartTime = Date.now();
@@ -1184,6 +1199,8 @@ export async function executeTranscriptionPipeline(params: TranscriptionPipeline
         emittedContext: chunkContext!, // Will be replaced by processTranscription with actual emitted context
         // Include speaker embeddings if present (from WhisperX fork)
         speakerEmbeddings: whisperxResult.speakerEmbeddings,
+        // Include speaker quality scores for quality-weighted reconciliation
+        speakerQuality,
         createdAt: new Date().toISOString(),
         storagePath: filePath
       };

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -373,11 +373,35 @@ export interface ChunkArtifact {
     [speakerId: string]: number[];
   };
 
+  /**
+   * Quality scores for each speaker in this chunk.
+   * Used to weight embedding similarity and filter low-quality segments.
+   * Present when quality assessment is enabled.
+   */
+  speakerQuality?: {
+    [speakerId: string]: SpeakerQuality;
+  };
+
   // Metadata
   /** When this chunk artifact was created */
   createdAt: string;
   /** Storage path to chunk audio file */
   storagePath: string;
+}
+
+/**
+ * Quality assessment for a speaker's audio in a chunk.
+ * Used to weight embedding similarity and filter unreliable segments.
+ */
+export interface SpeakerQuality {
+  /** SNR proxy from WhisperX word confidence scores [0-1] */
+  snrProxy: number;
+  /** Speech clarity from timing consistency and filler detection [0-1] */
+  clarityScore: number;
+  /** True if segment has excessive speaker overlap */
+  isContaminated: boolean;
+  /** Composite quality score [0-1]: 0.4*snr + 0.3*clarity + 0.3*(1-overlap) */
+  compositeScore: number;
 }
 
 // =============================================================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audio-transcript-analysis-app",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audio-transcript-analysis-app",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "dependencies": {
         "@google/genai": "^1.33.0",
         "dotenv": "^17.2.3",


### PR DESCRIPTION
## Summary
- Adds quality signals (SNR proxy, clarity, overlap contamination) extracted from WhisperX word-level data
- Implements quality-weighted similarity: `cosine * sqrt(quality_A * quality_B)` penalizes low-quality matches
- Excludes speakers below quality floor (0.3) from reconciliation to prevent garbage-in → garbage-out merges

## Changelog Entry
```markdown
### Changed
- **Quality-Weighted Speaker Reconciliation** - Speaker matching across chunks now considers audio quality signals
  - Embedding similarity weighted by composite quality score: `cosine * sqrt(quality_A * quality_B)`
  - Quality derived from WhisperX word confidence, timing consistency, and speaker overlap detection
  - Low-quality speakers (< 0.3 threshold) excluded from reconciliation graph to prevent false merges
  - Reduces speaker misidentification in noisy audio or sections with overlapping speech
```

## Files Changed
- `functions/src/speakerQuality.ts` - New module with quality extraction and composite scoring
- `functions/src/speakerReconciliationEmbeddings.ts` - Quality-weighted similarity, quality floor config
- `functions/src/transcribe.ts` - Compute and store speakerQuality in chunk artifacts
- `functions/src/types.ts` - SpeakerQuality interface, speakerQuality field on ChunkArtifact
- `functions/src/alignment.ts` - Added score field to Word interface

## Test Plan
- [x] 49 unit tests pass (quality calculation, weighted similarity, quality floor)
- [x] TypeScript compilation succeeds
- [x] Integration tests verify quality floor exclusion logging

---
Scope: `speaker_reconciliation_01_quality_weighted_similarity`
Iteration: `iteration_01_a`
Build: `13`