### PR TITLE
feat(speaker-merge): add manual speaker merge workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Manual Speaker Merge** - Correct diarization errors by merging speakers in the sidebar
+  - New "Speakers" tab in Viewer sidebar shows all speakers with merge controls
+  - 3-click workflow: Click "Merge" on source speaker → Select target → Confirm
+  - Corrections persist via Firestore subcollection using apply-on-read pattern
+  - "Undo Last Merge" button reverses most recent correction
+  - Original transcript data remains immutable (corrections applied at render time)
+
 ## [2.6.0] - 2026-01-28
 
 ### Added

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -107,6 +107,49 @@ interface ChatHistoryDoc {
 
 **Security**: Users can only access chat history for conversations they own. Messages are immutable (no updates allowed).
 
+#### conversations/{conversationId}/speakerCorrections (subcollection)
+
+Manual speaker merge operations. Users can merge incorrectly diarized speakers from the UI (e.g., "Speaker 2" is actually "Tom"). Corrections are applied at read time - original data remains immutable.
+
+**Path**: `conversations/{conversationId}/speakerCorrections/{correctionId}`
+
+```typescript
+interface SpeakerCorrectionDoc {
+  type: 'merge';                 // Correction type (future: 'split', 'rename', etc.)
+  sourceSpeakerId: string;       // Speaker being merged away (removed from speaker list)
+  targetSpeakerId: string;       // Speaker to merge into (all source segments reassigned)
+  userId: string;                // User who created the correction
+  createdAt: Timestamp;          // Server timestamp
+}
+```
+
+**Apply-on-Read Pattern**:
+- Corrections are NOT applied to the stored conversation data
+- Client applies corrections in order when loading conversation:
+  1. Load original speakers and segments from conversation document
+  2. Load corrections from subcollection (ordered by createdAt)
+  3. For each merge correction:
+     - Remove sourceSpeakerId from speaker list
+     - Remap all segments from sourceSpeakerId to targetSpeakerId
+  4. Display corrected data to user
+
+**Undo Support**:
+- Delete the most recent correction document to undo
+- Client re-applies remaining corrections on next read
+- Full correction history is preserved (cannot undo individual merges from middle of sequence)
+
+**Features**:
+- Real-time synchronization (Firestore listener)
+- Persists across reloads and devices
+- 3-click workflow: Click merge button → Select target speaker → Confirm
+- Non-destructive (original data unchanged)
+- Audit trail for debugging diarization issues
+
+**Security**:
+- Users can only read/delete corrections for conversations they own
+- Corrections are created via Cloud Function (not directly by client)
+- Immutable once created (no updates allowed)
+
 ### users
 
 User profile, preferences, and admin status.

--- a/firestore.rules
+++ b/firestore.rules
@@ -77,6 +77,24 @@ service cloud.firestore {
           && get(/databases/$(database)/documents/conversations/$(conversationId)).data.userId == request.auth.uid;
       }
 
+      // Speaker corrections subcollection - manual speaker merge records
+      match /speakerCorrections/{correctionId} {
+        // Users can only read corrections for their own conversations
+        allow read: if isAuthenticated()
+          && get(/databases/$(database)/documents/conversations/$(conversationId)).data.userId == request.auth.uid;
+
+        // Cloud Functions create corrections (via mergeSpeakers callable)
+        // Users cannot directly create via client SDK
+        allow create: if false;
+
+        // Users can delete corrections from their own conversations (for undo)
+        allow delete: if isAuthenticated()
+          && get(/databases/$(database)/documents/conversations/$(conversationId)).data.userId == request.auth.uid;
+
+        // Corrections are immutable once created (no updates)
+        allow update: if false;
+      }
+
       // Chunks subcollection - intermediate artifacts during chunk processing
       match /chunks/{chunkIndex} {
         // Users can read chunks for their own conversations

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -64,6 +64,7 @@ export { processTranscription } from './processTranscription';
 export { processMerge, processReprocessing } from './chunkMerge';
 export { chatWithConversation } from './chat';
 export { retryTranscription } from './retry';
+export { mergeSpeakers } from './speakerCorrections';
 
 // Export stats tracking triggers
 export { onConversationCreated, onConversationDeleted } from './statsTriggers';

--- a/functions/src/speakerCorrections.ts
+++ b/functions/src/speakerCorrections.ts
@@ -1,0 +1,150 @@
+/**
+ * Speaker Corrections Cloud Function
+ *
+ * Handles manual speaker merge operations.
+ * Users can merge incorrectly diarized speakers from the UI.
+ *
+ * Features:
+ * - Requires authentication and ownership verification
+ * - Writes correction records to speakerCorrections subcollection
+ * - Client applies corrections at read time (apply-on-read pattern)
+ */
+
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { db } from './index';
+import { log } from './logger';
+
+interface MergeSpeakersRequest {
+  conversationId: string;
+  sourceSpeakerId: string;  // Speaker being merged away
+  targetSpeakerId: string;  // Speaker to merge into
+}
+
+interface MergeSpeakersResponse {
+  success: boolean;
+  correctionId: string;
+}
+
+/**
+ * Merge two speakers by writing a correction record.
+ *
+ * Security:
+ * - Requires authentication
+ * - Verifies user owns the conversation
+ * - Validates speaker IDs exist
+ *
+ * The correction is stored in the speakerCorrections subcollection
+ * and applied at read time by the client.
+ */
+export const mergeSpeakers = onCall<MergeSpeakersRequest>(
+  {
+    region: 'us-central1',
+    memory: '256MiB',
+    timeoutSeconds: 30,
+    cors: true
+  },
+  async (request): Promise<MergeSpeakersResponse> => {
+    // Require authentication
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Must be signed in to merge speakers');
+    }
+
+    const { conversationId, sourceSpeakerId, targetSpeakerId } = request.data;
+    const userId = request.auth.uid;
+
+    // Validate input
+    if (!conversationId) {
+      throw new HttpsError('invalid-argument', 'conversationId is required');
+    }
+    if (!sourceSpeakerId || !targetSpeakerId) {
+      throw new HttpsError('invalid-argument', 'sourceSpeakerId and targetSpeakerId are required');
+    }
+    if (sourceSpeakerId === targetSpeakerId) {
+      throw new HttpsError('invalid-argument', 'Cannot merge a speaker into itself');
+    }
+
+    log.info('Speaker merge request received', {
+      conversationId,
+      userId,
+      sourceSpeakerId,
+      targetSpeakerId
+    });
+
+    try {
+      // Fetch conversation and verify ownership
+      const conversationDoc = await db.collection('conversations').doc(conversationId).get();
+
+      if (!conversationDoc.exists) {
+        throw new HttpsError('not-found', 'Conversation not found');
+      }
+
+      const conversation = conversationDoc.data();
+      if (!conversation) {
+        throw new HttpsError('not-found', 'Conversation data not found');
+      }
+
+      if (conversation.userId !== userId) {
+        throw new HttpsError('permission-denied', 'You do not have access to this conversation');
+      }
+
+      // Validate that both speakers exist in the conversation
+      const speakers = conversation.speakers || {};
+      if (!speakers[sourceSpeakerId]) {
+        throw new HttpsError('invalid-argument', `Source speaker '${sourceSpeakerId}' not found`);
+      }
+      if (!speakers[targetSpeakerId]) {
+        throw new HttpsError('invalid-argument', `Target speaker '${targetSpeakerId}' not found`);
+      }
+
+      // Write correction record to subcollection
+      const correctionRef = db
+        .collection('conversations')
+        .doc(conversationId)
+        .collection('speakerCorrections')
+        .doc(); // Auto-generate ID
+
+      const correctionData = {
+        type: 'merge',
+        sourceSpeakerId,
+        targetSpeakerId,
+        userId,
+        createdAt: new Date() // Firestore will convert to Timestamp
+      };
+
+      await correctionRef.set(correctionData);
+
+      log.info('Speaker merge correction saved', {
+        conversationId,
+        userId,
+        correctionId: correctionRef.id,
+        sourceSpeakerId,
+        targetSpeakerId
+      });
+
+      return {
+        success: true,
+        correctionId: correctionRef.id
+      };
+
+    } catch (error) {
+      log.error('Speaker merge request failed', {
+        conversationId,
+        userId,
+        sourceSpeakerId,
+        targetSpeakerId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+
+      // Re-throw HttpsErrors as-is
+      if (error instanceof HttpsError) {
+        throw error;
+      }
+
+      // Wrap other errors
+      throw new HttpsError(
+        'internal',
+        'Failed to merge speakers: ' + (error instanceof Error ? error.message : String(error))
+      );
+    }
+  }
+);

--- a/src/components/viewer/Sidebar.tsx
+++ b/src/components/viewer/Sidebar.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { Term, Person, Speaker } from '@/config/types';
 import { cn } from '@/utils';
-import { BookOpen, Search, Users, User, StickyNote, ChevronLeft, ChevronRight, MessageSquare } from 'lucide-react';
+import { BookOpen, Search, Users, User, StickyNote, ChevronLeft, ChevronRight, MessageSquare, Mic, Undo2 } from 'lucide-react';
 import { ChatSidebar } from './ChatSidebar';
 import { ChatHistoryMessage } from '@/services/chatHistoryService';
+import { Button } from '../Button';
 
 interface SidebarProps {
   terms: Term[];
@@ -40,8 +41,12 @@ interface SidebarProps {
   chatSuggestions?: string[];
   chatCumulativeCostUsd?: number;
   chatCostWarningLevel?: 'none' | 'primary' | 'escalated';
+  // Speaker corrections props
+  canUndoMerge?: boolean;
+  onUndoMerge?: () => void;
+  onMergeSpeaker?: (speakerId: string) => void;
   // Mobile support
-  defaultTab?: 'context' | 'people' | 'chat';
+  defaultTab?: 'context' | 'people' | 'speakers' | 'chat';
 }
 
 export const Sidebar: React.FC<SidebarProps> = ({
@@ -78,9 +83,13 @@ export const Sidebar: React.FC<SidebarProps> = ({
   chatSuggestions = [],
   chatCumulativeCostUsd = 0,
   chatCostWarningLevel = 'none',
+  // Speaker corrections
+  canUndoMerge = false,
+  onUndoMerge = () => {},
+  onMergeSpeaker = () => {},
   defaultTab = 'context'
 }) => {
-  const [activeTab, setActiveTab] = useState<'context' | 'people' | 'chat'>(defaultTab);
+  const [activeTab, setActiveTab] = useState<'context' | 'people' | 'speakers' | 'chat'>(defaultTab);
   const [searchTerm, setSearchTerm] = useState('');
 
   // Filtering based on active tab
@@ -97,8 +106,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
   return (
     <div className="h-full flex flex-col bg-white border-l border-slate-200">
 
-      {/* Search Header (hide for chat tab) */}
-      {activeTab !== 'chat' && (
+      {/* Search Header (hide for chat and speakers tabs) */}
+      {activeTab !== 'chat' && activeTab !== 'speakers' && (
         <div className="p-4 border-b border-slate-200 bg-slate-50/50">
           <div className="relative mb-3">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" size={14} />
@@ -112,41 +121,44 @@ export const Sidebar: React.FC<SidebarProps> = ({
           </div>
 
           {/* Tabs */}
-          <div className="flex p-1 bg-slate-200/60 rounded-lg">
+          <div className="grid grid-cols-4 p-1 bg-slate-200/60 rounded-lg gap-1">
             <button
               onClick={() => setActiveTab('context')}
               className={cn(
-                "flex-1 flex items-center justify-center gap-2 py-1.5 text-xs font-medium rounded-md transition-all",
+                "flex items-center justify-center gap-1 py-1.5 text-xs font-medium rounded-md transition-all",
                 activeTab === 'context'
                   ? "bg-white text-blue-600 shadow-sm"
                   : "text-slate-500 hover:text-slate-700 hover:bg-slate-200/50"
               )}
             >
               <BookOpen size={14} />
-              Context
+              <span className="hidden sm:inline">Context</span>
             </button>
             <button
               onClick={() => setActiveTab('people')}
               className={cn(
-                "flex-1 flex items-center justify-center gap-2 py-1.5 text-xs font-medium rounded-md transition-all",
+                "flex items-center justify-center gap-1 py-1.5 text-xs font-medium rounded-md transition-all",
                 activeTab === 'people'
                   ? "bg-white text-blue-600 shadow-sm"
                   : "text-slate-500 hover:text-slate-700 hover:bg-slate-200/50"
               )}
             >
               <Users size={14} />
-              People
+              <span className="hidden sm:inline">People</span>
+            </button>
+            <button
+              onClick={() => setActiveTab('speakers')}
+              className="flex items-center justify-center gap-1 py-1.5 text-xs font-medium rounded-md transition-all text-slate-500 hover:text-slate-700 hover:bg-slate-200/50"
+            >
+              <Mic size={14} />
+              <span className="hidden sm:inline">Speakers</span>
             </button>
             <button
               onClick={() => setActiveTab('chat')}
-              className={cn(
-                "flex-1 flex items-center justify-center gap-2 py-1.5 text-xs font-medium rounded-md transition-all relative",
-                // Note: This renders only when activeTab !== 'chat', so chat tab is never active here
-                "text-slate-500 hover:text-slate-700 hover:bg-slate-200/50"
-              )}
+              className="flex items-center justify-center gap-1 py-1.5 text-xs font-medium rounded-md transition-all relative text-slate-500 hover:text-slate-700 hover:bg-slate-200/50"
             >
               <MessageSquare size={14} />
-              Chat
+              <span className="hidden sm:inline">Chat</span>
               {chatMessageCount > 0 && (
                 <span className="absolute -top-1 -right-1 w-4 h-4 bg-blue-600 text-white text-[9px] font-bold rounded-full flex items-center justify-center">
                   {chatMessageCount > 9 ? '9+' : chatMessageCount}
@@ -157,39 +169,53 @@ export const Sidebar: React.FC<SidebarProps> = ({
         </div>
       )}
 
-      {/* Tab Header for Chat (replaces search header when chat active) */}
-      {activeTab === 'chat' && (
+      {/* Tab Header for Chat and Speakers (replaces search header when active) */}
+      {(activeTab === 'chat' || activeTab === 'speakers') && (
         <div className="p-4 border-b border-slate-200 bg-slate-50/50">
-          <div className="flex p-1 bg-slate-200/60 rounded-lg">
+          <div className="grid grid-cols-4 p-1 bg-slate-200/60 rounded-lg gap-1">
             <button
               onClick={() => setActiveTab('context')}
               className={cn(
-                "flex-1 flex items-center justify-center gap-2 py-1.5 text-xs font-medium rounded-md transition-all",
+                "flex items-center justify-center gap-1 py-1.5 text-xs font-medium rounded-md transition-all",
                 "text-slate-500 hover:text-slate-700 hover:bg-slate-200/50"
               )}
             >
               <BookOpen size={14} />
-              Context
+              <span className="hidden sm:inline">Context</span>
             </button>
             <button
               onClick={() => setActiveTab('people')}
               className={cn(
-                "flex-1 flex items-center justify-center gap-2 py-1.5 text-xs font-medium rounded-md transition-all",
+                "flex items-center justify-center gap-1 py-1.5 text-xs font-medium rounded-md transition-all",
                 "text-slate-500 hover:text-slate-700 hover:bg-slate-200/50"
               )}
             >
               <Users size={14} />
-              People
+              <span className="hidden sm:inline">People</span>
+            </button>
+            <button
+              onClick={() => setActiveTab('speakers')}
+              className={cn(
+                "flex items-center justify-center gap-1 py-1.5 text-xs font-medium rounded-md transition-all",
+                activeTab === 'speakers'
+                  ? "bg-white text-blue-600 shadow-sm"
+                  : "text-slate-500 hover:text-slate-700 hover:bg-slate-200/50"
+              )}
+            >
+              <Mic size={14} />
+              <span className="hidden sm:inline">Speakers</span>
             </button>
             <button
               onClick={() => setActiveTab('chat')}
               className={cn(
-                "flex-1 flex items-center justify-center gap-2 py-1.5 text-xs font-medium rounded-md transition-all relative",
-                "bg-white text-blue-600 shadow-sm"
+                "flex items-center justify-center gap-1 py-1.5 text-xs font-medium rounded-md transition-all relative",
+                activeTab === 'chat'
+                  ? "bg-white text-blue-600 shadow-sm"
+                  : "text-slate-500 hover:text-slate-700 hover:bg-slate-200/50"
               )}
             >
               <MessageSquare size={14} />
-              Chat
+              <span className="hidden sm:inline">Chat</span>
               {chatMessageCount > 0 && (
                 <span className="absolute -top-1 -right-1 w-4 h-4 bg-blue-600 text-white text-[9px] font-bold rounded-full flex items-center justify-center">
                   {chatMessageCount > 9 ? '9+' : chatMessageCount}
@@ -229,6 +255,40 @@ export const Sidebar: React.FC<SidebarProps> = ({
             cumulativeCostUsd={chatCumulativeCostUsd}
             costWarningLevel={chatCostWarningLevel}
           />
+        </div>
+      ) : activeTab === 'speakers' ? (
+        // --- Speakers Tab ---
+        <div className="flex-1 flex flex-col">
+          <div className="flex-1 overflow-y-auto p-4 space-y-3">
+            {Object.values(speakers).length === 0 ? (
+              <div className="text-center text-slate-500 py-8">
+                <Mic size={32} className="mx-auto mb-2 text-slate-300" />
+                <p className="text-sm">No speakers identified.</p>
+              </div>
+            ) : (
+              Object.values(speakers).map(speaker => (
+                <SpeakerCard
+                  key={speaker.speakerId}
+                  speaker={speaker}
+                  onMerge={() => onMergeSpeaker(speaker.speakerId)}
+                />
+              ))
+            )}
+          </div>
+
+          {/* Undo Button at bottom */}
+          {canUndoMerge && (
+            <div className="p-4 border-t border-slate-200 bg-slate-50/50">
+              <Button
+                variant="outline"
+                onClick={onUndoMerge}
+                className="w-full flex items-center justify-center gap-2"
+              >
+                <Undo2 size={14} />
+                Undo Last Merge
+              </Button>
+            </div>
+          )}
         </div>
       ) : (
         <div className="flex-1 overflow-y-auto p-4 space-y-3">
@@ -407,6 +467,61 @@ const PersonCard: React.FC<{
           className="w-full text-xs pl-6 p-2 bg-slate-50 border border-slate-100 rounded focus:bg-white focus:outline-none focus:ring-1 focus:ring-blue-300 resize-none text-slate-900 placeholder:text-slate-400"
           rows={2}
         />
+      </div>
+    </div>
+  );
+};
+
+// Sub-component for Speaker Card with merge button
+const SpeakerCard: React.FC<{
+  speaker: Speaker;
+  onMerge: () => void;
+}> = ({ speaker, onMerge }) => {
+  // Get color class for speaker badge
+  const getSpeakerColorClass = (colorIndex: number): string => {
+    const colors = [
+      'bg-blue-100 text-blue-800 border-blue-200',
+      'bg-purple-100 text-purple-800 border-purple-200',
+      'bg-green-100 text-green-800 border-green-200',
+      'bg-orange-100 text-orange-800 border-orange-200',
+      'bg-pink-100 text-pink-800 border-pink-200',
+      'bg-teal-100 text-teal-800 border-teal-200',
+      'bg-yellow-100 text-yellow-800 border-yellow-200',
+      'bg-red-100 text-red-800 border-red-200'
+    ];
+    return colors[colorIndex % colors.length];
+  };
+
+  return (
+    <div className="p-3 rounded-lg border border-slate-200 bg-white shadow-sm hover:shadow-md transition-all">
+      <div className="flex justify-between items-center">
+        {/* Speaker info */}
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 rounded-full bg-slate-100 flex items-center justify-center text-slate-400 shrink-0">
+            <Mic size={16} />
+          </div>
+          <div>
+            <div className={cn(
+              "px-2 py-1 rounded text-xs font-medium border",
+              getSpeakerColorClass(speaker.colorIndex)
+            )}>
+              {speaker.displayName}
+            </div>
+          </div>
+        </div>
+
+        {/* Merge button */}
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={(e) => {
+            e.stopPropagation();
+            onMerge();
+          }}
+          className="text-xs"
+        >
+          Merge
+        </Button>
       </div>
     </div>
   );

--- a/src/components/viewer/SpeakerMergeModal.tsx
+++ b/src/components/viewer/SpeakerMergeModal.tsx
@@ -1,0 +1,140 @@
+/**
+ * SpeakerMergeModal - Modal for merging speakers
+ *
+ * Simple 3-click workflow:
+ * 1. Click merge button on source speaker (opens modal)
+ * 2. Click target speaker from list
+ * 3. Confirm merge
+ *
+ * Design: Extracted from Viewer to keep components focused.
+ * Follows RenameSpeakerModal pattern for consistency.
+ */
+
+import React, { useState } from 'react';
+import { X, Users } from 'lucide-react';
+import { Speaker } from '@/config/types';
+import { Button } from '../Button';
+import { cn } from '@/utils';
+
+interface SpeakerMergeModalProps {
+  /** The speaker being merged away (will be removed) */
+  sourceSpeaker: Speaker;
+  /** All speakers EXCEPT the source (these are merge targets) */
+  targetSpeakers: Speaker[];
+  /** Close modal without merging */
+  onClose: () => void;
+  /** Confirm merge with selected target */
+  onConfirm: (targetSpeakerId: string) => void;
+}
+
+/**
+ * Get color class for speaker color index
+ * Matches the colors used in TranscriptSegment component
+ */
+function getSpeakerColorClass(colorIndex: number): string {
+  const colors = [
+    'bg-blue-100 text-blue-800',
+    'bg-purple-100 text-purple-800',
+    'bg-green-100 text-green-800',
+    'bg-orange-100 text-orange-800',
+    'bg-pink-100 text-pink-800',
+    'bg-teal-100 text-teal-800',
+    'bg-yellow-100 text-yellow-800',
+    'bg-red-100 text-red-800'
+  ];
+  return colors[colorIndex % colors.length];
+}
+
+/**
+ * SpeakerMergeModal component
+ *
+ * Shows list of target speakers to merge into.
+ * User clicks a target speaker and then confirms.
+ */
+export const SpeakerMergeModal: React.FC<SpeakerMergeModalProps> = ({
+  sourceSpeaker,
+  targetSpeakers,
+  onClose,
+  onConfirm
+}) => {
+  const [selectedTargetId, setSelectedTargetId] = useState<string | null>(null);
+
+  const handleConfirm = () => {
+    if (!selectedTargetId) return;
+    onConfirm(selectedTargetId);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/60 backdrop-blur-sm animate-in fade-in duration-200">
+      <div className="bg-white w-full max-w-md rounded-xl shadow-2xl p-6 scale-100 animate-in zoom-in-95 duration-200">
+        {/* Header */}
+        <div className="flex justify-between items-start mb-4">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900">Merge Speaker</h3>
+            <p className="text-sm text-slate-600 mt-1">
+              Merge <span className="font-medium text-slate-900">{sourceSpeaker.displayName}</span> into another speaker
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-600 transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Target Speaker List */}
+        <div className="mb-6 max-h-64 overflow-y-auto">
+          {targetSpeakers.length === 0 ? (
+            <div className="text-center py-8 text-slate-500">
+              <Users size={32} className="mx-auto mb-2 text-slate-300" />
+              <p className="text-sm">No other speakers available</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {targetSpeakers.map(speaker => (
+                <button
+                  key={speaker.speakerId}
+                  onClick={() => setSelectedTargetId(speaker.speakerId)}
+                  className={cn(
+                    "w-full p-3 rounded-lg border-2 transition-all text-left",
+                    selectedTargetId === speaker.speakerId
+                      ? "border-blue-500 bg-blue-50 shadow-sm"
+                      : "border-slate-200 hover:border-blue-300 hover:bg-slate-50"
+                  )}
+                >
+                  <div className="flex items-center gap-3">
+                    {/* Speaker color badge */}
+                    <div className={cn(
+                      "px-2 py-1 rounded text-xs font-medium",
+                      getSpeakerColorClass(speaker.colorIndex)
+                    )}>
+                      {speaker.displayName}
+                    </div>
+                    {selectedTargetId === speaker.speakerId && (
+                      <span className="text-xs text-blue-600 font-medium ml-auto">Selected</span>
+                    )}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!selectedTargetId}
+          >
+            Merge Speakers
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -384,3 +384,33 @@ export interface ReconciliationMetadata {
   /** Processing duration for reconciliation phase (ms) */
   reconciliationDurationMs?: number;
 }
+
+// =============================================================================
+// Speaker Correction Types (Manual Merge Feature)
+// =============================================================================
+
+/**
+ * Type of speaker correction operation.
+ * Currently only 'merge' is supported - future: 'split', 'rename', etc.
+ */
+export type SpeakerCorrectionType = 'merge';
+
+/**
+ * User-initiated speaker correction record.
+ * Stored in conversations/{id}/speakerCorrections subcollection.
+ * Applied at read-time to derive corrected speaker list and segment assignments.
+ */
+export interface SpeakerCorrection {
+  /** Unique ID for this correction */
+  correctionId: string;
+  /** Type of correction */
+  type: SpeakerCorrectionType;
+  /** Speaker ID being merged away (will be removed from speaker list) */
+  sourceSpeakerId: string;
+  /** Speaker ID to merge into (all source segments reassigned to this) */
+  targetSpeakerId: string;
+  /** When this correction was created (ISO timestamp) */
+  createdAt: string;
+  /** User who created this correction (for verification) */
+  userId: string;
+}

--- a/src/hooks/useSpeakerCorrections.ts
+++ b/src/hooks/useSpeakerCorrections.ts
@@ -1,0 +1,220 @@
+/**
+ * useSpeakerCorrections Hook
+ *
+ * Manages speaker correction state for a conversation:
+ * - Real-time subscription to speakerCorrections subcollection
+ * - Apply-on-read logic: compute corrected speakers and segments
+ * - Merge speakers via Cloud Function
+ * - Undo last merge
+ *
+ * Pattern: Original conversation data stays immutable.
+ * All corrections are applied at read time.
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import {
+  collection,
+  query,
+  orderBy,
+  onSnapshot,
+  Timestamp
+} from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
+import { db, functions } from '@/config/firebase-config';
+import type { Speaker, Segment, SpeakerCorrection } from '@/config/types';
+
+interface UseSpeakerCorrectionsOptions {
+  conversationId: string;
+  originalSpeakers: Record<string, Speaker>;
+  originalSegments: Segment[];
+}
+
+interface UseSpeakerCorrectionsReturn {
+  /** Corrected speaker list with merges applied */
+  correctedSpeakers: Record<string, Speaker>;
+  /** Segments with corrected speaker IDs */
+  correctedSegments: Segment[];
+  /** Whether undo is available */
+  canUndo: boolean;
+  /** Merge two speakers (calls Cloud Function) */
+  mergeSpeakers: (sourceSpeakerId: string, targetSpeakerId: string) => Promise<void>;
+  /** Undo the most recent merge */
+  undoLastMerge: () => Promise<void>;
+  /** Loading state for merge operations */
+  isLoading: boolean;
+  /** Error message if merge fails */
+  error: string | null;
+  /** Clear error state */
+  clearError: () => void;
+}
+
+/**
+ * Firestore document type for speaker corrections
+ */
+interface SpeakerCorrectionDoc extends Omit<SpeakerCorrection, 'createdAt'> {
+  createdAt: Timestamp;
+}
+
+/**
+ * Hook to manage speaker corrections with apply-on-read logic.
+ *
+ * Subscribes to speakerCorrections subcollection and recomputes
+ * corrected speakers/segments whenever corrections change.
+ */
+export function useSpeakerCorrections({
+  conversationId,
+  originalSpeakers,
+  originalSegments
+}: UseSpeakerCorrectionsOptions): UseSpeakerCorrectionsReturn {
+  const [corrections, setCorrections] = useState<SpeakerCorrection[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Subscribe to speakerCorrections subcollection
+  useEffect(() => {
+    if (!conversationId) return;
+
+    const correctionsRef = collection(db, 'conversations', conversationId, 'speakerCorrections');
+    const q = query(correctionsRef, orderBy('createdAt', 'asc'));
+
+    const unsubscribe = onSnapshot(
+      q,
+      (snapshot) => {
+        const loadedCorrections: SpeakerCorrection[] = snapshot.docs.map(doc => {
+          const data = doc.data() as SpeakerCorrectionDoc;
+          return {
+            correctionId: doc.id,
+            type: data.type,
+            sourceSpeakerId: data.sourceSpeakerId,
+            targetSpeakerId: data.targetSpeakerId,
+            createdAt: data.createdAt.toDate().toISOString(),
+            userId: data.userId
+          };
+        });
+
+        setCorrections(loadedCorrections);
+      },
+      (err) => {
+        console.error('[useSpeakerCorrections] Subscription error:', err);
+        setError('Failed to load speaker corrections');
+      }
+    );
+
+    return () => unsubscribe();
+  }, [conversationId]);
+
+  /**
+   * Apply corrections to derive corrected speakers and segments.
+   * This is the core apply-on-read logic - we never mutate the original data.
+   */
+  const { correctedSpeakers, correctedSegments } = useMemo(() => {
+    // Start with originals
+    let speakers = { ...originalSpeakers };
+    let segments = [...originalSegments];
+
+    // Apply each correction in chronological order
+    for (const correction of corrections) {
+      if (correction.type === 'merge') {
+        const { sourceSpeakerId, targetSpeakerId } = correction;
+
+        // Remove source speaker from list
+        delete speakers[sourceSpeakerId];
+
+        // Remap all segments from source to target
+        segments = segments.map(seg =>
+          seg.speakerId === sourceSpeakerId
+            ? { ...seg, speakerId: targetSpeakerId }
+            : seg
+        );
+      }
+    }
+
+    return { correctedSpeakers: speakers, correctedSegments: segments };
+  }, [originalSpeakers, originalSegments, corrections]);
+
+  /**
+   * Check if undo is available (have corrections to undo)
+   */
+  const canUndo = corrections.length > 0;
+
+  /**
+   * Merge two speakers by calling Cloud Function.
+   * The function writes to Firestore, and our listener picks it up automatically.
+   */
+  const mergeSpeakers = useCallback(async (sourceSpeakerId: string, targetSpeakerId: string) => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const mergeSpeakersFunction = httpsCallable(functions, 'mergeSpeakers');
+      await mergeSpeakersFunction({
+        conversationId,
+        sourceSpeakerId,
+        targetSpeakerId
+      });
+
+      // Success - the onSnapshot listener will update our state automatically
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to merge speakers';
+      setError(errorMessage);
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [conversationId, isLoading]);
+
+  /**
+   * Undo the most recent merge by deleting its correction record.
+   * Firestore listener will automatically update our state.
+   */
+  const undoLastMerge = useCallback(async () => {
+    if (!canUndo || isLoading) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const lastCorrection = corrections[corrections.length - 1];
+
+      // Dynamically import to avoid build-time resolution issues
+      const { doc, deleteDoc } = await import('firebase/firestore');
+      const correctionRef = doc(
+        db,
+        'conversations',
+        conversationId,
+        'speakerCorrections',
+        lastCorrection.correctionId
+      );
+
+      await deleteDoc(correctionRef);
+
+      // Success - the onSnapshot listener will update our state automatically
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to undo merge';
+      setError(errorMessage);
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [conversationId, corrections, canUndo, isLoading]);
+
+  /**
+   * Clear error state
+   */
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return {
+    correctedSpeakers,
+    correctedSegments,
+    canUndo,
+    mergeSpeakers,
+    undoLastMerge,
+    isLoading,
+    error,
+    clearError
+  };
+}

--- a/src/pages/Viewer.tsx
+++ b/src/pages/Viewer.tsx
@@ -8,11 +8,13 @@ import { useAutoScroll } from '../hooks/useAutoScroll';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import { useChat } from '../hooks/useChat';
 import { useChatHistory } from '../hooks/useChatHistory';
+import { useSpeakerCorrections } from '../hooks/useSpeakerCorrections';
 import { ViewerHeader } from '../components/viewer/ViewerHeader';
 import { TranscriptView } from '../components/viewer/TranscriptView';
 import { Sidebar } from '../components/viewer/Sidebar';
 import { AudioPlayer } from '../components/viewer/AudioPlayer';
 import { RenameSpeakerModal } from '../components/viewer/RenameSpeakerModal';
+import { SpeakerMergeModal } from '../components/viewer/SpeakerMergeModal';
 import { EditTitleModal } from '../components/viewer/EditTitleModal';
 import { KeyboardShortcutsModal } from '../components/viewer/KeyboardShortcutsModal';
 import { exportTranscript } from '../utils/exportTranscript';
@@ -49,6 +51,7 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
 
   const [conversation, setConversation] = useState(activeConversation);
   const [editingSpeakerId, setEditingSpeakerId] = useState<string | null>(null);
+  const [mergingSpeakerId, setMergingSpeakerId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState(false);
   const [audioUrl, setAudioUrl] = useState<string | null>(null);
   const [highlightedSegmentId, setHighlightedSegmentId] = useState<string | null>(null);
@@ -184,6 +187,22 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
     messages: chatMessages
   });
 
+  // Speaker corrections (manual merge)
+  const {
+    correctedSpeakers,
+    correctedSegments,
+    canUndo: canUndoMerge,
+    mergeSpeakers,
+    undoLastMerge,
+    isLoading: _mergeIsLoading,
+    error: _mergeError,
+    clearError: _mergeClearError
+  } = useSpeakerCorrections({
+    conversationId: conversation.conversationId,
+    originalSpeakers: conversation.speakers,
+    originalSegments: conversation.segments
+  });
+
   /**
    * Handle speaker rename
    */
@@ -302,6 +321,40 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
     setHighlightedSegmentId(segmentId);
   }, []);
 
+  /**
+   * Handle speaker merge - open modal to select target
+   */
+  const handleMergeSpeaker = useCallback((speakerId: string) => {
+    setMergingSpeakerId(speakerId);
+  }, []);
+
+  /**
+   * Confirm merge - call Cloud Function via hook
+   */
+  const handleConfirmMerge = useCallback(async (targetSpeakerId: string) => {
+    if (!mergingSpeakerId) return;
+
+    try {
+      await mergeSpeakers(mergingSpeakerId, targetSpeakerId);
+      setMergingSpeakerId(null); // Close modal on success
+    } catch (err) {
+      // Error is handled by the hook and exposed via mergeError
+      console.error('[Viewer] Merge failed:', err);
+    }
+  }, [mergingSpeakerId, mergeSpeakers]);
+
+  /**
+   * Handle undo merge
+   */
+  const handleUndoMerge = useCallback(async () => {
+    try {
+      await undoLastMerge();
+    } catch (err) {
+      // Error is handled by the hook and exposed via mergeError
+      console.error('[Viewer] Undo merge failed:', err);
+    }
+  }, [undoLastMerge]);
+
   return (
     <div className="flex flex-col h-screen-safe bg-slate-50">
       {/* Header */}
@@ -375,9 +428,13 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
 
       {/* Main Content Split */}
       <div className="flex-1 flex overflow-hidden">
-        {/* Transcript Area */}
+        {/* Transcript Area - use corrected speakers/segments */}
         <TranscriptView
-          conversation={conversation}
+          conversation={{
+            ...conversation,
+            speakers: correctedSpeakers,
+            segments: correctedSegments
+          }}
           activeSegmentIndex={activeSegmentIndex}
           selectedTermId={selectedTermId}
           selectedPersonId={selectedPersonId}
@@ -389,7 +446,7 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
           onReassignSpeaker={handleReassignSpeaker}
         />
 
-        {/* Sidebar (Desktop) */}
+        {/* Sidebar (Desktop) - use corrected speakers */}
         <div className="hidden lg:block w-80 shrink-0 z-10 shadow-xl shadow-slate-200/50">
           <Sidebar
             terms={Object.values(conversation.terms)}
@@ -418,13 +475,17 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
             chatIsLoadingOlder={chatHistoryLoading}
             conversationTitle={conversation.title}
             conversationDurationMs={conversation.durationMs}
-            speakers={conversation.speakers}
+            speakers={correctedSpeakers}
             chatOnSeek={handleChatTimestampSeek}
             chatOnPlay={handleChatTimestampPlay}
             chatOnHighlight={handleChatTimestampHighlight}
             chatSuggestions={chatSuggestions}
             chatCumulativeCostUsd={chatCumulativeCostUsd}
             chatCostWarningLevel={chatCostWarningLevel}
+            // Speaker corrections
+            canUndoMerge={canUndoMerge}
+            onUndoMerge={handleUndoMerge}
+            onMergeSpeaker={handleMergeSpeaker}
           />
         </div>
 
@@ -489,7 +550,7 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
                 chatIsLoadingOlder={chatHistoryLoading}
                 conversationTitle={conversation.title}
                 conversationDurationMs={conversation.durationMs}
-                speakers={conversation.speakers}
+                speakers={correctedSpeakers}
                 chatOnSeek={(timeMs) => {
                   handleChatTimestampSeek(timeMs);
                   setMobileChatOpen(false); // Close chat when seeking
@@ -499,6 +560,10 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
                 chatSuggestions={chatSuggestions}
                 chatCumulativeCostUsd={chatCumulativeCostUsd}
                 chatCostWarningLevel={chatCostWarningLevel}
+                // Speaker corrections
+                canUndoMerge={canUndoMerge}
+                onUndoMerge={handleUndoMerge}
+                onMergeSpeaker={handleMergeSpeaker}
                 defaultTab="context"
               />
             </div>
@@ -546,6 +611,16 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
           initialName={conversation.speakers[editingSpeakerId].displayName}
           onClose={() => setEditingSpeakerId(null)}
           onSave={saveSpeakerName}
+        />
+      )}
+
+      {/* Speaker Merge Modal */}
+      {mergingSpeakerId && (
+        <SpeakerMergeModal
+          sourceSpeaker={correctedSpeakers[mergingSpeakerId]}
+          targetSpeakers={Object.values(correctedSpeakers).filter(s => s.speakerId !== mergingSpeakerId)}
+          onClose={() => setMergingSpeakerId(null)}
+          onConfirm={handleConfirmMerge}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Add manual speaker merge feature allowing users to correct diarization errors from the sidebar
- New "Speakers" tab with merge controls and undo functionality
- Corrections persist via apply-on-read pattern (original transcript data immutable)

## Changelog Entry
```markdown
### Added
- **Manual Speaker Merge** - Correct diarization errors by merging speakers in the sidebar
  - New "Speakers" tab in Viewer sidebar shows all speakers with merge controls
  - 3-click workflow: Click "Merge" on source speaker → Select target → Confirm
  - Corrections persist via Firestore subcollection using apply-on-read pattern
  - "Undo Last Merge" button reverses most recent correction
  - Original transcript data remains immutable (corrections applied at render time)
```

## Files Changed
- `functions/src/speakerCorrections.ts` - New Cloud Function for merge persistence
- `src/hooks/useSpeakerCorrections.ts` - New hook for apply-on-read correction logic
- `src/components/viewer/SpeakerMergeModal.tsx` - New modal for target selection
- `src/components/viewer/Sidebar.tsx` - Added Speakers tab
- `src/pages/Viewer.tsx` - Integrated corrections hook
- `src/config/types.ts` - Added SpeakerCorrection type
- `firestore.rules` - Added speakerCorrections subcollection rules
- `docs/reference/data-model.md` - Documented new subcollection

## Test Plan
- [ ] ESLint passes on all scope files
- [ ] TypeScript compilation passes
- [ ] Firestore rules deployed with correct permissions
- [ ] Cloud Function deployed and callable
- [ ] Manual test: merge speakers, verify UI updates, reload and verify persistence

---
Scope: `speaker_reconciliation_manual_speaker_merge_08_01`
Iteration: `iteration_01`
Build: `22`