### PR TITLE
feat(speaker-corrections): add segment speaker reassignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Corrections persist via Firestore subcollection using apply-on-read pattern
   - "Undo Last Merge" button reverses most recent correction
   - Original transcript data remains immutable (corrections applied at render time)
+- **Segment Speaker Reassignment** - Reassign individual or multiple segments to different speakers
+  - Right-click (or long-press on mobile) any segment to reassign via context menu
+  - Shift+Click to select multiple segments, then use floating action bar to bulk reassign
+  - Reassignments persist as correction records and apply on read (original data unchanged)
+  - Speakers with zero remaining segments are automatically hidden from the speaker list
 
 ## [2.6.0] - 2026-01-28
 

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -109,15 +109,23 @@ interface ChatHistoryDoc {
 
 #### conversations/{conversationId}/speakerCorrections (subcollection)
 
-Manual speaker merge operations. Users can merge incorrectly diarized speakers from the UI (e.g., "Speaker 2" is actually "Tom"). Corrections are applied at read time - original data remains immutable.
+Manual speaker corrections. Users can merge incorrectly diarized speakers or reassign individual segments from the UI. Corrections are applied at read time - original data remains immutable.
 
 **Path**: `conversations/{conversationId}/speakerCorrections/{correctionId}`
 
 ```typescript
 interface SpeakerCorrectionDoc {
-  type: 'merge';                 // Correction type (future: 'split', 'rename', etc.)
-  sourceSpeakerId: string;       // Speaker being merged away (removed from speaker list)
-  targetSpeakerId: string;       // Speaker to merge into (all source segments reassigned)
+  type: 'merge' | 'reassign';    // Correction type
+
+  // For 'merge' corrections
+  sourceSpeakerId?: string;      // Speaker being merged away (removed from speaker list)
+  targetSpeakerId?: string;      // Speaker to merge into (all source segments reassigned)
+
+  // For 'reassign' corrections
+  segmentIds?: string[];         // Specific segments to reassign
+  fromSpeakerId?: string;        // Speaker segments are being moved from
+  toSpeakerId?: string;          // Speaker segments are being moved to
+
   userId: string;                // User who created the correction
   createdAt: Timestamp;          // Server timestamp
 }
@@ -131,23 +139,29 @@ interface SpeakerCorrectionDoc {
   3. For each merge correction:
      - Remove sourceSpeakerId from speaker list
      - Remap all segments from sourceSpeakerId to targetSpeakerId
-  4. Display corrected data to user
+  4. For each reassign correction:
+     - Reassign specified segmentIds to toSpeakerId
+  5. Remove speakers with zero remaining segments from speaker list
+  6. Display corrected data to user
 
 **Undo Support**:
 - Delete the most recent correction document to undo
 - Client re-applies remaining corrections on next read
-- Full correction history is preserved (cannot undo individual merges from middle of sequence)
+- Full correction history is preserved (cannot undo individual corrections from middle of sequence)
 
 **Features**:
 - Real-time synchronization (Firestore listener)
 - Persists across reloads and devices
-- 3-click workflow: Click merge button → Select target speaker → Confirm
+- **Merge workflow**: Click merge button → Select target speaker → Confirm
+- **Reassign workflow (single segment)**: Right-click/long-press segment → Select target speaker
+- **Reassign workflow (multiple segments)**: Shift+Click to select range → Choose target speaker from floating bar
 - Non-destructive (original data unchanged)
 - Audit trail for debugging diarization issues
 
 **Security**:
 - Users can only read/delete corrections for conversations they own
 - Corrections are created via Cloud Function (not directly by client)
+- Cloud Function validates all segments belong to same speaker before reassigning
 - Immutable once created (no updates allowed)
 
 ### users

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -64,7 +64,7 @@ export { processTranscription } from './processTranscription';
 export { processMerge, processReprocessing } from './chunkMerge';
 export { chatWithConversation } from './chat';
 export { retryTranscription } from './retry';
-export { mergeSpeakers } from './speakerCorrections';
+export { mergeSpeakers, reassignSegments } from './speakerCorrections';
 
 // Export stats tracking triggers
 export { onConversationCreated, onConversationDeleted } from './statsTriggers';

--- a/functions/src/speakerCorrections.ts
+++ b/functions/src/speakerCorrections.ts
@@ -25,6 +25,17 @@ interface MergeSpeakersResponse {
   correctionId: string;
 }
 
+interface ReassignSegmentsRequest {
+  conversationId: string;
+  segmentIds: string[];    // Segments to reassign
+  toSpeakerId: string;     // Target speaker
+}
+
+interface ReassignSegmentsResponse {
+  success: boolean;
+  correctionId: string;
+}
+
 /**
  * Merge two speakers by writing a correction record.
  *
@@ -144,6 +155,171 @@ export const mergeSpeakers = onCall<MergeSpeakersRequest>(
       throw new HttpsError(
         'internal',
         'Failed to merge speakers: ' + (error instanceof Error ? error.message : String(error))
+      );
+    }
+  }
+);
+
+/**
+ * Reassign specific segments to a different speaker.
+ *
+ * Security:
+ * - Requires authentication
+ * - Verifies user owns the conversation
+ * - Validates segments exist and belong to the same speaker
+ * - Validates target speaker exists
+ *
+ * The correction is stored in the speakerCorrections subcollection
+ * and applied at read time by the client.
+ */
+export const reassignSegments = onCall<ReassignSegmentsRequest>(
+  {
+    region: 'us-central1',
+    memory: '256MiB',
+    timeoutSeconds: 30,
+    cors: true
+  },
+  async (request): Promise<ReassignSegmentsResponse> => {
+    // Require authentication
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Must be signed in to reassign segments');
+    }
+
+    const { conversationId, segmentIds, toSpeakerId } = request.data;
+    const userId = request.auth.uid;
+
+    // Validate input
+    if (!conversationId) {
+      throw new HttpsError('invalid-argument', 'conversationId is required');
+    }
+    if (!segmentIds || !Array.isArray(segmentIds) || segmentIds.length === 0) {
+      throw new HttpsError('invalid-argument', 'segmentIds must be a non-empty array');
+    }
+    if (!toSpeakerId) {
+      throw new HttpsError('invalid-argument', 'toSpeakerId is required');
+    }
+
+    log.info('Segment reassignment request received', {
+      conversationId,
+      userId,
+      segmentCount: segmentIds.length,
+      toSpeakerId
+    });
+
+    try {
+      // Fetch conversation and verify ownership
+      const conversationDoc = await db.collection('conversations').doc(conversationId).get();
+
+      if (!conversationDoc.exists) {
+        throw new HttpsError('not-found', 'Conversation not found');
+      }
+
+      const conversation = conversationDoc.data();
+      if (!conversation) {
+        throw new HttpsError('not-found', 'Conversation data not found');
+      }
+
+      if (conversation.userId !== userId) {
+        throw new HttpsError('permission-denied', 'You do not have access to this conversation');
+      }
+
+      // Validate segments exist and all belong to the same speaker
+      const segments = conversation.segments || [];
+
+      interface SegmentData {
+        segmentId: string;
+        speakerId: string;
+        [key: string]: any;
+      }
+
+      const segmentMap = new Map<string, SegmentData>(
+        segments.map((s: any) => [s.segmentId, s as SegmentData])
+      );
+
+      let fromSpeakerId: string | null = null;
+
+      for (const segmentId of segmentIds) {
+        const segment = segmentMap.get(segmentId);
+        if (!segment) {
+          throw new HttpsError('invalid-argument', `Segment '${segmentId}' not found`);
+        }
+
+        // All segments must belong to the same speaker
+        if (fromSpeakerId === null) {
+          fromSpeakerId = segment.speakerId;
+        } else if (segment.speakerId !== fromSpeakerId) {
+          throw new HttpsError(
+            'invalid-argument',
+            'All segments must belong to the same speaker'
+          );
+        }
+      }
+
+      if (!fromSpeakerId) {
+        throw new HttpsError('invalid-argument', 'Could not determine source speaker');
+      }
+
+      // Validate target speaker exists
+      const speakers = conversation.speakers || {};
+      if (!speakers[toSpeakerId]) {
+        throw new HttpsError('invalid-argument', `Target speaker '${toSpeakerId}' not found`);
+      }
+
+      // Don't allow reassigning to the same speaker
+      if (fromSpeakerId === toSpeakerId) {
+        throw new HttpsError('invalid-argument', 'Segments already belong to the target speaker');
+      }
+
+      // Write correction record to subcollection
+      const correctionRef = db
+        .collection('conversations')
+        .doc(conversationId)
+        .collection('speakerCorrections')
+        .doc(); // Auto-generate ID
+
+      const correctionData = {
+        type: 'reassign',
+        segmentIds,
+        fromSpeakerId,
+        toSpeakerId,
+        userId,
+        createdAt: new Date() // Firestore will convert to Timestamp
+      };
+
+      await correctionRef.set(correctionData);
+
+      log.info('Segment reassignment correction saved', {
+        conversationId,
+        userId,
+        correctionId: correctionRef.id,
+        segmentCount: segmentIds.length,
+        fromSpeakerId,
+        toSpeakerId
+      });
+
+      return {
+        success: true,
+        correctionId: correctionRef.id
+      };
+
+    } catch (error) {
+      log.error('Segment reassignment request failed', {
+        conversationId,
+        userId,
+        segmentCount: segmentIds.length,
+        toSpeakerId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+
+      // Re-throw HttpsErrors as-is
+      if (error instanceof HttpsError) {
+        throw error;
+      }
+
+      // Wrap other errors
+      throw new HttpsError(
+        'internal',
+        'Failed to reassign segments: ' + (error instanceof Error ? error.message : String(error))
       );
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audio-transcript-analysis-app",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audio-transcript-analysis-app",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "dependencies": {
         "@google/genai": "^1.33.0",
         "dotenv": "^17.2.3",

--- a/src/components/viewer/TranscriptSegment.tsx
+++ b/src/components/viewer/TranscriptSegment.tsx
@@ -14,6 +14,7 @@ interface TranscriptSegmentProps {
   personOccurrences?: { start: number; end: number; personId: string }[];
   isActive: boolean;
   isHighlighted?: boolean; // True when segment is highlighted from timestamp click
+  isSelected?: boolean; // True when segment is part of multi-select
   showSpeakerChange: boolean; // True when speaker changes from previous segment
   activeTermId?: string;
   activePersonId?: string;
@@ -21,6 +22,7 @@ interface TranscriptSegmentProps {
   onTermClick: (termId: string) => void;
   onRenameSpeaker: (speakerId: string) => void;
   onReassignSpeaker?: (segmentId: string, newSpeakerId: string) => void;
+  onSegmentClick?: (shiftKey: boolean) => void;
 }
 
 export const TranscriptSegment: React.FC<TranscriptSegmentProps> = ({
@@ -31,13 +33,15 @@ export const TranscriptSegment: React.FC<TranscriptSegmentProps> = ({
   personOccurrences = [],
   isActive,
   isHighlighted = false,
+  isSelected = false,
   showSpeakerChange,
   activeTermId,
   activePersonId,
   onSeek,
   onTermClick,
   onRenameSpeaker,
-  onReassignSpeaker
+  onReassignSpeaker,
+  onSegmentClick
 }) => {
   // State for speaker change header dropdown (bulk reassignment)
   const [showHeaderDropdown, setShowHeaderDropdown] = useState(false);
@@ -224,6 +228,19 @@ export const TranscriptSegment: React.FC<TranscriptSegmentProps> = ({
       {/* Segment with comfortable spacing */}
       <div
         {...(onReassignSpeaker && allSpeakers.length > 1 ? longPressHandlers : {})}
+        onClick={(e) => {
+          // Handle selection with Shift key
+          if (onSegmentClick && e.shiftKey) {
+            e.preventDefault();
+            onSegmentClick(true);
+          } else if (onSegmentClick && !e.shiftKey && !isActive) {
+            // Regular click when not active - toggle selection
+            onSegmentClick(false);
+          } else if (!e.shiftKey) {
+            // No selection handler or active segment - seek to timestamp
+            onSeek(segment.startMs + 1);
+          }
+        }}
         className={cn(
           "group relative flex items-start gap-3 px-3 border-l-[3px] transition-all",
           // Tight vertical spacing - segments flow together
@@ -231,9 +248,12 @@ export const TranscriptSegment: React.FC<TranscriptSegmentProps> = ({
           speakerBorderColor,
           isActive && "bg-blue-50/80 border border-blue-200 shadow-sm",
           isHighlighted && "bg-yellow-50 border border-yellow-300 shadow-md ring-1 ring-yellow-200",
-          !isActive && !isHighlighted && "hover:bg-slate-50/50",
+          isSelected && "bg-purple-50 border border-purple-300 ring-1 ring-purple-200",
+          !isActive && !isHighlighted && !isSelected && "hover:bg-slate-50/50",
           // Long-press visual feedback
-          longPressHandlers.isLongPressing && onReassignSpeaker && allSpeakers.length > 1 && "scale-[1.02] opacity-95 cursor-context-menu"
+          longPressHandlers.isLongPressing && onReassignSpeaker && allSpeakers.length > 1 && "scale-[1.02] opacity-95 cursor-context-menu",
+          // Selection cursor
+          onSegmentClick && "cursor-pointer"
         )}
       >
         {/* Timestamp Button - pill-shaped with proper touch targets */}

--- a/src/components/viewer/TranscriptSelectionBar.tsx
+++ b/src/components/viewer/TranscriptSelectionBar.tsx
@@ -1,0 +1,104 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Speaker } from '@/config/types';
+import { SPEAKER_DOT_COLORS } from '@/config/constants';
+import { X, ChevronDown } from 'lucide-react';
+import { cn } from '@/utils';
+
+interface TranscriptSelectionBarProps {
+  selectedSegmentIds: Set<string>;
+  allSpeakers: Speaker[];
+  onReassign: (toSpeakerId: string) => void;
+  onClear: () => void;
+}
+
+/**
+ * TranscriptSelectionBar - Floating action bar for multi-segment operations
+ *
+ * Appears when segments are selected via Shift+Click.
+ * Provides UI for bulk reassignment to a different speaker.
+ */
+export const TranscriptSelectionBar: React.FC<TranscriptSelectionBarProps> = ({
+  selectedSegmentIds,
+  allSpeakers,
+  onReassign,
+  onClear
+}) => {
+  const [showDropdown, setShowDropdown] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setShowDropdown(false);
+      }
+    };
+
+    if (showDropdown) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [showDropdown]);
+
+  const handleSpeakerSelect = (speakerId: string) => {
+    onReassign(speakerId);
+    setShowDropdown(false);
+  };
+
+  if (selectedSegmentIds.size === 0) return null;
+
+  return (
+    <div
+      className="fixed bottom-20 left-1/2 -translate-x-1/2 z-30 bg-slate-900 text-white rounded-lg shadow-2xl px-4 py-3 flex items-center gap-4 animate-in slide-in-from-bottom duration-200"
+      style={{ minWidth: '320px' }}
+    >
+      {/* Selection count */}
+      <div className="flex items-center gap-2">
+        <div className="w-8 h-8 rounded-full bg-blue-500 flex items-center justify-center text-sm font-semibold">
+          {selectedSegmentIds.size}
+        </div>
+        <span className="text-sm font-medium">
+          {selectedSegmentIds.size === 1 ? '1 segment selected' : `${selectedSegmentIds.size} segments selected`}
+        </span>
+      </div>
+
+      {/* Reassign dropdown */}
+      <div className="flex-1 relative" ref={dropdownRef}>
+        <button
+          onClick={() => setShowDropdown(!showDropdown)}
+          className="w-full px-3 py-1.5 bg-slate-700 hover:bg-slate-600 rounded text-sm flex items-center justify-between gap-2 transition-colors"
+        >
+          <span>Reassign to...</span>
+          <ChevronDown size={14} className={cn("transition-transform", showDropdown && "rotate-180")} />
+        </button>
+
+        {showDropdown && (
+          <div className="absolute bottom-full left-0 right-0 mb-2 bg-white text-slate-900 border border-slate-200 rounded-lg shadow-lg max-h-64 overflow-y-auto">
+            <div className="px-3 py-2 text-xs text-slate-500 border-b border-slate-100 font-medium">
+              Select speaker:
+            </div>
+            {allSpeakers.map((speaker) => (
+              <button
+                key={speaker.speakerId}
+                onClick={() => handleSpeakerSelect(speaker.speakerId)}
+                className="w-full px-3 py-2 text-left text-sm hover:bg-slate-50 flex items-center gap-2 transition-colors"
+              >
+                <span className={cn("w-2 h-2 rounded-full", SPEAKER_DOT_COLORS[speaker.colorIndex % SPEAKER_DOT_COLORS.length])} />
+                <span className="flex-1">{speaker.displayName}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Clear button */}
+      <button
+        onClick={onClear}
+        className="p-2 hover:bg-slate-700 rounded transition-colors"
+        aria-label="Clear selection"
+      >
+        <X size={18} />
+      </button>
+    </div>
+  );
+};

--- a/src/components/viewer/TranscriptView.tsx
+++ b/src/components/viewer/TranscriptView.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import { Conversation } from '@/config/types';
 import { TranscriptSegment } from './TranscriptSegment';
 import { TopicMarker } from './TopicMarker';
+import { TranscriptSelectionBar } from './TranscriptSelectionBar';
 
 interface TranscriptViewProps {
   conversation: Conversation;
@@ -14,6 +15,7 @@ interface TranscriptViewProps {
   onTermClick: (termId: string) => void;
   onRenameSpeaker: (speakerId: string) => void;
   onReassignSpeaker?: (segmentId: string, newSpeakerId: string) => void;
+  onReassignSegments?: (segmentIds: string[], toSpeakerId: string) => void;
 }
 
 /**
@@ -22,6 +24,8 @@ interface TranscriptViewProps {
  * Handles the layout and iteration of segments with their associated
  * topics, occurrences, and highlighting. Extracted from Viewer.tsx
  * to separate rendering concerns.
+ *
+ * Also manages multi-segment selection via Shift+Click for bulk reassignment.
  */
 export const TranscriptView: React.FC<TranscriptViewProps> = ({
   conversation,
@@ -33,10 +37,70 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({
   onSeek,
   onTermClick,
   onRenameSpeaker,
-  onReassignSpeaker
+  onReassignSpeaker,
+  onReassignSegments
 }) => {
   // Get all speakers as an array for the reassignment dropdown
   const allSpeakers = Object.values(conversation.speakers);
+
+  // Multi-select state for bulk operations
+  const [selectedSegmentIds, setSelectedSegmentIds] = useState<Set<string>>(new Set());
+  const [lastSelectedIndex, setLastSelectedIndex] = useState<number | null>(null);
+
+  /**
+   * Handle segment click with Shift modifier for multi-select
+   */
+  const handleSegmentClick = useCallback((segmentId: string, segmentIndex: number, shiftKey: boolean) => {
+    if (!shiftKey) {
+      // Regular click - toggle single selection
+      setSelectedSegmentIds(prev => {
+        const next = new Set(prev);
+        if (next.has(segmentId)) {
+          next.delete(segmentId);
+        } else {
+          next.add(segmentId);
+        }
+        return next;
+      });
+      setLastSelectedIndex(segmentIndex);
+    } else {
+      // Shift+Click - select range
+      if (lastSelectedIndex !== null) {
+        const start = Math.min(lastSelectedIndex, segmentIndex);
+        const end = Math.max(lastSelectedIndex, segmentIndex);
+        const rangeIds = conversation.segments.slice(start, end + 1).map(s => s.segmentId);
+
+        setSelectedSegmentIds(prev => {
+          const next = new Set(prev);
+          rangeIds.forEach(id => next.add(id));
+          return next;
+        });
+      } else {
+        // No previous selection, just select this one
+        setSelectedSegmentIds(new Set([segmentId]));
+        setLastSelectedIndex(segmentIndex);
+      }
+    }
+  }, [lastSelectedIndex, conversation.segments]);
+
+  /**
+   * Handle bulk reassignment via selection bar
+   */
+  const handleBulkReassign = useCallback((toSpeakerId: string) => {
+    if (selectedSegmentIds.size === 0 || !onReassignSegments) return;
+
+    onReassignSegments(Array.from(selectedSegmentIds), toSpeakerId);
+    setSelectedSegmentIds(new Set()); // Clear selection after reassignment
+    setLastSelectedIndex(null);
+  }, [selectedSegmentIds, onReassignSegments]);
+
+  /**
+   * Clear selection
+   */
+  const handleClearSelection = useCallback(() => {
+    setSelectedSegmentIds(new Set());
+    setLastSelectedIndex(null);
+  }, []);
   return (
     <div className="flex-1 overflow-y-auto relative">
       <div className="max-w-3xl mx-auto px-4 py-8 pb-32">
@@ -45,6 +109,7 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({
           const topic = conversation.topics.find(t => t.startIndex === idx);
           const isActive = idx === activeSegmentIndex;
           const isHighlighted = highlightedSegmentId === seg.segmentId;
+          const isSelected = selectedSegmentIds.has(seg.segmentId);
 
           // Find term occurrences for this segment
           const segmentOccurrences = conversation.termOccurrences.filter(
@@ -76,6 +141,7 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({
                 personOccurrences={segmentPersonOccurrences}
                 isActive={isActive}
                 isHighlighted={isHighlighted}
+                isSelected={isSelected}
                 activeTermId={selectedTermId}
                 activePersonId={selectedPersonId}
                 showSpeakerChange={showSpeakerChange}
@@ -83,11 +149,22 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({
                 onTermClick={onTermClick}
                 onRenameSpeaker={onRenameSpeaker}
                 onReassignSpeaker={onReassignSpeaker}
+                onSegmentClick={(shiftKey) => handleSegmentClick(seg.segmentId, idx, shiftKey)}
               />
             </div>
           );
         })}
       </div>
+
+      {/* Selection bar for bulk operations */}
+      {onReassignSegments && (
+        <TranscriptSelectionBar
+          selectedSegmentIds={selectedSegmentIds}
+          allSpeakers={allSpeakers}
+          onReassign={handleBulkReassign}
+          onClear={handleClearSelection}
+        />
+      )}
     </div>
   );
 };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -391,9 +391,10 @@ export interface ReconciliationMetadata {
 
 /**
  * Type of speaker correction operation.
- * Currently only 'merge' is supported - future: 'split', 'rename', etc.
+ * - 'merge': Merge all segments from one speaker into another
+ * - 'reassign': Reassign specific segments to a different speaker
  */
-export type SpeakerCorrectionType = 'merge';
+export type SpeakerCorrectionType = 'merge' | 'reassign';
 
 /**
  * User-initiated speaker correction record.
@@ -405,10 +406,21 @@ export interface SpeakerCorrection {
   correctionId: string;
   /** Type of correction */
   type: SpeakerCorrectionType;
+
+  // Fields for 'merge' corrections
   /** Speaker ID being merged away (will be removed from speaker list) */
-  sourceSpeakerId: string;
+  sourceSpeakerId?: string;
   /** Speaker ID to merge into (all source segments reassigned to this) */
-  targetSpeakerId: string;
+  targetSpeakerId?: string;
+
+  // Fields for 'reassign' corrections
+  /** Segment IDs to reassign (reassign type only) */
+  segmentIds?: string[];
+  /** Speaker ID segments are being moved from (reassign type only) */
+  fromSpeakerId?: string;
+  /** Speaker ID segments are being moved to (reassign type only) */
+  toSpeakerId?: string;
+
   /** When this correction was created (ISO timestamp) */
   createdAt: string;
   /** User who created this correction (for verification) */

--- a/src/hooks/useSpeakerCorrections.ts
+++ b/src/hooks/useSpeakerCorrections.ts
@@ -38,6 +38,8 @@ interface UseSpeakerCorrectionsReturn {
   canUndo: boolean;
   /** Merge two speakers (calls Cloud Function) */
   mergeSpeakers: (sourceSpeakerId: string, targetSpeakerId: string) => Promise<void>;
+  /** Reassign specific segments to a different speaker (calls Cloud Function) */
+  reassignSegments: (segmentIds: string[], toSpeakerId: string) => Promise<void>;
   /** Undo the most recent merge */
   undoLastMerge: () => Promise<void>;
   /** Loading state for merge operations */
@@ -85,8 +87,13 @@ export function useSpeakerCorrections({
           return {
             correctionId: doc.id,
             type: data.type,
+            // Merge correction fields
             sourceSpeakerId: data.sourceSpeakerId,
             targetSpeakerId: data.targetSpeakerId,
+            // Reassign correction fields
+            segmentIds: data.segmentIds,
+            fromSpeakerId: data.fromSpeakerId,
+            toSpeakerId: data.toSpeakerId,
             createdAt: data.createdAt.toDate().toISOString(),
             userId: data.userId
           };
@@ -117,6 +124,8 @@ export function useSpeakerCorrections({
       if (correction.type === 'merge') {
         const { sourceSpeakerId, targetSpeakerId } = correction;
 
+        if (!sourceSpeakerId || !targetSpeakerId) continue;
+
         // Remove source speaker from list
         delete speakers[sourceSpeakerId];
 
@@ -126,6 +135,26 @@ export function useSpeakerCorrections({
             ? { ...seg, speakerId: targetSpeakerId }
             : seg
         );
+      } else if (correction.type === 'reassign') {
+        const { segmentIds, toSpeakerId } = correction;
+
+        if (!segmentIds || !toSpeakerId) continue;
+
+        // Reassign only the specified segments to the new speaker
+        const segmentIdSet = new Set(segmentIds);
+        segments = segments.map(seg =>
+          segmentIdSet.has(seg.segmentId)
+            ? { ...seg, speakerId: toSpeakerId }
+            : seg
+        );
+      }
+    }
+
+    // Prune speakers with zero remaining segments
+    const speakersWithSegments = new Set(segments.map(seg => seg.speakerId));
+    for (const speakerId in speakers) {
+      if (!speakersWithSegments.has(speakerId)) {
+        delete speakers[speakerId];
       }
     }
 
@@ -201,6 +230,34 @@ export function useSpeakerCorrections({
   }, [conversationId, corrections, canUndo, isLoading]);
 
   /**
+   * Reassign specific segments to a different speaker by calling Cloud Function.
+   * The function writes to Firestore, and our listener picks it up automatically.
+   */
+  const reassignSegments = useCallback(async (segmentIds: string[], toSpeakerId: string) => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const reassignSegmentsFunction = httpsCallable(functions, 'reassignSegments');
+      await reassignSegmentsFunction({
+        conversationId,
+        segmentIds,
+        toSpeakerId
+      });
+
+      // Success - the onSnapshot listener will update our state automatically
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to reassign segments';
+      setError(errorMessage);
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [conversationId, isLoading]);
+
+  /**
    * Clear error state
    */
   const clearError = useCallback(() => {
@@ -212,6 +269,7 @@ export function useSpeakerCorrections({
     correctedSegments,
     canUndo,
     mergeSpeakers,
+    reassignSegments,
     undoLastMerge,
     isLoading,
     error,

--- a/src/pages/Viewer.tsx
+++ b/src/pages/Viewer.tsx
@@ -187,12 +187,13 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
     messages: chatMessages
   });
 
-  // Speaker corrections (manual merge)
+  // Speaker corrections (manual merge and reassignment)
   const {
     correctedSpeakers,
     correctedSegments,
     canUndo: canUndoMerge,
     mergeSpeakers,
+    reassignSegments,
     undoLastMerge,
     isLoading: _mergeIsLoading,
     error: _mergeError,
@@ -211,30 +212,38 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
   }, []);
 
   /**
-   * Handle segment speaker reassignment
-   * Allows user to change which speaker a specific segment is attributed to
+   * Handle segment speaker reassignment (single segment)
+   * Uses the apply-on-read correction pattern via Cloud Function
    */
-  const handleReassignSpeaker = useCallback((segmentId: string, newSpeakerId: string) => {
-    const updatedSegments = conversation.segments.map(seg =>
-      seg.segmentId === segmentId
-        ? { ...seg, speakerId: newSpeakerId }
-        : seg
-    );
+  const handleReassignSpeaker = useCallback(async (segmentId: string, newSpeakerId: string) => {
+    try {
+      await reassignSegments([segmentId], newSpeakerId);
+      console.log('[Viewer] Reassigned segment speaker:', {
+        segmentId,
+        newSpeakerId,
+        newSpeakerName: conversation.speakers[newSpeakerId]?.displayName
+      });
+    } catch (err) {
+      console.error('[Viewer] Reassignment failed:', err);
+    }
+  }, [reassignSegments, conversation.speakers]);
 
-    const updatedConversation = {
-      ...conversation,
-      segments: updatedSegments
-    };
-
-    setConversation(updatedConversation);
-    updateConversation(updatedConversation);
-
-    console.log('[Viewer] Reassigned segment speaker:', {
-      segmentId,
-      newSpeakerId,
-      newSpeakerName: conversation.speakers[newSpeakerId]?.displayName
-    });
-  }, [conversation, updateConversation]);
+  /**
+   * Handle bulk segment reassignment (multiple segments)
+   * Uses the apply-on-read correction pattern via Cloud Function
+   */
+  const handleReassignSegments = useCallback(async (segmentIds: string[], toSpeakerId: string) => {
+    try {
+      await reassignSegments(segmentIds, toSpeakerId);
+      console.log('[Viewer] Bulk reassigned segments:', {
+        segmentCount: segmentIds.length,
+        toSpeakerId,
+        toSpeakerName: conversation.speakers[toSpeakerId]?.displayName
+      });
+    } catch (err) {
+      console.error('[Viewer] Bulk reassignment failed:', err);
+    }
+  }, [reassignSegments, conversation.speakers]);
 
   const saveSpeakerName = useCallback((newName: string) => {
     if (editingSpeakerId && newName.trim()) {
@@ -444,6 +453,7 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
           onTermClick={handleTermClickInTranscript}
           onRenameSpeaker={handleRenameSpeaker}
           onReassignSpeaker={handleReassignSpeaker}
+          onReassignSegments={handleReassignSegments}
         />
 
         {/* Sidebar (Desktop) - use corrected speakers */}


### PR DESCRIPTION
## Summary
- Single-segment reassignment via context menu (right-click or long-press on mobile)
- Bulk segment selection with Shift+Click and floating action bar for batch operations
- Reassign corrections persist via Firestore apply-on-read pattern (original data unchanged)
- Speakers with zero remaining segments auto-hidden from speaker list

## Changelog Entry
```markdown
- **Segment Speaker Reassignment** - Reassign individual or multiple segments to different speakers
  - Right-click (or long-press on mobile) any segment to reassign via context menu
  - Shift+Click to select multiple segments, then use floating action bar to bulk reassign
  - Reassignments persist as correction records and apply on read (original data unchanged)
  - Speakers with zero remaining segments are automatically hidden from the speaker list
```

## Test Plan
- [ ] Right-click a segment → context menu appears with "Reassign to..." option
- [ ] Select target speaker → segment updates immediately in UI
- [ ] Shift+Click multiple segments → floating action bar appears with reassign/cancel
- [ ] Reassign bulk selection → all selected segments update to new speaker
- [ ] Reload page → reassignments persist (apply-on-read working)
- [ ] Reassign all segments away from a speaker → speaker disappears from list

---
Scope: `speaker_reconciliation_manual_speaker_merge_08_02`
Iteration: `iteration_01_a`
Build: `23`