### PR TITLE
feat(speaker-reconciliation): add temporal proximity weighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Quality derived from WhisperX word confidence, timing consistency, and speaker overlap detection
   - Low-quality speakers (< 0.3 threshold) excluded from reconciliation graph to prevent false merges
   - Reduces speaker misidentification in noisy audio or sections with overlapping speech
+- **Temporal Proximity Speaker Reconciliation** - Speaker matching now considers when speakers appear in the audio timeline
+  - Speakers appearing close in time receive similarity boosts via exponential decay (5-minute half-life)
+  - Speakers at chunk boundaries (within 30 seconds of edge) receive additional bridging boost when similarity > 0.65
+  - Time window constraint: no temporal boost for speakers more than 1 hour apart
+  - Reduces false speaker splits when the same person speaks across chunk boundaries
 
 ## [2.5.0] - 2026-01-19
 

--- a/functions/src/__tests__/temporalGraph.test.ts
+++ b/functions/src/__tests__/temporalGraph.test.ts
@@ -1,0 +1,716 @@
+/**
+ * Tests for Temporal Graph Module
+ *
+ * Validates temporal proximity weighting and chunk boundary bridging
+ * for speaker reconciliation.
+ */
+
+import {
+  computeTemporalWeight,
+  isBoundaryPair,
+  computeFinalSimilarity,
+  buildSpeakerAppearanceWindows,
+  buildChunkBoundsMap,
+  computeTimeDeltaMs,
+  computeTimeDeltaSeconds,
+  isCrossChunkPair,
+  applyTemporalBoosts,
+  SpeakerAppearanceWindow,
+} from '../temporalGraph';
+import { ChunkArtifact } from '../types';
+
+// ============================================================================
+// computeTemporalWeight tests
+// ============================================================================
+
+describe('computeTemporalWeight', () => {
+  const halfLife = 300; // 5 minutes
+  const maxWindow = 3600; // 1 hour
+
+  it('should return 1.0 for zero time delta', () => {
+    expect(computeTemporalWeight(0, halfLife, maxWindow)).toBe(1.0);
+  });
+
+  it('should return ~0.368 at half-life (exp(-1))', () => {
+    const weight = computeTemporalWeight(halfLife, halfLife, maxWindow);
+    expect(weight).toBeCloseTo(Math.exp(-1), 5);
+  });
+
+  it('should return ~0.135 at 2x half-life (exp(-2))', () => {
+    const weight = computeTemporalWeight(halfLife * 2, halfLife, maxWindow);
+    expect(weight).toBeCloseTo(Math.exp(-2), 5);
+  });
+
+  it('should return 0 beyond max window', () => {
+    expect(computeTemporalWeight(maxWindow + 1, halfLife, maxWindow)).toBe(0);
+    expect(computeTemporalWeight(maxWindow * 2, halfLife, maxWindow)).toBe(0);
+  });
+
+  it('should return 0 for exactly max window', () => {
+    // At exactly maxWindow, we still apply the cutoff
+    expect(computeTemporalWeight(maxWindow + 0.001, halfLife, maxWindow)).toBe(0);
+  });
+
+  it('should use default config values', () => {
+    // Uses TemporalConfig.HALF_LIFE_SECONDS (300) and MAX_WINDOW_SECONDS (3600)
+    const weight = computeTemporalWeight(300);
+    expect(weight).toBeCloseTo(Math.exp(-1), 5);
+  });
+
+  it('should handle negative time deltas gracefully', () => {
+    expect(computeTemporalWeight(-100, halfLife, maxWindow)).toBe(0);
+  });
+
+  it('should smoothly decay between 0 and half-life', () => {
+    const weights = [0, 60, 120, 180, 240, 300].map(t =>
+      computeTemporalWeight(t, halfLife, maxWindow)
+    );
+
+    // Each weight should be less than the previous
+    for (let i = 1; i < weights.length; i++) {
+      expect(weights[i]).toBeLessThan(weights[i - 1]);
+    }
+  });
+
+  it('should produce expected values for 5-minute half-life', () => {
+    // At 1 minute: exp(-60/300) = exp(-0.2) ≈ 0.819
+    expect(computeTemporalWeight(60, 300, 3600)).toBeCloseTo(0.819, 2);
+
+    // At 10 minutes: exp(-600/300) = exp(-2) ≈ 0.135
+    expect(computeTemporalWeight(600, 300, 3600)).toBeCloseTo(0.135, 2);
+
+    // At 30 minutes: exp(-1800/300) = exp(-6) ≈ 0.0025
+    expect(computeTemporalWeight(1800, 300, 3600)).toBeCloseTo(0.0025, 3);
+  });
+});
+
+// ============================================================================
+// isBoundaryPair tests
+// ============================================================================
+
+describe('isBoundaryPair', () => {
+  const chunkBounds = new Map<number, { startMs: number; endMs: number }>([
+    [0, { startMs: 0, endMs: 600000 }],      // 0-10 minutes
+    [1, { startMs: 600000, endMs: 1200000 }], // 10-20 minutes
+    [2, { startMs: 1200000, endMs: 1800000 }], // 20-30 minutes
+  ]);
+
+  // Boundary window is 30 seconds (30000ms) - configured in TemporalConfig
+
+  it('should return true for adjacent chunks with speaker at end/start', () => {
+    const windowA: SpeakerAppearanceWindow = {
+      chunkIndex: 0,
+      speakerId: 'SPEAKER_00',
+      firstOriginalMs: 500000,
+      lastOriginalMs: 595000, // 5 seconds from end (within 30s window)
+    };
+
+    const windowB: SpeakerAppearanceWindow = {
+      chunkIndex: 1,
+      speakerId: 'SPEAKER_01',
+      firstOriginalMs: 605000, // 5 seconds from start (within 30s window)
+      lastOriginalMs: 700000,
+    };
+
+    expect(isBoundaryPair(windowA, windowB, chunkBounds)).toBe(true);
+  });
+
+  it('should return true if only earlier speaker is near boundary', () => {
+    const windowA: SpeakerAppearanceWindow = {
+      chunkIndex: 0,
+      speakerId: 'SPEAKER_00',
+      firstOriginalMs: 500000,
+      lastOriginalMs: 590000, // 10 seconds from end (within 30s)
+    };
+
+    const windowB: SpeakerAppearanceWindow = {
+      chunkIndex: 1,
+      speakerId: 'SPEAKER_01',
+      firstOriginalMs: 700000, // 100 seconds from start (outside 30s)
+      lastOriginalMs: 800000,
+    };
+
+    expect(isBoundaryPair(windowA, windowB, chunkBounds)).toBe(true);
+  });
+
+  it('should return true if only later speaker is near boundary', () => {
+    const windowA: SpeakerAppearanceWindow = {
+      chunkIndex: 0,
+      speakerId: 'SPEAKER_00',
+      firstOriginalMs: 100000,
+      lastOriginalMs: 500000, // 100 seconds from end (outside 30s)
+    };
+
+    const windowB: SpeakerAppearanceWindow = {
+      chunkIndex: 1,
+      speakerId: 'SPEAKER_01',
+      firstOriginalMs: 610000, // 10 seconds from start (within 30s)
+      lastOriginalMs: 700000,
+    };
+
+    expect(isBoundaryPair(windowA, windowB, chunkBounds)).toBe(true);
+  });
+
+  it('should return false for non-adjacent chunks', () => {
+    const windowA: SpeakerAppearanceWindow = {
+      chunkIndex: 0,
+      speakerId: 'SPEAKER_00',
+      firstOriginalMs: 500000,
+      lastOriginalMs: 595000,
+    };
+
+    const windowB: SpeakerAppearanceWindow = {
+      chunkIndex: 2, // Skipped chunk 1
+      speakerId: 'SPEAKER_01',
+      firstOriginalMs: 1205000,
+      lastOriginalMs: 1300000,
+    };
+
+    expect(isBoundaryPair(windowA, windowB, chunkBounds)).toBe(false);
+  });
+
+  it('should return false when neither speaker is near boundary', () => {
+    const windowA: SpeakerAppearanceWindow = {
+      chunkIndex: 0,
+      speakerId: 'SPEAKER_00',
+      firstOriginalMs: 100000,
+      lastOriginalMs: 400000, // 200 seconds from end (outside 30s)
+    };
+
+    const windowB: SpeakerAppearanceWindow = {
+      chunkIndex: 1,
+      speakerId: 'SPEAKER_01',
+      firstOriginalMs: 800000, // 200 seconds from start (outside 30s)
+      lastOriginalMs: 900000,
+    };
+
+    expect(isBoundaryPair(windowA, windowB, chunkBounds)).toBe(false);
+  });
+
+  it('should return false for same-chunk speakers', () => {
+    const windowA: SpeakerAppearanceWindow = {
+      chunkIndex: 0,
+      speakerId: 'SPEAKER_00',
+      firstOriginalMs: 100000,
+      lastOriginalMs: 200000,
+    };
+
+    const windowB: SpeakerAppearanceWindow = {
+      chunkIndex: 0, // Same chunk
+      speakerId: 'SPEAKER_01',
+      firstOriginalMs: 300000,
+      lastOriginalMs: 400000,
+    };
+
+    expect(isBoundaryPair(windowA, windowB, chunkBounds)).toBe(false);
+  });
+
+  it('should handle reversed order (B before A)', () => {
+    const windowA: SpeakerAppearanceWindow = {
+      chunkIndex: 1,
+      speakerId: 'SPEAKER_00',
+      firstOriginalMs: 605000, // Near start of chunk 1
+      lastOriginalMs: 700000,
+    };
+
+    const windowB: SpeakerAppearanceWindow = {
+      chunkIndex: 0,
+      speakerId: 'SPEAKER_01',
+      firstOriginalMs: 500000,
+      lastOriginalMs: 595000, // Near end of chunk 0
+    };
+
+    expect(isBoundaryPair(windowA, windowB, chunkBounds)).toBe(true);
+  });
+
+  it('should return false when chunk bounds are missing', () => {
+    const windowA: SpeakerAppearanceWindow = {
+      chunkIndex: 5, // Not in chunkBounds map
+      speakerId: 'SPEAKER_00',
+      firstOriginalMs: 500000,
+      lastOriginalMs: 595000,
+    };
+
+    const windowB: SpeakerAppearanceWindow = {
+      chunkIndex: 6, // Not in chunkBounds map
+      speakerId: 'SPEAKER_01',
+      firstOriginalMs: 605000,
+      lastOriginalMs: 700000,
+    };
+
+    expect(isBoundaryPair(windowA, windowB, chunkBounds)).toBe(false);
+  });
+});
+
+// ============================================================================
+// computeFinalSimilarity tests
+// ============================================================================
+
+describe('computeFinalSimilarity', () => {
+  it('should apply temporal boost correctly', () => {
+    const base = 0.8;
+    const temporalWeight = 1.0; // Full weight
+    // Default boost factor is 0.5, so:
+    // Expected: 0.8 * (1 + 0.5 * 1.0) = 0.8 * 1.5 = 1.2 → capped at 1.0
+    const result = computeFinalSimilarity(base, temporalWeight, false);
+    expect(result).toBe(1.0); // Capped
+  });
+
+  it('should not apply temporal boost when weight is 0', () => {
+    const base = 0.75;
+    const result = computeFinalSimilarity(base, 0, false);
+    expect(result).toBe(base); // Unchanged
+  });
+
+  it('should apply partial temporal boost', () => {
+    const base = 0.6;
+    const temporalWeight = 0.5;
+    // Default factor is 0.5
+    // Expected: 0.6 * (1 + 0.5 * 0.5) = 0.6 * 1.25 = 0.75
+    const result = computeFinalSimilarity(base, temporalWeight, false);
+    expect(result).toBeCloseTo(0.75, 5);
+  });
+
+  it('should apply boundary boost when conditions met', () => {
+    const base = 0.7; // Above threshold (0.65)
+    const temporalWeight = 0;
+    // Default boundary boost is 1.3
+    // Expected: 0.7 * 1.3 = 0.91
+    const result = computeFinalSimilarity(base, temporalWeight, true);
+    expect(result).toBeCloseTo(0.91, 5);
+  });
+
+  it('should NOT apply boundary boost when base below threshold', () => {
+    const base = 0.6; // Below threshold (0.65)
+    const result = computeFinalSimilarity(base, 0, true);
+    expect(result).toBe(base); // No boost applied
+  });
+
+  it('should apply both temporal and boundary boosts', () => {
+    const base = 0.7;
+    const temporalWeight = 0.5;
+
+    // Temporal first: 0.7 * (1 + 0.5 * 0.5) = 0.7 * 1.25 = 0.875
+    // Boundary: 0.875 * 1.3 = 1.1375 → capped at 1.0
+    const result = computeFinalSimilarity(base, temporalWeight, true);
+    expect(result).toBe(1.0);
+  });
+
+  it('should cap result at 1.0', () => {
+    const base = 0.9;
+    const temporalWeight = 1.0;
+
+    // Without cap: 0.9 * 1.5 = 1.35
+    const result = computeFinalSimilarity(base, temporalWeight, false);
+    expect(result).toBe(1.0);
+  });
+
+  it('should handle negative base similarity', () => {
+    const base = -0.3;
+    const temporalWeight = 0.5;
+
+    // Should still apply temporal boost (might make it more negative)
+    // -0.3 * (1 + 0.5 * 0.5) = -0.3 * 1.25 = -0.375
+    const result = computeFinalSimilarity(base, temporalWeight, false);
+    expect(result).toBeCloseTo(-0.375, 5);
+  });
+
+  it('should respect custom config', () => {
+    const base = 0.5;
+    const config = {
+      TEMPORAL_BOOST_FACTOR: 1.0,
+      BOUNDARY_BOOST: 1.5,
+      BOUNDARY_SIMILARITY_THRESHOLD: 0.4,
+    };
+
+    // With custom factor: 0.5 * (1 + 1.0 * 1.0) = 1.0
+    const result = computeFinalSimilarity(base, 1.0, false, config);
+    expect(result).toBe(1.0);
+
+    // With custom boundary threshold: 0.5 > 0.4, so boundary boost applies
+    // 0.5 * 1.5 = 0.75
+    const resultBoundary = computeFinalSimilarity(base, 0, true, config);
+    expect(resultBoundary).toBeCloseTo(0.75, 5);
+  });
+});
+
+// ============================================================================
+// computeTimeDeltaMs / computeTimeDeltaSeconds tests
+// ============================================================================
+
+describe('computeTimeDeltaMs', () => {
+  it('should return 0 for overlapping windows', () => {
+    const windowA: SpeakerAppearanceWindow = {
+      chunkIndex: 0,
+      speakerId: 'SPEAKER_00',
+      firstOriginalMs: 100,
+      lastOriginalMs: 500,
+    };
+
+    const windowB: SpeakerAppearanceWindow = {
+      chunkIndex: 1,
+      speakerId: 'SPEAKER_01',
+      firstOriginalMs: 300, // Overlaps with A (100-500)
+      lastOriginalMs: 700,
+    };
+
+    expect(computeTimeDeltaMs(windowA, windowB)).toBe(0);
+  });
+
+  it('should compute gap when A ends before B starts', () => {
+    const windowA: SpeakerAppearanceWindow = {
+      chunkIndex: 0,
+      speakerId: 'SPEAKER_00',
+      firstOriginalMs: 100,
+      lastOriginalMs: 500,
+    };
+
+    const windowB: SpeakerAppearanceWindow = {
+      chunkIndex: 1,
+      speakerId: 'SPEAKER_01',
+      firstOriginalMs: 800, // 300ms after A ends
+      lastOriginalMs: 1000,
+    };
+
+    expect(computeTimeDeltaMs(windowA, windowB)).toBe(300);
+  });
+
+  it('should compute gap when B ends before A starts', () => {
+    const windowA: SpeakerAppearanceWindow = {
+      chunkIndex: 1,
+      speakerId: 'SPEAKER_00',
+      firstOriginalMs: 1000,
+      lastOriginalMs: 1500,
+    };
+
+    const windowB: SpeakerAppearanceWindow = {
+      chunkIndex: 0,
+      speakerId: 'SPEAKER_01',
+      firstOriginalMs: 100,
+      lastOriginalMs: 500, // 500ms before A starts
+    };
+
+    expect(computeTimeDeltaMs(windowA, windowB)).toBe(500);
+  });
+
+  it('should return 0 for adjacent windows (no gap)', () => {
+    const windowA: SpeakerAppearanceWindow = {
+      chunkIndex: 0,
+      speakerId: 'SPEAKER_00',
+      firstOriginalMs: 100,
+      lastOriginalMs: 500,
+    };
+
+    const windowB: SpeakerAppearanceWindow = {
+      chunkIndex: 1,
+      speakerId: 'SPEAKER_01',
+      firstOriginalMs: 500, // Exactly where A ends
+      lastOriginalMs: 800,
+    };
+
+    expect(computeTimeDeltaMs(windowA, windowB)).toBe(0);
+  });
+});
+
+describe('computeTimeDeltaSeconds', () => {
+  it('should convert milliseconds to seconds', () => {
+    const windowA: SpeakerAppearanceWindow = {
+      chunkIndex: 0,
+      speakerId: 'SPEAKER_00',
+      firstOriginalMs: 0,
+      lastOriginalMs: 1000,
+    };
+
+    const windowB: SpeakerAppearanceWindow = {
+      chunkIndex: 1,
+      speakerId: 'SPEAKER_01',
+      firstOriginalMs: 61000, // 60 seconds after A ends
+      lastOriginalMs: 70000,
+    };
+
+    expect(computeTimeDeltaSeconds(windowA, windowB)).toBe(60);
+  });
+});
+
+// ============================================================================
+// isCrossChunkPair tests
+// ============================================================================
+
+describe('isCrossChunkPair', () => {
+  it('should return true for different chunks', () => {
+    expect(isCrossChunkPair('SPEAKER_00_chunk0', 'SPEAKER_01_chunk1')).toBe(true);
+    expect(isCrossChunkPair('SPEAKER_00_chunk5', 'SPEAKER_00_chunk7')).toBe(true);
+  });
+
+  it('should return false for same chunk', () => {
+    expect(isCrossChunkPair('SPEAKER_00_chunk0', 'SPEAKER_01_chunk0')).toBe(false);
+    expect(isCrossChunkPair('SPEAKER_02_chunk3', 'SPEAKER_05_chunk3')).toBe(false);
+  });
+
+  it('should return false for malformed keys', () => {
+    expect(isCrossChunkPair('SPEAKER_00', 'SPEAKER_01')).toBe(false);
+    expect(isCrossChunkPair('invalid', 'SPEAKER_01_chunk1')).toBe(false);
+  });
+});
+
+// ============================================================================
+// buildSpeakerAppearanceWindows tests
+// ============================================================================
+
+describe('buildSpeakerAppearanceWindows', () => {
+  it('should build windows from chunk artifacts', () => {
+    const artifacts: ChunkArtifact[] = [
+      createMockChunkArtifact(0, [
+        { speakerId: 'SPEAKER_00', startMs: 0, endMs: 5000 },
+        { speakerId: 'SPEAKER_00', startMs: 10000, endMs: 15000 },
+        { speakerId: 'SPEAKER_01', startMs: 20000, endMs: 25000 },
+      ], { startMs: 0, endMs: 60000, overlapBeforeMs: 0, overlapAfterMs: 5000 }),
+    ];
+
+    const windows = buildSpeakerAppearanceWindows(artifacts);
+
+    expect(windows.size).toBe(2);
+
+    const speaker00 = windows.get('SPEAKER_00_chunk0');
+    expect(speaker00).toBeDefined();
+    expect(speaker00!.firstOriginalMs).toBe(0);
+    expect(speaker00!.lastOriginalMs).toBe(15000);
+
+    const speaker01 = windows.get('SPEAKER_01_chunk0');
+    expect(speaker01).toBeDefined();
+    expect(speaker01!.firstOriginalMs).toBe(20000);
+    expect(speaker01!.lastOriginalMs).toBe(25000);
+  });
+
+  it('should convert chunk-local timestamps to original timeline', () => {
+    // Chunk starts at 300000ms (5 minutes) with 5000ms overlap before
+    const artifacts: ChunkArtifact[] = [
+      createMockChunkArtifact(1, [
+        { speakerId: 'SPEAKER_00', startMs: 0, endMs: 5000 }, // Chunk-local
+      ], { startMs: 300000, endMs: 600000, overlapBeforeMs: 5000, overlapAfterMs: 5000 }),
+    ];
+
+    const windows = buildSpeakerAppearanceWindows(artifacts);
+    const speaker00 = windows.get('SPEAKER_00_chunk1');
+
+    // chunkAudioStartMs = 300000 - 5000 = 295000
+    // originalStartMs = 295000 + 0 = 295000
+    // originalEndMs = 295000 + 5000 = 300000
+    expect(speaker00!.firstOriginalMs).toBe(295000);
+    expect(speaker00!.lastOriginalMs).toBe(300000);
+  });
+
+  it('should handle multiple chunks', () => {
+    const artifacts: ChunkArtifact[] = [
+      createMockChunkArtifact(0, [
+        { speakerId: 'SPEAKER_00', startMs: 0, endMs: 5000 },
+      ], { startMs: 0, endMs: 60000, overlapBeforeMs: 0, overlapAfterMs: 5000 }),
+      createMockChunkArtifact(1, [
+        { speakerId: 'SPEAKER_00', startMs: 0, endMs: 5000 },
+      ], { startMs: 60000, endMs: 120000, overlapBeforeMs: 5000, overlapAfterMs: 0 }),
+    ];
+
+    const windows = buildSpeakerAppearanceWindows(artifacts);
+
+    expect(windows.size).toBe(2);
+    expect(windows.has('SPEAKER_00_chunk0')).toBe(true);
+    expect(windows.has('SPEAKER_00_chunk1')).toBe(true);
+  });
+
+  it('should return empty map for empty artifacts', () => {
+    const windows = buildSpeakerAppearanceWindows([]);
+    expect(windows.size).toBe(0);
+  });
+});
+
+// ============================================================================
+// buildChunkBoundsMap tests
+// ============================================================================
+
+describe('buildChunkBoundsMap', () => {
+  it('should build bounds map from chunk artifacts', () => {
+    const artifacts: ChunkArtifact[] = [
+      createMockChunkArtifact(0, [], { startMs: 0, endMs: 60000, overlapBeforeMs: 0, overlapAfterMs: 5000 }),
+      createMockChunkArtifact(1, [], { startMs: 60000, endMs: 120000, overlapBeforeMs: 5000, overlapAfterMs: 5000 }),
+      createMockChunkArtifact(2, [], { startMs: 120000, endMs: 180000, overlapBeforeMs: 5000, overlapAfterMs: 0 }),
+    ];
+
+    const boundsMap = buildChunkBoundsMap(artifacts);
+
+    expect(boundsMap.size).toBe(3);
+    expect(boundsMap.get(0)).toEqual({ startMs: 0, endMs: 60000 });
+    expect(boundsMap.get(1)).toEqual({ startMs: 60000, endMs: 120000 });
+    expect(boundsMap.get(2)).toEqual({ startMs: 120000, endMs: 180000 });
+  });
+});
+
+// ============================================================================
+// applyTemporalBoosts tests
+// ============================================================================
+
+describe('applyTemporalBoosts', () => {
+  it('should apply temporal boosts to cross-chunk pairs', () => {
+    const matrix = [
+      [1.0, 0.7, 0.6],
+      [0.7, 1.0, 0.65],
+      [0.6, 0.65, 1.0],
+    ];
+
+    const speakerKeys = [
+      'SPEAKER_00_chunk0',
+      'SPEAKER_01_chunk0', // Same chunk as [0]
+      'SPEAKER_00_chunk1', // Different chunk
+    ];
+
+    const appearances = new Map<string, SpeakerAppearanceWindow>([
+      ['SPEAKER_00_chunk0', { chunkIndex: 0, speakerId: 'SPEAKER_00', firstOriginalMs: 0, lastOriginalMs: 50000 }],
+      ['SPEAKER_01_chunk0', { chunkIndex: 0, speakerId: 'SPEAKER_01', firstOriginalMs: 10000, lastOriginalMs: 40000 }],
+      ['SPEAKER_00_chunk1', { chunkIndex: 1, speakerId: 'SPEAKER_00', firstOriginalMs: 60000, lastOriginalMs: 100000 }],
+    ]);
+
+    const chunkBounds = new Map([
+      [0, { startMs: 0, endMs: 60000 }],
+      [1, { startMs: 60000, endMs: 120000 }],
+    ]);
+
+    applyTemporalBoosts(matrix, speakerKeys, appearances, chunkBounds);
+
+    // [0][1] should be unchanged (same chunk)
+    expect(matrix[0][1]).toBe(0.7);
+    expect(matrix[1][0]).toBe(0.7);
+
+    // [0][2] should be boosted (cross-chunk, temporal proximity)
+    // Time delta: 60000 - 50000 = 10000ms = 10 seconds
+    // Temporal weight: exp(-10/300) ≈ 0.967
+    // Base 0.6, boosted: 0.6 * (1 + 0.5 * 0.967) ≈ 0.6 * 1.484 ≈ 0.89
+    expect(matrix[0][2]).toBeGreaterThan(0.6);
+    expect(matrix[2][0]).toBe(matrix[0][2]); // Symmetric
+
+    // [1][2] should also be boosted (cross-chunk)
+    expect(matrix[1][2]).toBeGreaterThan(0.65);
+    expect(matrix[2][1]).toBe(matrix[1][2]);
+  });
+
+  it('should not modify same-chunk pairs', () => {
+    const matrix = [
+      [1.0, 0.8],
+      [0.8, 1.0],
+    ];
+
+    const speakerKeys = ['SPEAKER_00_chunk0', 'SPEAKER_01_chunk0'];
+
+    const appearances = new Map<string, SpeakerAppearanceWindow>([
+      ['SPEAKER_00_chunk0', { chunkIndex: 0, speakerId: 'SPEAKER_00', firstOriginalMs: 0, lastOriginalMs: 10000 }],
+      ['SPEAKER_01_chunk0', { chunkIndex: 0, speakerId: 'SPEAKER_01', firstOriginalMs: 20000, lastOriginalMs: 30000 }],
+    ]);
+
+    const chunkBounds = new Map([[0, { startMs: 0, endMs: 60000 }]]);
+
+    applyTemporalBoosts(matrix, speakerKeys, appearances, chunkBounds);
+
+    // Should remain unchanged
+    expect(matrix[0][1]).toBe(0.8);
+    expect(matrix[1][0]).toBe(0.8);
+  });
+
+  it('should apply boundary boost for eligible pairs', () => {
+    const matrix = [
+      [1.0, 0.7],
+      [0.7, 1.0],
+    ];
+
+    const speakerKeys = ['SPEAKER_00_chunk0', 'SPEAKER_00_chunk1'];
+
+    // Speaker at end of chunk 0, start of chunk 1 (boundary pair)
+    const appearances = new Map<string, SpeakerAppearanceWindow>([
+      ['SPEAKER_00_chunk0', { chunkIndex: 0, speakerId: 'SPEAKER_00', firstOriginalMs: 50000, lastOriginalMs: 58000 }], // 2s from end
+      ['SPEAKER_00_chunk1', { chunkIndex: 1, speakerId: 'SPEAKER_00', firstOriginalMs: 62000, lastOriginalMs: 80000 }], // 2s from start
+    ]);
+
+    const chunkBounds = new Map([
+      [0, { startMs: 0, endMs: 60000 }],
+      [1, { startMs: 60000, endMs: 120000 }],
+    ]);
+
+    applyTemporalBoosts(matrix, speakerKeys, appearances, chunkBounds);
+
+    // Base 0.7 > 0.65 threshold, so boundary boost applies
+    // Time delta: 62000 - 58000 = 4000ms = 4 seconds
+    // Temporal weight: exp(-4/300) ≈ 0.987
+    // After temporal: 0.7 * (1 + 0.5 * 0.987) ≈ 0.7 * 1.49 ≈ 1.04 → capped at 1.0
+    // After boundary: min(1.0 * 1.3, 1.0) = 1.0
+    expect(matrix[0][1]).toBe(1.0);
+  });
+
+  it('should not apply boundary boost when base similarity below threshold', () => {
+    const matrix = [
+      [1.0, 0.5], // Below 0.65 threshold
+      [0.5, 1.0],
+    ];
+
+    const speakerKeys = ['SPEAKER_00_chunk0', 'SPEAKER_00_chunk1'];
+
+    const appearances = new Map<string, SpeakerAppearanceWindow>([
+      ['SPEAKER_00_chunk0', { chunkIndex: 0, speakerId: 'SPEAKER_00', firstOriginalMs: 55000, lastOriginalMs: 59000 }],
+      ['SPEAKER_00_chunk1', { chunkIndex: 1, speakerId: 'SPEAKER_00', firstOriginalMs: 61000, lastOriginalMs: 70000 }],
+    ]);
+
+    const chunkBounds = new Map([
+      [0, { startMs: 0, endMs: 60000 }],
+      [1, { startMs: 60000, endMs: 120000 }],
+    ]);
+
+    applyTemporalBoosts(matrix, speakerKeys, appearances, chunkBounds);
+
+    // Should have temporal boost but NOT boundary boost (base < 0.65)
+    // Time delta: 61000 - 59000 = 2000ms = 2 seconds
+    // Temporal weight: exp(-2/300) ≈ 0.993
+    // After temporal: 0.5 * (1 + 0.5 * 0.993) ≈ 0.5 * 1.497 ≈ 0.748
+    // No boundary boost because base (0.5) < threshold (0.65)
+    expect(matrix[0][1]).toBeCloseTo(0.748, 2);
+    expect(matrix[0][1]).toBeLessThan(0.8); // Should NOT have 1.3x boundary boost
+  });
+});
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function createMockChunkArtifact(
+  chunkIndex: number,
+  segments: Array<{ speakerId: string; startMs: number; endMs: number }>,
+  chunkBounds: { startMs: number; endMs: number; overlapBeforeMs: number; overlapAfterMs: number }
+): ChunkArtifact {
+  return {
+    conversationId: 'test-conv',
+    userId: 'test-user',
+    chunkIndex,
+    totalChunks: 3,
+    segments: segments.map((s, i) => ({
+      segmentId: `seg-${chunkIndex}-${i}`,
+      index: i,
+      speakerId: s.speakerId,
+      startMs: s.startMs,
+      endMs: s.endMs,
+      text: 'Test segment',
+    })),
+    speakers: {},
+    terms: {},
+    termOccurrences: [],
+    topics: [],
+    people: [],
+    chunkBounds,
+    emittedContext: {
+      emittedByChunkIndex: chunkIndex,
+      speakerMap: [],
+      previousSummary: '',
+      knownTermIds: [],
+      knownTopicIds: [],
+      knownPersonIds: [],
+      cumulativeSegmentCount: 0,
+      lastProcessedMs: 0,
+    },
+    createdAt: new Date().toISOString(),
+    storagePath: `chunks/${chunkIndex}.wav`,
+  };
+}

--- a/functions/src/speakerReconciliationEmbeddings.ts
+++ b/functions/src/speakerReconciliationEmbeddings.ts
@@ -13,6 +13,11 @@
 
 import { ChunkArtifact } from './types';
 import { computeWeightedSimilarity } from './speakerQuality';
+import {
+  buildSpeakerAppearanceWindows,
+  buildChunkBoundsMap,
+  applyTemporalBoosts,
+} from './temporalGraph';
 
 // ============================================================================
 // Types
@@ -120,6 +125,18 @@ export function reconcileSpeakersWithEmbeddings(
 
   // Step 2: Compute pairwise quality-weighted cosine similarity matrix
   const similarityMatrix = computeCosineSimilarityMatrix(embeddingEntries);
+
+  // Step 2.5: Apply temporal and boundary boosts to cross-chunk pairs
+  const speakerKeys = embeddingEntries.map(e => e.originalId);
+  const speakerAppearances = buildSpeakerAppearanceWindows(chunkArtifacts);
+  const chunkBounds = buildChunkBoundsMap(chunkArtifacts);
+
+  applyTemporalBoosts(similarityMatrix, speakerKeys, speakerAppearances, chunkBounds);
+
+  console.log('[EmbeddingReconciliation] Applied temporal/boundary boosts:', {
+    speakerAppearanceCount: speakerAppearances.size,
+    chunkBoundsCount: chunkBounds.size
+  });
 
   // Step 3: Cluster using agglomerative clustering
   const clusterLabels = agglomerativeCluster(

--- a/functions/src/temporalGraph.ts
+++ b/functions/src/temporalGraph.ts
@@ -1,0 +1,417 @@
+/**
+ * Temporal Graph Module for Speaker Reconciliation
+ *
+ * Provides temporal proximity weighting and chunk boundary bridging
+ * to improve embedding-based speaker matching across chunks.
+ *
+ * Key concepts:
+ * - Temporal weight: exponential decay based on time since last appearance
+ * - Boundary bridging: boost for speakers at chunk boundaries (where splits are artificial)
+ * - Final similarity: combines base cosine similarity with temporal and boundary boosts
+ */
+
+import { ChunkArtifact, Segment } from './types';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+export const TemporalConfig = {
+  /** Half-life for temporal decay in seconds (5 minutes) */
+  HALF_LIFE_SECONDS: 300,
+
+  /** Maximum temporal window in seconds (1 hour) - no boost beyond this */
+  MAX_WINDOW_SECONDS: 3600,
+
+  /** Temporal boost factor: final = base * (1 + factor * weight) */
+  TEMPORAL_BOOST_FACTOR: 0.5,
+
+  /** Window from chunk boundary to consider "boundary adjacent" (seconds) */
+  BOUNDARY_WINDOW_SECONDS: 30,
+
+  /** Boundary bridge boost multiplier (30% boost) */
+  BOUNDARY_BOOST: 1.3,
+
+  /** Minimum base similarity required for boundary boost */
+  BOUNDARY_SIMILARITY_THRESHOLD: 0.65,
+};
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Appearance window for a speaker in a chunk.
+ * Timestamps are in original audio timeline (milliseconds).
+ */
+export interface SpeakerAppearanceWindow {
+  /** Chunk index where this speaker appeared */
+  chunkIndex: number;
+  /** Speaker ID within the chunk (e.g., "SPEAKER_00") */
+  speakerId: string;
+  /** First appearance in original timeline (ms) */
+  firstOriginalMs: number;
+  /** Last appearance in original timeline (ms) */
+  lastOriginalMs: number;
+}
+
+/**
+ * Key for identifying a unique (chunk, speaker) pair.
+ * Format: "SPEAKER_00_chunk0"
+ */
+export type SpeakerChunkKey = string;
+
+// ============================================================================
+// Core Temporal Functions
+// ============================================================================
+
+/**
+ * Compute temporal weight based on time delta using exponential decay.
+ *
+ * Formula: weight = exp(-timeDelta / halfLife)
+ *
+ * Returns 0 if timeDelta exceeds maxWindow (temporal boost disabled).
+ *
+ * @param timeDeltaSeconds - Absolute time difference between speaker appearances (seconds)
+ * @param halfLifeSeconds - Half-life for decay (default 300s = 5 minutes)
+ * @param maxWindowSeconds - Maximum window for temporal boost (default 3600s = 1 hour)
+ * @returns Temporal weight in [0, 1]
+ */
+export function computeTemporalWeight(
+  timeDeltaSeconds: number,
+  halfLifeSeconds: number = TemporalConfig.HALF_LIFE_SECONDS,
+  maxWindowSeconds: number = TemporalConfig.MAX_WINDOW_SECONDS
+): number {
+  // No temporal boost for very distant appearances
+  if (timeDeltaSeconds > maxWindowSeconds) {
+    return 0;
+  }
+
+  // Negative time deltas shouldn't happen, but handle gracefully
+  if (timeDeltaSeconds < 0) {
+    return 0;
+  }
+
+  // Same-time appearances get full weight
+  if (timeDeltaSeconds === 0) {
+    return 1;
+  }
+
+  // Exponential decay: weight = exp(-t / τ)
+  // At t = halfLife, weight = exp(-1) ≈ 0.368
+  return Math.exp(-timeDeltaSeconds / halfLifeSeconds);
+}
+
+/**
+ * Check if two speakers form a "boundary pair" eligible for boundary bridging.
+ *
+ * Conditions:
+ * 1. They are in adjacent chunks (|chunkA - chunkB| === 1)
+ * 2. At least one speaker is within BOUNDARY_WINDOW_SECONDS of the chunk boundary
+ *
+ * @param windowA - Speaker appearance window in chunk A
+ * @param windowB - Speaker appearance window in chunk B
+ * @param chunkBounds - Chunk boundary info for both chunks (keyed by chunkIndex)
+ * @returns True if this is a valid boundary pair
+ */
+export function isBoundaryPair(
+  windowA: SpeakerAppearanceWindow,
+  windowB: SpeakerAppearanceWindow,
+  chunkBounds: Map<number, { startMs: number; endMs: number }>
+): boolean {
+  // Must be adjacent chunks
+  const chunkDiff = Math.abs(windowA.chunkIndex - windowB.chunkIndex);
+  if (chunkDiff !== 1) {
+    return false;
+  }
+
+  // Determine which is the earlier chunk
+  const [earlier, later] = windowA.chunkIndex < windowB.chunkIndex
+    ? [windowA, windowB]
+    : [windowB, windowA];
+
+  const earlierBounds = chunkBounds.get(earlier.chunkIndex);
+  const laterBounds = chunkBounds.get(later.chunkIndex);
+
+  if (!earlierBounds || !laterBounds) {
+    return false;
+  }
+
+  const boundaryWindowMs = TemporalConfig.BOUNDARY_WINDOW_SECONDS * 1000;
+
+  // Earlier speaker should be near the END of their chunk
+  const earlierDistanceFromEnd = earlierBounds.endMs - earlier.lastOriginalMs;
+  const earlierNearBoundary = earlierDistanceFromEnd <= boundaryWindowMs;
+
+  // Later speaker should be near the START of their chunk
+  const laterDistanceFromStart = later.firstOriginalMs - laterBounds.startMs;
+  const laterNearBoundary = laterDistanceFromStart <= boundaryWindowMs;
+
+  // At least one must be near the boundary
+  return earlierNearBoundary || laterNearBoundary;
+}
+
+/**
+ * Compute final similarity with temporal and boundary boosts.
+ *
+ * Combines:
+ * 1. Base similarity (quality-weighted cosine)
+ * 2. Temporal proximity boost (if within temporal window)
+ * 3. Boundary bridge boost (if adjacent chunks + near boundary + high similarity)
+ *
+ * @param baseSimilarity - Quality-weighted cosine similarity (may be negative)
+ * @param temporalWeight - Temporal weight from computeTemporalWeight [0,1]
+ * @param isBoundary - Whether this is a boundary pair
+ * @param config - Optional config override
+ * @returns Final boosted similarity, capped at 1.0
+ */
+export function computeFinalSimilarity(
+  baseSimilarity: number,
+  temporalWeight: number,
+  isBoundary: boolean,
+  config: Partial<typeof TemporalConfig> = {}
+): number {
+  const boostFactor = config.TEMPORAL_BOOST_FACTOR ?? TemporalConfig.TEMPORAL_BOOST_FACTOR;
+  const boundaryBoost = config.BOUNDARY_BOOST ?? TemporalConfig.BOUNDARY_BOOST;
+  const boundaryThreshold = config.BOUNDARY_SIMILARITY_THRESHOLD ?? TemporalConfig.BOUNDARY_SIMILARITY_THRESHOLD;
+
+  let finalSimilarity = baseSimilarity;
+
+  // Apply temporal boost: final = base * (1 + factor * weight)
+  // Only applies if there's actual temporal proximity (weight > 0)
+  if (temporalWeight > 0) {
+    finalSimilarity = baseSimilarity * (1 + boostFactor * temporalWeight);
+  }
+
+  // Apply boundary boost if eligible
+  // Must be a boundary pair AND base similarity must be above threshold
+  if (isBoundary && baseSimilarity > boundaryThreshold) {
+    finalSimilarity = finalSimilarity * boundaryBoost;
+  }
+
+  // Cap at 1.0 to maintain similarity semantics
+  return Math.min(1.0, finalSimilarity);
+}
+
+// ============================================================================
+// Speaker Appearance Window Building
+// ============================================================================
+
+/**
+ * Build speaker appearance windows from chunk artifacts.
+ *
+ * For each (chunk, speaker) pair, computes the first and last appearance
+ * times in the original audio timeline.
+ *
+ * @param chunkArtifacts - Array of chunk artifacts with segments
+ * @returns Map from SpeakerChunkKey to SpeakerAppearanceWindow
+ */
+export function buildSpeakerAppearanceWindows(
+  chunkArtifacts: ChunkArtifact[]
+): Map<SpeakerChunkKey, SpeakerAppearanceWindow> {
+  const windows = new Map<SpeakerChunkKey, SpeakerAppearanceWindow>();
+
+  for (const artifact of chunkArtifacts) {
+    const { chunkIndex, segments, chunkBounds } = artifact;
+
+    // Group segments by speaker
+    const speakerSegments = new Map<string, Segment[]>();
+    for (const segment of segments) {
+      const existing = speakerSegments.get(segment.speakerId) ?? [];
+      existing.push(segment);
+      speakerSegments.set(segment.speakerId, existing);
+    }
+
+    // Build window for each speaker
+    for (const [speakerId, segs] of speakerSegments) {
+      if (segs.length === 0) continue;
+
+      // Segments already have timestamps in original timeline (converted during artifact creation)
+      // But we need to verify - if they're chunk-local, we'd need to convert
+      // Per codebase: chunkMerge.ts converts to original timeline, but artifacts store chunk-local
+      // Let's use chunkBounds to convert if needed
+
+      // Actually, examining types.ts: ChunkArtifact.segments have "chunk-local timestamps initially"
+      // We need to convert using chunkBounds
+      const chunkAudioStartMs = chunkBounds.startMs - chunkBounds.overlapBeforeMs;
+
+      let firstMs = Infinity;
+      let lastMs = -Infinity;
+
+      for (const seg of segs) {
+        // Convert chunk-local to original timeline
+        const originalStartMs = chunkAudioStartMs + seg.startMs;
+        const originalEndMs = chunkAudioStartMs + seg.endMs;
+
+        if (originalStartMs < firstMs) firstMs = originalStartMs;
+        if (originalEndMs > lastMs) lastMs = originalEndMs;
+      }
+
+      if (firstMs !== Infinity && lastMs !== -Infinity) {
+        const key = `${speakerId}_chunk${chunkIndex}`;
+        windows.set(key, {
+          chunkIndex,
+          speakerId,
+          firstOriginalMs: firstMs,
+          lastOriginalMs: lastMs,
+        });
+      }
+    }
+  }
+
+  return windows;
+}
+
+/**
+ * Build chunk bounds map from chunk artifacts.
+ *
+ * @param chunkArtifacts - Array of chunk artifacts
+ * @returns Map from chunkIndex to {startMs, endMs}
+ */
+export function buildChunkBoundsMap(
+  chunkArtifacts: ChunkArtifact[]
+): Map<number, { startMs: number; endMs: number }> {
+  const boundsMap = new Map<number, { startMs: number; endMs: number }>();
+
+  for (const artifact of chunkArtifacts) {
+    boundsMap.set(artifact.chunkIndex, {
+      startMs: artifact.chunkBounds.startMs,
+      endMs: artifact.chunkBounds.endMs,
+    });
+  }
+
+  return boundsMap;
+}
+
+// ============================================================================
+// Time Delta Computation
+// ============================================================================
+
+/**
+ * Compute the time delta between two speaker appearances.
+ *
+ * Uses the closest edges of their appearance windows:
+ * - If A ends before B starts: delta = B.first - A.last
+ * - If B ends before A starts: delta = A.first - B.last
+ * - If they overlap: delta = 0
+ *
+ * @param windowA - First speaker's appearance window
+ * @param windowB - Second speaker's appearance window
+ * @returns Time delta in milliseconds (always >= 0)
+ */
+export function computeTimeDeltaMs(
+  windowA: SpeakerAppearanceWindow,
+  windowB: SpeakerAppearanceWindow
+): number {
+  // Check for overlap
+  if (windowA.lastOriginalMs >= windowB.firstOriginalMs &&
+      windowB.lastOriginalMs >= windowA.firstOriginalMs) {
+    // Overlapping windows - no temporal gap
+    return 0;
+  }
+
+  // Non-overlapping - compute gap
+  if (windowA.lastOriginalMs < windowB.firstOriginalMs) {
+    // A ends before B starts
+    return windowB.firstOriginalMs - windowA.lastOriginalMs;
+  } else {
+    // B ends before A starts
+    return windowA.firstOriginalMs - windowB.lastOriginalMs;
+  }
+}
+
+/**
+ * Compute time delta in seconds.
+ * Convenience wrapper around computeTimeDeltaMs.
+ */
+export function computeTimeDeltaSeconds(
+  windowA: SpeakerAppearanceWindow,
+  windowB: SpeakerAppearanceWindow
+): number {
+  return computeTimeDeltaMs(windowA, windowB) / 1000;
+}
+
+// ============================================================================
+// Integration Helpers
+// ============================================================================
+
+/**
+ * Determine if a pair is cross-chunk (eligible for temporal boost).
+ *
+ * Intra-chunk pairs (same chunk) don't get temporal boost because
+ * they're already being compared within the same context.
+ *
+ * @param keyA - Speaker chunk key A (e.g., "SPEAKER_00_chunk0")
+ * @param keyB - Speaker chunk key B (e.g., "SPEAKER_01_chunk1")
+ * @returns True if the speakers are from different chunks
+ */
+export function isCrossChunkPair(keyA: SpeakerChunkKey, keyB: SpeakerChunkKey): boolean {
+  const matchA = keyA.match(/_chunk(\d+)$/);
+  const matchB = keyB.match(/_chunk(\d+)$/);
+
+  if (!matchA || !matchB) {
+    // Can't determine chunk - treat as same chunk (no boost)
+    return false;
+  }
+
+  return matchA[1] !== matchB[1];
+}
+
+/**
+ * Apply temporal and boundary boosts to a similarity matrix.
+ *
+ * This is the main integration point for speaker reconciliation.
+ * Call this after computing the quality-weighted cosine similarity matrix.
+ *
+ * @param matrix - NxN similarity matrix (will be modified in place)
+ * @param speakerKeys - Array of speaker keys corresponding to matrix indices
+ * @param appearances - Speaker appearance windows
+ * @param chunkBounds - Chunk boundary info
+ */
+export function applyTemporalBoosts(
+  matrix: number[][],
+  speakerKeys: string[],
+  appearances: Map<SpeakerChunkKey, SpeakerAppearanceWindow>,
+  chunkBounds: Map<number, { startMs: number; endMs: number }>
+): void {
+  const n = matrix.length;
+
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const keyA = speakerKeys[i];
+      const keyB = speakerKeys[j];
+
+      // Only apply boosts to cross-chunk pairs
+      if (!isCrossChunkPair(keyA, keyB)) {
+        continue;
+      }
+
+      const windowA = appearances.get(keyA);
+      const windowB = appearances.get(keyB);
+
+      if (!windowA || !windowB) {
+        // No appearance data - can't compute temporal boost
+        continue;
+      }
+
+      // Compute temporal weight
+      const timeDeltaSeconds = computeTimeDeltaSeconds(windowA, windowB);
+      const temporalWeight = computeTemporalWeight(timeDeltaSeconds);
+
+      // Check if boundary pair
+      const boundary = isBoundaryPair(windowA, windowB, chunkBounds);
+
+      // Apply boosts
+      const baseSimilarity = matrix[i][j];
+      const boostedSimilarity = computeFinalSimilarity(
+        baseSimilarity,
+        temporalWeight,
+        boundary
+      );
+
+      // Update matrix (symmetric)
+      matrix[i][j] = boostedSimilarity;
+      matrix[j][i] = boostedSimilarity;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Speakers appearing close in time now receive similarity boosts via exponential decay (5-minute half-life)
- Chunk boundary bridging: speakers within 30 seconds of chunk edges get additional boost when similarity > 0.65
- Time window constraint prevents false merges for speakers more than 1 hour apart

## Changelog Entry
```markdown
- **Temporal Proximity Speaker Reconciliation** - Speaker matching now considers when speakers appear in the audio timeline
  - Speakers appearing close in time receive similarity boosts via exponential decay (5-minute half-life)
  - Speakers at chunk boundaries (within 30 seconds of edge) receive additional bridging boost when similarity > 0.65
  - Time window constraint: no temporal boost for speakers more than 1 hour apart
  - Reduces false speaker splits when the same person speaks across chunk boundaries
```

## Test Plan
- [x] TypeScript build passes
- [x] 43 new unit tests covering temporal weight decay, boundary detection, and boost application
- [x] All 49 scoped tests pass (43 temporal + 6 quality integration)
- [ ] Manual testing with multi-chunk audio files (reviewer discretion)

---
Scope: `speaker_reconciliation_02_temporal_distance_modeling`
Iteration: `iteration_01`
Build: `14`