### PR TITLE
fix(transcribe): sanitize chunk artifacts before Firestore save

### DIFF
--- a/functions/src/transcribe.ts
+++ b/functions/src/transcribe.ts
@@ -37,7 +37,8 @@ import {
 } from './chunking';
 import { validateChunkSequence } from './chunkBounds';
 import {
-  createInitialChunkStatuses
+  createInitialChunkStatuses,
+  sanitizeForFirestore
 } from './chunkContext';
 import {
   ChunkingMetadata,
@@ -1205,13 +1206,17 @@ export async function executeTranscriptionPipeline(params: TranscriptionPipeline
         storagePath: filePath
       };
 
+      // Sanitize to remove undefined values (Firestore doesn't allow them)
+      // e.g., Person.affiliation is optional but Firestore rejects undefined
+      const sanitizedChunkArtifact = sanitizeForFirestore(chunkArtifact);
+
       await retryWithBackoff(
         () => db
           .collection('conversations')
           .doc(conversationId)
           .collection('chunks')
           .doc(String(chunkMetadata.chunkIndex))
-          .set(chunkArtifact),
+          .set(sanitizedChunkArtifact),
         'Firestore save chunk artifact'
       );
 
@@ -1245,14 +1250,19 @@ export async function executeTranscriptionPipeline(params: TranscriptionPipeline
       });
     } else {
       // For whole-file tasks, update the main conversation document as before
+      // Sanitize to remove undefined values (Firestore doesn't allow them)
+      const sanitizedData = sanitizeForFirestore({
+        ...processedData,
+        status: 'complete',
+        alignmentStatus: finalAlignmentStatus,
+        alignmentError: usedGeminiFallback ? 'WhisperX failed, used Gemini fallback' : null,
+        abortRequested: false,
+        audioStoragePath: filePath
+      });
+
       await retryWithBackoff(
         () => db.collection('conversations').doc(conversationId).update({
-          ...processedData,
-          status: 'complete',
-          alignmentStatus: finalAlignmentStatus,
-          alignmentError: usedGeminiFallback ? 'WhisperX failed, used Gemini fallback' : null,
-          abortRequested: false,
-          audioStoragePath: filePath,
+          ...sanitizedData,
           updatedAt: FieldValue.serverTimestamp()
         }),
         'Firestore save results'


### PR DESCRIPTION
## Summary

- Fixes transient Firestore failures caused by `undefined` values in optional fields (e.g., `Person.affiliation`)
- Applies `sanitizeForFirestore()` to chunk artifacts and whole-file saves before writing to Firestore

## Context

During chunk processing, Gemini occasionally returns people without the `affiliation` field. Since `Person.affiliation` is typed as optional (`affiliation?: string`), this results in `undefined` values. Firestore rejects documents containing `undefined`, causing the chunk to fail.

Cloud Tasks would retry and often succeed (if Gemini returned the field on retry), but this fix prevents the transient failure entirely.

## Test plan

- [x] TypeScript build passes
- [x] Pre-commit hooks pass
- [ ] Deploy and verify no more "Cannot use undefined as a Firestore value" errors