### PR TITLE
chore(release): v2.5.1-beta.2

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -216,6 +216,17 @@ jobs:
         run: |
           firebase deploy --only functions --force
 
+      # Initialize feature flags in Firestore (idempotent - preserves existing values)
+      - name: Install Root Dependencies
+        if: github.event_name == 'push' || github.event.inputs.deploy_target != 'rules-only'
+        run: npm ci
+
+      - name: Initialize Feature Flags
+        if: github.event_name == 'push' || github.event.inputs.deploy_target != 'rules-only'
+        run: |
+          echo "Initializing feature flags..."
+          node scripts/init-feature-flags.js ${{ env.FIREBASE_PROJECT_ID }}
+
       - name: Deployment Summary
         if: success()
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.1-beta.2] - 2026-01-25
+
+### Added
+- **Automatic Feature Flag Initialization** - CI/CD pipeline now creates Firestore feature flags during deployment
+  - New `scripts/init-feature-flags.js` creates `/system/feature_flags` document when missing
+  - Idempotent: preserves existing values, only creates if document doesn't exist
+  - Production-ready defaults: `enableContextAwareReconciliation=true`, `contextAwareRolloutPercentage=100`
+  - Deployment logs clearly show initialization status (created or already exists)
+
+### Changed
+- **Firebase Deploy Workflow** - Added root dependency installation and feature flag initialization steps
+  - Runs after functions deploy, before summary
+  - Conditionally skipped for "rules-only" deployments
+
 ## [2.5.1-beta.1] - 2026-01-25
 
 ### Added

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -1,5 +1,16 @@
 # What's New
 
+## Version 2.5.1-beta.2 - January 25, 2026
+
+### 🔧 Behind the Scenes
+
+**Zero-Configuration Deployments**
+- Speaker reconciliation feature flags are now automatically created during deployment
+- Fresh deployments work immediately—no manual Firestore setup required
+- Existing settings are preserved; the system only initializes when flags don't exist
+
+---
+
 ## Version 2.5.1-beta.1 - January 25, 2026
 
 ### 🔧 Behind the Scenes

--- a/docs/how-to/speaker-reconciliation-rollout.md
+++ b/docs/how-to/speaker-reconciliation-rollout.md
@@ -30,6 +30,50 @@ Feature flags are stored in Firestore at:
 | `disableReason` | string | Human-readable reason for auto-disable |
 | `updatedAt` | timestamp | Last modification time |
 
+## Automatic Initialization (CI/CD)
+
+The feature flags document is **automatically created** during Firebase deployment if it doesn't already exist. This ensures a consistent baseline configuration across environments.
+
+### How It Works
+
+1. After Cloud Functions deploy, the CI/CD pipeline runs `scripts/init-feature-flags.js`
+2. The script checks if `/system/feature_flags` exists
+3. If missing, it creates the document with production-ready defaults:
+   - `enableContextAwareReconciliation: true`
+   - `contextAwareRolloutPercentage: 100`
+   - `forceEmbeddingOnlyConversationIds: []`
+4. If the document already exists, **existing values are preserved** (no overwrites)
+
+### Deployment Logs
+
+The deployment output shows initialization status:
+
+```
+# Fresh deployment (document created)
+Initializing feature flags...
+✓ Feature flags initialized with defaults
+  Values: {"enableContextAwareReconciliation":true,"contextAwareRolloutPercentage":100,"forceEmbeddingOnlyConversationIds":[]}
+
+# Subsequent deployment (document preserved)
+Initializing feature flags...
+✓ Feature flags already initialized
+  Current values: {"enableContextAwareReconciliation":true,"contextAwareRolloutPercentage":50,...}
+```
+
+### Manual Initialization (Fallback)
+
+If you need to create the feature flags document manually (e.g., before first deployment or in a fresh environment), you can:
+
+**Option 1: Run the script locally**
+```bash
+# Requires gcloud auth or service account credentials
+node scripts/init-feature-flags.js YOUR_PROJECT_ID
+```
+
+**Option 2: Create via Firebase Console**
+
+Navigate to Firestore > `/system/feature_flags` and create the document with the fields listed in the table above.
+
 ## Rollout Procedure
 
 ### Step 1: Pre-flight Checks

--- a/scripts/init-feature-flags.js
+++ b/scripts/init-feature-flags.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Initialize feature flags document in Firestore
+ *
+ * Idempotent: Only creates if doesn't exist, preserves existing values.
+ * Uses Application Default Credentials (ADC) from gcloud auth or service account.
+ *
+ * Usage: node scripts/init-feature-flags.js [project-id]
+ *
+ * Exit codes:
+ *   0 - Success (created or already exists)
+ *   1 - Error (no project ID, auth failure, etc.)
+ */
+import admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
+
+const projectId =
+  process.argv[2] ||
+  process.env.FIREBASE_PROJECT_ID ||
+  process.env.GCP_PROJECT_ID;
+
+if (!projectId) {
+  console.error('✗ No project ID provided');
+  console.error('  Usage: node scripts/init-feature-flags.js <project-id>');
+  console.error(
+    '  Or set FIREBASE_PROJECT_ID or GCP_PROJECT_ID environment variable'
+  );
+  process.exit(1);
+}
+
+admin.initializeApp({ projectId });
+const db = admin.firestore();
+
+// Default values for speaker reconciliation feature flags
+const DEFAULTS = {
+  enableContextAwareReconciliation: true,
+  contextAwareRolloutPercentage: 100,
+  forceEmbeddingOnlyConversationIds: [],
+};
+
+async function initFeatureFlags() {
+  const docRef = db.collection('system').doc('feature_flags');
+  const doc = await docRef.get();
+
+  if (doc.exists) {
+    console.log('✓ Feature flags already initialized');
+    console.log('  Current values:', JSON.stringify(doc.data(), null, 2));
+    return;
+  }
+
+  await docRef.set({
+    ...DEFAULTS,
+    createdAt: FieldValue.serverTimestamp(),
+    initializedBy: 'ci-cd-init',
+  });
+
+  console.log('✓ Feature flags initialized with defaults');
+  console.log('  Values:', JSON.stringify(DEFAULTS, null, 2));
+}
+
+initFeatureFlags()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error('✗ Failed to initialize feature flags:', e.message);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Beta Release v2.5.1-beta.2

### Added
- **Automatic Feature Flag Initialization** - CI/CD pipeline now creates Firestore feature flags during deployment
  - New `scripts/init-feature-flags.js` creates `/system/feature_flags` document when missing
  - Idempotent: preserves existing values, only creates if document doesn't exist
  - Production-ready defaults: `enableContextAwareReconciliation=true`, `contextAwareRolloutPercentage=100`
  - Deployment logs clearly show initialization status (created or already exists)

### Changed
- **Firebase Deploy Workflow** - Added root dependency installation and feature flag initialization steps
  - Runs after functions deploy, before summary
  - Conditionally skipped for "rules-only" deployments

## Testing This Beta

The feature flag initialization script will run automatically on the next Firebase deployment. Expected log output:
- `✓ Created feature_flags document with defaults` (fresh deployment)
- `✓ feature_flags document already exists, skipping` (existing deployment)

Manual testing:
```bash
node scripts/init-feature-flags.js <project-id>
```

---
Scope: `speaker_reconciliation_context_aware_speaker_reconciliation_requirements_05`
Tag: `v2.5.1-beta.2`
Build: `18`