### PR TITLE
chore(release): v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-01-30
+
 ### Added
 - **Manual Speaker Merge** - Correct diarization errors by merging speakers in the sidebar
   - New "Speakers" tab in Viewer sidebar shows all speakers with merge controls
@@ -19,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Shift+Click to select multiple segments, then use floating action bar to bulk reassign
   - Reassignments persist as correction records and apply on read (original data unchanged)
   - Speakers with zero remaining segments are automatically hidden from the speaker list
+- **Inline Speaker Renaming** - Double-click any speaker name to edit directly in place
+  - Enter to save, Escape to cancel, with validation (non-empty, <50 chars)
+  - Renames stored as correction records using apply-on-read pattern (no direct mutation)
+- **Multi-Step Undo Stack** - Undo merge, reassign, and rename corrections with a ~20 action in-memory stack
+  - Toast-based undo appears after each correction with 10-second undo window
+  - "Undo Last Change" button available in edit mode
+  - Correction history preserved for audit (undo marks records inactive, doesn't delete)
+- **Visual Feedback for Speaker Edits** - Merge fade/shrink animation, segment count animation on target, reassignment highlight
 
 ## [2.6.0] - 2026-01-28
 

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -1,5 +1,31 @@
 # What's New
 
+## Version 2.7.0 - January 30, 2026
+
+### ✨ Manual Speaker Correction
+
+**Fix Diarization Mistakes Yourself**
+- When the system incorrectly splits one person into multiple speakers, you can now **merge them** with a simple 3-click workflow
+- New "Speakers" tab in the sidebar shows all speakers with merge controls
+- Click "Merge" on the wrong speaker → Select the correct speaker → Confirm
+- Your changes are saved automatically and apply instantly—no need to re-process
+
+**Reassign Individual Segments**
+- Right-click (or long-press on mobile) any transcript segment to move it to a different speaker
+- Shift+Click to select multiple segments, then bulk-reassign them all at once
+- Speakers with no remaining segments automatically hide from the list
+
+**Inline Speaker Renaming**
+- Double-click any speaker name to rename them directly
+- Names update everywhere instantly—no modal dialogs needed
+
+**Full Undo Support**
+- Every change (merge, reassign, rename) can be undone with the Undo button
+- Toast notifications appear after each action with a 10-second undo window
+- Your original transcript is never modified—all corrections are applied on top
+
+---
+
 ## Version 2.6.0 - January 28, 2026
 
 ### ✨ Smarter Speaker Identification

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -109,13 +109,13 @@ interface ChatHistoryDoc {
 
 #### conversations/{conversationId}/speakerCorrections (subcollection)
 
-Manual speaker corrections. Users can merge incorrectly diarized speakers or reassign individual segments from the UI. Corrections are applied at read time - original data remains immutable.
+Manual speaker corrections. Users can merge incorrectly diarized speakers, reassign individual segments, or rename speakers from the UI. Corrections are applied at read time - original data remains immutable.
 
 **Path**: `conversations/{conversationId}/speakerCorrections/{correctionId}`
 
 ```typescript
 interface SpeakerCorrectionDoc {
-  type: 'merge' | 'reassign';    // Correction type
+  type: 'merge' | 'reassign' | 'rename';  // Correction type
 
   // For 'merge' corrections
   sourceSpeakerId?: string;      // Speaker being merged away (removed from speaker list)
@@ -126,28 +126,42 @@ interface SpeakerCorrectionDoc {
   fromSpeakerId?: string;        // Speaker segments are being moved from
   toSpeakerId?: string;          // Speaker segments are being moved to
 
+  // For 'rename' corrections
+  speakerId?: string;            // Speaker being renamed
+  newDisplayName?: string;       // New display name for the speaker
+  previousDisplayName?: string;  // Previous name (for undo display purposes)
+
   userId: string;                // User who created the correction
   createdAt: Timestamp;          // Server timestamp
+
+  // Undo support (audit-preserving)
+  undoneAt?: Timestamp;          // If set, this correction has been undone
 }
 ```
 
 **Apply-on-Read Pattern**:
 - Corrections are NOT applied to the stored conversation data
-- Client applies corrections in order when loading conversation:
+- Client applies **active** corrections (where `undoneAt` is not set) in chronological order:
   1. Load original speakers and segments from conversation document
   2. Load corrections from subcollection (ordered by createdAt)
-  3. For each merge correction:
+  3. Filter to active corrections only (where `undoneAt` is null/undefined)
+  4. For each merge correction:
      - Remove sourceSpeakerId from speaker list
      - Remap all segments from sourceSpeakerId to targetSpeakerId
-  4. For each reassign correction:
+  5. For each reassign correction:
      - Reassign specified segmentIds to toSpeakerId
-  5. Remove speakers with zero remaining segments from speaker list
-  6. Display corrected data to user
+  6. For each rename correction:
+     - Update speaker's displayName (preserves colorIndex)
+  7. Remove speakers with zero remaining segments from speaker list
+  8. Display corrected data to user
 
-**Undo Support**:
-- Delete the most recent correction document to undo
-- Client re-applies remaining corrections on next read
-- Full correction history is preserved (cannot undo individual corrections from middle of sequence)
+**Undo Support (Audit-Preserving)**:
+- Undo sets the `undoneAt` timestamp via Cloud Function (does NOT delete the document)
+- This preserves the full audit trail for debugging and compliance
+- Client re-applies active corrections (filtering out undone ones) on next read
+- Toast notification with 10-second undo window appears after each correction
+- "Undo Last Change" button available in Speakers tab (covers all correction types)
+- Maximum ~20 corrections tracked in in-memory undo stack (per session)
 
 **Features**:
 - Real-time synchronization (Firestore listener)
@@ -155,14 +169,20 @@ interface SpeakerCorrectionDoc {
 - **Merge workflow**: Click merge button → Select target speaker → Confirm
 - **Reassign workflow (single segment)**: Right-click/long-press segment → Select target speaker
 - **Reassign workflow (multiple segments)**: Shift+Click to select range → Choose target speaker from floating bar
+- **Rename workflow**: Double-click speaker name in sidebar → Edit inline → Enter to save, Escape to cancel
 - Non-destructive (original data unchanged)
-- Audit trail for debugging diarization issues
+- Audit trail preserved even after undo
+
+**Validation (rename corrections)**:
+- Name must be non-empty
+- Name must be less than 50 characters
+- Validated server-side by Cloud Function
 
 **Security**:
-- Users can only read/delete corrections for conversations they own
-- Corrections are created via Cloud Function (not directly by client)
-- Cloud Function validates all segments belong to same speaker before reassigning
-- Immutable once created (no updates allowed)
+- Users can only read corrections for conversations they own
+- Corrections are created/undone via Cloud Functions (not directly by client)
+- Cloud Function validates ownership, speaker existence, and input constraints
+- Cloud Function sets `undoneAt` for undo (Admin SDK bypasses Firestore rules)
 
 ### users
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -77,21 +77,22 @@ service cloud.firestore {
           && get(/databases/$(database)/documents/conversations/$(conversationId)).data.userId == request.auth.uid;
       }
 
-      // Speaker corrections subcollection - manual speaker merge records
+      // Speaker corrections subcollection - manual speaker merge/reassign/rename records
       match /speakerCorrections/{correctionId} {
         // Users can only read corrections for their own conversations
         allow read: if isAuthenticated()
           && get(/databases/$(database)/documents/conversations/$(conversationId)).data.userId == request.auth.uid;
 
-        // Cloud Functions create corrections (via mergeSpeakers callable)
+        // Cloud Functions create corrections (via callable functions)
         // Users cannot directly create via client SDK
         allow create: if false;
 
-        // Users can delete corrections from their own conversations (for undo)
+        // Users can delete corrections from their own conversations
+        // Note: Prefer undoCorrection callable which sets undoneAt to preserve audit trail
         allow delete: if isAuthenticated()
           && get(/databases/$(database)/documents/conversations/$(conversationId)).data.userId == request.auth.uid;
 
-        // Corrections are immutable once created (no updates)
+        // Client updates blocked - Cloud Functions (Admin SDK) can update for undo (sets undoneAt)
         allow update: if false;
       }
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -64,7 +64,7 @@ export { processTranscription } from './processTranscription';
 export { processMerge, processReprocessing } from './chunkMerge';
 export { chatWithConversation } from './chat';
 export { retryTranscription } from './retry';
-export { mergeSpeakers, reassignSegments } from './speakerCorrections';
+export { mergeSpeakers, reassignSegments, renameSpeaker, undoCorrection } from './speakerCorrections';
 
 // Export stats tracking triggers
 export { onConversationCreated, onConversationDeleted } from './statsTriggers';

--- a/functions/src/speakerCorrections.ts
+++ b/functions/src/speakerCorrections.ts
@@ -1,13 +1,14 @@
 /**
- * Speaker Corrections Cloud Function
+ * Speaker Corrections Cloud Functions
  *
- * Handles manual speaker merge operations.
- * Users can merge incorrectly diarized speakers from the UI.
+ * Handles manual speaker corrections: merge, reassign, and rename.
+ * Users can fix incorrectly diarized speakers from the UI.
  *
  * Features:
  * - Requires authentication and ownership verification
  * - Writes correction records to speakerCorrections subcollection
  * - Client applies corrections at read time (apply-on-read pattern)
+ * - Undo preserves audit trail (sets undoneAt instead of deleting)
  */
 
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
@@ -34,6 +35,26 @@ interface ReassignSegmentsRequest {
 interface ReassignSegmentsResponse {
   success: boolean;
   correctionId: string;
+}
+
+interface RenameSpeakerRequest {
+  conversationId: string;
+  speakerId: string;       // Speaker to rename
+  newDisplayName: string;  // New name (validated: non-empty, <50 chars)
+}
+
+interface RenameSpeakerResponse {
+  success: boolean;
+  correctionId: string;
+}
+
+interface UndoCorrectionRequest {
+  conversationId: string;
+  correctionId: string;    // Correction to undo
+}
+
+interface UndoCorrectionResponse {
+  success: boolean;
 }
 
 /**
@@ -320,6 +341,258 @@ export const reassignSegments = onCall<ReassignSegmentsRequest>(
       throw new HttpsError(
         'internal',
         'Failed to reassign segments: ' + (error instanceof Error ? error.message : String(error))
+      );
+    }
+  }
+);
+
+/**
+ * Rename a speaker by writing a correction record.
+ *
+ * Security:
+ * - Requires authentication
+ * - Verifies user owns the conversation
+ * - Validates speaker exists
+ * - Validates name: non-empty, <50 characters
+ *
+ * The correction is stored in the speakerCorrections subcollection
+ * and applied at read time by the client.
+ */
+export const renameSpeaker = onCall<RenameSpeakerRequest>(
+  {
+    region: 'us-central1',
+    memory: '256MiB',
+    timeoutSeconds: 30,
+    cors: true
+  },
+  async (request): Promise<RenameSpeakerResponse> => {
+    // Require authentication
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Must be signed in to rename speaker');
+    }
+
+    const { conversationId, speakerId, newDisplayName } = request.data;
+    const userId = request.auth.uid;
+
+    // Validate input
+    if (!conversationId) {
+      throw new HttpsError('invalid-argument', 'conversationId is required');
+    }
+    if (!speakerId) {
+      throw new HttpsError('invalid-argument', 'speakerId is required');
+    }
+
+    // Validate name: non-empty and <50 characters
+    const trimmedName = newDisplayName?.trim();
+    if (!trimmedName) {
+      throw new HttpsError('invalid-argument', 'newDisplayName cannot be empty');
+    }
+    if (trimmedName.length >= 50) {
+      throw new HttpsError('invalid-argument', 'newDisplayName must be less than 50 characters');
+    }
+
+    log.info('Speaker rename request received', {
+      conversationId,
+      userId,
+      speakerId,
+      newDisplayName: trimmedName
+    });
+
+    try {
+      // Fetch conversation and verify ownership
+      const conversationDoc = await db.collection('conversations').doc(conversationId).get();
+
+      if (!conversationDoc.exists) {
+        throw new HttpsError('not-found', 'Conversation not found');
+      }
+
+      const conversation = conversationDoc.data();
+      if (!conversation) {
+        throw new HttpsError('not-found', 'Conversation data not found');
+      }
+
+      if (conversation.userId !== userId) {
+        throw new HttpsError('permission-denied', 'You do not have access to this conversation');
+      }
+
+      // Validate speaker exists
+      const speakers = conversation.speakers || {};
+      if (!speakers[speakerId]) {
+        throw new HttpsError('invalid-argument', `Speaker '${speakerId}' not found`);
+      }
+
+      const previousDisplayName = speakers[speakerId].displayName;
+
+      // Write correction record to subcollection
+      const correctionRef = db
+        .collection('conversations')
+        .doc(conversationId)
+        .collection('speakerCorrections')
+        .doc(); // Auto-generate ID
+
+      const correctionData = {
+        type: 'rename',
+        speakerId,
+        newDisplayName: trimmedName,
+        previousDisplayName,
+        userId,
+        createdAt: new Date() // Firestore will convert to Timestamp
+      };
+
+      await correctionRef.set(correctionData);
+
+      log.info('Speaker rename correction saved', {
+        conversationId,
+        userId,
+        correctionId: correctionRef.id,
+        speakerId,
+        previousDisplayName,
+        newDisplayName: trimmedName
+      });
+
+      return {
+        success: true,
+        correctionId: correctionRef.id
+      };
+
+    } catch (error) {
+      log.error('Speaker rename request failed', {
+        conversationId,
+        userId,
+        speakerId,
+        newDisplayName: trimmedName,
+        error: error instanceof Error ? error.message : String(error)
+      });
+
+      // Re-throw HttpsErrors as-is
+      if (error instanceof HttpsError) {
+        throw error;
+      }
+
+      // Wrap other errors
+      throw new HttpsError(
+        'internal',
+        'Failed to rename speaker: ' + (error instanceof Error ? error.message : String(error))
+      );
+    }
+  }
+);
+
+/**
+ * Undo a correction by setting its undoneAt timestamp.
+ * This preserves the audit trail - we don't delete corrections.
+ *
+ * Security:
+ * - Requires authentication
+ * - Verifies user owns the conversation
+ * - Validates correction exists and is not already undone
+ *
+ * After undo, the correction still exists but apply-on-read
+ * logic filters it out based on undoneAt being set.
+ */
+export const undoCorrection = onCall<UndoCorrectionRequest>(
+  {
+    region: 'us-central1',
+    memory: '256MiB',
+    timeoutSeconds: 30,
+    cors: true
+  },
+  async (request): Promise<UndoCorrectionResponse> => {
+    // Require authentication
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Must be signed in to undo correction');
+    }
+
+    const { conversationId, correctionId } = request.data;
+    const userId = request.auth.uid;
+
+    // Validate input
+    if (!conversationId) {
+      throw new HttpsError('invalid-argument', 'conversationId is required');
+    }
+    if (!correctionId) {
+      throw new HttpsError('invalid-argument', 'correctionId is required');
+    }
+
+    log.info('Undo correction request received', {
+      conversationId,
+      userId,
+      correctionId
+    });
+
+    try {
+      // Fetch conversation and verify ownership
+      const conversationDoc = await db.collection('conversations').doc(conversationId).get();
+
+      if (!conversationDoc.exists) {
+        throw new HttpsError('not-found', 'Conversation not found');
+      }
+
+      const conversation = conversationDoc.data();
+      if (!conversation) {
+        throw new HttpsError('not-found', 'Conversation data not found');
+      }
+
+      if (conversation.userId !== userId) {
+        throw new HttpsError('permission-denied', 'You do not have access to this conversation');
+      }
+
+      // Fetch the correction and validate
+      const correctionRef = db
+        .collection('conversations')
+        .doc(conversationId)
+        .collection('speakerCorrections')
+        .doc(correctionId);
+
+      const correctionDoc = await correctionRef.get();
+
+      if (!correctionDoc.exists) {
+        throw new HttpsError('not-found', 'Correction not found');
+      }
+
+      const correction = correctionDoc.data();
+      if (!correction) {
+        throw new HttpsError('not-found', 'Correction data not found');
+      }
+
+      // Check if already undone
+      if (correction.undoneAt) {
+        throw new HttpsError('failed-precondition', 'Correction has already been undone');
+      }
+
+      // Set undoneAt to preserve audit trail (don't delete)
+      await correctionRef.update({
+        undoneAt: new Date()
+      });
+
+      log.info('Correction undone (audit preserved)', {
+        conversationId,
+        userId,
+        correctionId,
+        correctionType: correction.type
+      });
+
+      return {
+        success: true
+      };
+
+    } catch (error) {
+      log.error('Undo correction request failed', {
+        conversationId,
+        userId,
+        correctionId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+
+      // Re-throw HttpsErrors as-is
+      if (error instanceof HttpsError) {
+        throw error;
+      }
+
+      // Wrap other errors
+      throw new HttpsError(
+        'internal',
+        'Failed to undo correction: ' + (error instanceof Error ? error.message : String(error))
       );
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-transcript-analysis-app",
   "private": true,
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/shared/Toast.tsx
+++ b/src/components/shared/Toast.tsx
@@ -1,0 +1,153 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { cn } from '@/utils';
+import { X, Undo2 } from 'lucide-react';
+
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface ToastData {
+  id: string;
+  message: string;
+  action?: ToastAction;
+  duration?: number; // ms, defaults to 10000
+  type?: 'info' | 'success' | 'warning' | 'error';
+}
+
+interface ToastProps {
+  toast: ToastData;
+  onDismiss: (id: string) => void;
+}
+
+/**
+ * Individual toast notification with optional undo action.
+ * Auto-dismisses after duration (default 10s) unless dismissed manually.
+ */
+const Toast: React.FC<ToastProps> = ({ toast, onDismiss }) => {
+  const [progress, setProgress] = useState(100);
+  const duration = toast.duration ?? 10000;
+
+  useEffect(() => {
+    const startTime = Date.now();
+    const interval = setInterval(() => {
+      const elapsed = Date.now() - startTime;
+      const remaining = Math.max(0, 100 - (elapsed / duration) * 100);
+      setProgress(remaining);
+
+      if (remaining <= 0) {
+        clearInterval(interval);
+        onDismiss(toast.id);
+      }
+    }, 50);
+
+    return () => clearInterval(interval);
+  }, [toast.id, duration, onDismiss]);
+
+  const typeStyles = {
+    info: 'bg-slate-900 text-white',
+    success: 'bg-green-800 text-white',
+    warning: 'bg-amber-600 text-white',
+    error: 'bg-red-700 text-white'
+  };
+
+  return (
+    <div
+      className={cn(
+        "relative flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg min-w-[300px] max-w-[400px]",
+        "animate-in slide-in-from-bottom-2 fade-in duration-200",
+        typeStyles[toast.type ?? 'info']
+      )}
+    >
+      {/* Message */}
+      <span className="flex-1 text-sm font-medium">{toast.message}</span>
+
+      {/* Action button (e.g., Undo) */}
+      {toast.action && (
+        <button
+          onClick={() => {
+            toast.action?.onClick();
+            onDismiss(toast.id);
+          }}
+          className="flex items-center gap-1.5 px-2.5 py-1 rounded bg-white/20 hover:bg-white/30 text-sm font-medium transition-colors"
+        >
+          <Undo2 size={14} />
+          {toast.action.label}
+        </button>
+      )}
+
+      {/* Dismiss button */}
+      <button
+        onClick={() => onDismiss(toast.id)}
+        className="p-1 hover:bg-white/20 rounded transition-colors"
+        aria-label="Dismiss"
+      >
+        <X size={16} />
+      </button>
+
+      {/* Progress bar - shows time remaining */}
+      <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-white/20 rounded-b-lg overflow-hidden">
+        <div
+          className="h-full bg-white/60 transition-all duration-50"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </div>
+  );
+};
+
+interface ToastContainerProps {
+  toasts: ToastData[];
+  onDismiss: (id: string) => void;
+}
+
+/**
+ * Container for toast notifications. Stacks toasts from bottom.
+ * Position: bottom-right, above the audio player.
+ */
+export const ToastContainer: React.FC<ToastContainerProps> = ({ toasts, onDismiss }) => {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      className="fixed z-50 flex flex-col gap-2"
+      style={{
+        bottom: 'calc(4rem + 1.5rem)', // Above audio player (64px) + gap
+        right: '1.5rem'
+      }}
+    >
+      {toasts.map((toast) => (
+        <Toast key={toast.id} toast={toast} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+};
+
+/**
+ * Hook for managing toast notifications.
+ * Provides addToast and dismissToast functions.
+ */
+export function useToasts() {
+  const [toasts, setToasts] = useState<ToastData[]>([]);
+
+  const addToast = useCallback((toast: Omit<ToastData, 'id'>) => {
+    const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    setToasts((prev) => [...prev, { ...toast, id }]);
+    return id;
+  }, []);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setToasts([]);
+  }, []);
+
+  return {
+    toasts,
+    addToast,
+    dismissToast,
+    clearAll
+  };
+}

--- a/src/components/viewer/Sidebar.tsx
+++ b/src/components/viewer/Sidebar.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Term, Person, Speaker } from '@/config/types';
 import { cn } from '@/utils';
-import { BookOpen, Search, Users, User, StickyNote, ChevronLeft, ChevronRight, MessageSquare, Mic, Undo2 } from 'lucide-react';
+import { BookOpen, Search, Users, User, StickyNote, ChevronLeft, ChevronRight, MessageSquare, Mic, Undo2, Check, X } from 'lucide-react';
 import { ChatSidebar } from './ChatSidebar';
 import { ChatHistoryMessage } from '@/services/chatHistoryService';
 import { Button } from '../Button';
@@ -42,9 +42,14 @@ interface SidebarProps {
   chatCumulativeCostUsd?: number;
   chatCostWarningLevel?: 'none' | 'primary' | 'escalated';
   // Speaker corrections props
-  canUndoMerge?: boolean;
-  onUndoMerge?: () => void;
+  canUndo?: boolean;
+  undoStackSize?: number;
+  onUndo?: () => void;
   onMergeSpeaker?: (speakerId: string) => void;
+  onRenameSpeaker?: (speakerId: string, newName: string) => Promise<void>;
+  isCorrectionsLoading?: boolean;
+  recentMerge?: { sourceSpeakerId: string; targetSpeakerId: string } | null;
+  speakerSegmentCounts?: Record<string, number>;
   // Mobile support
   defaultTab?: 'context' | 'people' | 'speakers' | 'chat';
 }
@@ -84,9 +89,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
   chatCumulativeCostUsd = 0,
   chatCostWarningLevel = 'none',
   // Speaker corrections
-  canUndoMerge = false,
-  onUndoMerge = () => {},
+  canUndo = false,
+  undoStackSize = 0,
+  onUndo = () => {},
   onMergeSpeaker = () => {},
+  onRenameSpeaker,
+  isCorrectionsLoading = false,
+  recentMerge = null,
+  speakerSegmentCounts = {},
   defaultTab = 'context'
 }) => {
   const [activeTab, setActiveTab] = useState<'context' | 'people' | 'speakers' | 'chat'>(defaultTab);
@@ -270,22 +280,28 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 <SpeakerCard
                   key={speaker.speakerId}
                   speaker={speaker}
+                  segmentCount={speakerSegmentCounts[speaker.speakerId] || 0}
                   onMerge={() => onMergeSpeaker(speaker.speakerId)}
+                  onRename={onRenameSpeaker}
+                  isLoading={isCorrectionsLoading}
+                  isMergeSource={recentMerge?.sourceSpeakerId === speaker.speakerId}
+                  isMergeTarget={recentMerge?.targetSpeakerId === speaker.speakerId}
                 />
               ))
             )}
           </div>
 
           {/* Undo Button at bottom */}
-          {canUndoMerge && (
+          {canUndo && (
             <div className="p-4 border-t border-slate-200 bg-slate-50/50">
               <Button
                 variant="outline"
-                onClick={onUndoMerge}
+                onClick={onUndo}
+                disabled={isCorrectionsLoading}
                 className="w-full flex items-center justify-center gap-2"
               >
                 <Undo2 size={14} />
-                Undo Last Merge
+                Undo Last Change{undoStackSize > 1 ? ` (${undoStackSize})` : ''}
               </Button>
             </div>
           )}
@@ -472,11 +488,46 @@ const PersonCard: React.FC<{
   );
 };
 
-// Sub-component for Speaker Card with merge button
+// Sub-component for Speaker Card with merge button and inline rename
 const SpeakerCard: React.FC<{
   speaker: Speaker;
+  segmentCount: number;
   onMerge: () => void;
-}> = ({ speaker, onMerge }) => {
+  onRename?: (speakerId: string, newName: string) => Promise<void>;
+  isLoading?: boolean;
+  isMergeSource?: boolean;
+  isMergeTarget?: boolean;
+}> = ({ speaker, segmentCount, onMerge, onRename, isLoading = false, isMergeSource = false, isMergeTarget = false }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(speaker.displayName);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [animatingCount, setAnimatingCount] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus input when entering edit mode
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  // Reset edit value when speaker changes (e.g., after undo)
+  useEffect(() => {
+    if (!isEditing) {
+      setEditValue(speaker.displayName);
+    }
+  }, [speaker.displayName, isEditing]);
+
+  // Animate segment count when this speaker is the merge target
+  useEffect(() => {
+    if (isMergeTarget) {
+      setAnimatingCount(true);
+      const timer = setTimeout(() => setAnimatingCount(false), 300);
+      return () => clearTimeout(timer);
+    }
+  }, [isMergeTarget, segmentCount]);
+
   // Get color class for speaker badge
   const getSpeakerColorClass = (colorIndex: number): string => {
     const colors = [
@@ -492,36 +543,171 @@ const SpeakerCard: React.FC<{
     return colors[colorIndex % colors.length];
   };
 
+  const handleDoubleClick = () => {
+    if (onRename && !isLoading) {
+      setIsEditing(true);
+      setEditValue(speaker.displayName);
+      setValidationError(null);
+    }
+  };
+
+  const validateName = (name: string): string | null => {
+    const trimmed = name.trim();
+    if (!trimmed) return 'Name cannot be empty';
+    if (trimmed.length >= 50) return 'Name must be less than 50 characters';
+    return null;
+  };
+
+  const handleSave = async () => {
+    const trimmed = editValue.trim();
+    const error = validateName(trimmed);
+
+    if (error) {
+      setValidationError(error);
+      return;
+    }
+
+    // Don't save if name hasn't changed
+    if (trimmed === speaker.displayName) {
+      setIsEditing(false);
+      return;
+    }
+
+    try {
+      await onRename?.(speaker.speakerId, trimmed);
+      setIsEditing(false);
+      setValidationError(null);
+    } catch (_err) {
+      setValidationError('Failed to rename speaker');
+    }
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setEditValue(speaker.displayName);
+    setValidationError(null);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      handleCancel();
+    }
+  };
+
   return (
-    <div className="p-3 rounded-lg border border-slate-200 bg-white shadow-sm hover:shadow-md transition-all">
-      <div className="flex justify-between items-center">
+    <div className={cn(
+      "p-3 rounded-lg border border-slate-200 bg-white shadow-sm hover:shadow-md transition-all",
+      isMergeSource && "opacity-50 scale-95",
+      isMergeTarget && "ring-2 ring-green-400 animate-pulse"
+    )}>
+      <div className="flex justify-between items-center gap-2">
         {/* Speaker info */}
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-1 min-w-0">
           <div className="w-8 h-8 rounded-full bg-slate-100 flex items-center justify-center text-slate-400 shrink-0">
             <Mic size={16} />
           </div>
-          <div>
-            <div className={cn(
-              "px-2 py-1 rounded text-xs font-medium border",
-              getSpeakerColorClass(speaker.colorIndex)
-            )}>
-              {speaker.displayName}
-            </div>
+          <div className="flex-1 min-w-0">
+            {isEditing ? (
+              // Inline edit mode
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-1">
+                  <input
+                    ref={inputRef}
+                    type="text"
+                    value={editValue}
+                    onChange={(e) => {
+                      setEditValue(e.target.value);
+                      setValidationError(null);
+                    }}
+                    onKeyDown={handleKeyDown}
+                    onBlur={() => {
+                      // Small delay to allow button clicks to register
+                      setTimeout(() => {
+                        if (isEditing) handleCancel();
+                      }, 150);
+                    }}
+                    maxLength={50}
+                    className={cn(
+                      "flex-1 px-2 py-1 text-xs font-medium border rounded focus:outline-none focus:ring-2",
+                      validationError
+                        ? "border-red-300 focus:ring-red-500"
+                        : "border-slate-300 focus:ring-blue-500"
+                    )}
+                    disabled={isLoading}
+                  />
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleSave();
+                    }}
+                    disabled={isLoading}
+                    className="p-1 text-green-600 hover:bg-green-50 rounded transition-colors"
+                    title="Save (Enter)"
+                  >
+                    <Check size={14} />
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleCancel();
+                    }}
+                    disabled={isLoading}
+                    className="p-1 text-slate-500 hover:bg-slate-100 rounded transition-colors"
+                    title="Cancel (Escape)"
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+                {validationError && (
+                  <p className="text-[10px] text-red-500">{validationError}</p>
+                )}
+              </div>
+            ) : (
+              // Display mode - double-click to edit
+              <div className="flex items-center gap-2">
+                <div
+                  onDoubleClick={handleDoubleClick}
+                  className={cn(
+                    "px-2 py-1 rounded text-xs font-medium border truncate",
+                    getSpeakerColorClass(speaker.colorIndex),
+                    onRename && "cursor-text hover:ring-1 hover:ring-blue-300"
+                  )}
+                  title={onRename ? "Double-click to rename" : undefined}
+                >
+                  {speaker.displayName}
+                </div>
+                <span
+                  className={cn(
+                    "text-[10px] text-slate-400 tabular-nums whitespace-nowrap transition-all duration-300",
+                    animatingCount && "text-green-600 font-semibold scale-110"
+                  )}
+                >
+                  {segmentCount} {segmentCount === 1 ? 'segment' : 'segments'}
+                </span>
+              </div>
+            )}
           </div>
         </div>
 
-        {/* Merge button */}
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={(e) => {
-            e.stopPropagation();
-            onMerge();
-          }}
-          className="text-xs"
-        >
-          Merge
-        </Button>
+        {/* Merge button - hide during editing */}
+        {!isEditing && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={(e) => {
+              e.stopPropagation();
+              onMerge();
+            }}
+            disabled={isLoading}
+            className="text-xs shrink-0"
+          >
+            Merge
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/components/viewer/TranscriptSegment.tsx
+++ b/src/components/viewer/TranscriptSegment.tsx
@@ -15,6 +15,7 @@ interface TranscriptSegmentProps {
   isActive: boolean;
   isHighlighted?: boolean; // True when segment is highlighted from timestamp click
   isSelected?: boolean; // True when segment is part of multi-select
+  isRecentlyReassigned?: boolean; // True when segment was just reassigned (cleared after 1.5s)
   showSpeakerChange: boolean; // True when speaker changes from previous segment
   activeTermId?: string;
   activePersonId?: string;
@@ -34,6 +35,7 @@ export const TranscriptSegment: React.FC<TranscriptSegmentProps> = ({
   isActive,
   isHighlighted = false,
   isSelected = false,
+  isRecentlyReassigned = false,
   showSpeakerChange,
   activeTermId,
   activePersonId,
@@ -249,7 +251,8 @@ export const TranscriptSegment: React.FC<TranscriptSegmentProps> = ({
           isActive && "bg-blue-50/80 border border-blue-200 shadow-sm",
           isHighlighted && "bg-yellow-50 border border-yellow-300 shadow-md ring-1 ring-yellow-200",
           isSelected && "bg-purple-50 border border-purple-300 ring-1 ring-purple-200",
-          !isActive && !isHighlighted && !isSelected && "hover:bg-slate-50/50",
+          isRecentlyReassigned && "bg-green-50 border border-green-300 ring-1 ring-green-200",
+          !isActive && !isHighlighted && !isSelected && !isRecentlyReassigned && "hover:bg-slate-50/50",
           // Long-press visual feedback
           longPressHandlers.isLongPressing && onReassignSpeaker && allSpeakers.length > 1 && "scale-[1.02] opacity-95 cursor-context-menu",
           // Selection cursor

--- a/src/components/viewer/TranscriptView.tsx
+++ b/src/components/viewer/TranscriptView.tsx
@@ -11,6 +11,7 @@ interface TranscriptViewProps {
   selectedPersonId?: string;
   personOccurrences: Record<string, { start: number; end: number; personId: string }[]>;
   highlightedSegmentId?: string | null;
+  recentReassignSegmentIds?: string[];
   onSeek: (ms: number) => void;
   onTermClick: (termId: string) => void;
   onRenameSpeaker: (speakerId: string) => void;
@@ -34,6 +35,7 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({
   selectedPersonId,
   personOccurrences,
   highlightedSegmentId,
+  recentReassignSegmentIds = [],
   onSeek,
   onTermClick,
   onRenameSpeaker,
@@ -110,6 +112,7 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({
           const isActive = idx === activeSegmentIndex;
           const isHighlighted = highlightedSegmentId === seg.segmentId;
           const isSelected = selectedSegmentIds.has(seg.segmentId);
+          const isRecentlyReassigned = recentReassignSegmentIds.includes(seg.segmentId);
 
           // Find term occurrences for this segment
           const segmentOccurrences = conversation.termOccurrences.filter(
@@ -142,6 +145,7 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({
                 isActive={isActive}
                 isHighlighted={isHighlighted}
                 isSelected={isSelected}
+                isRecentlyReassigned={isRecentlyReassigned}
                 activeTermId={selectedTermId}
                 activePersonId={selectedPersonId}
                 showSpeakerChange={showSpeakerChange}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -393,8 +393,9 @@ export interface ReconciliationMetadata {
  * Type of speaker correction operation.
  * - 'merge': Merge all segments from one speaker into another
  * - 'reassign': Reassign specific segments to a different speaker
+ * - 'rename': Rename a speaker's display name
  */
-export type SpeakerCorrectionType = 'merge' | 'reassign';
+export type SpeakerCorrectionType = 'merge' | 'reassign' | 'rename';
 
 /**
  * User-initiated speaker correction record.
@@ -421,8 +422,20 @@ export interface SpeakerCorrection {
   /** Speaker ID segments are being moved to (reassign type only) */
   toSpeakerId?: string;
 
+  // Fields for 'rename' corrections
+  /** Speaker ID being renamed (rename type only) */
+  speakerId?: string;
+  /** New display name for the speaker (rename type only) */
+  newDisplayName?: string;
+  /** Previous display name for undo display purposes (rename type only) */
+  previousDisplayName?: string;
+
   /** When this correction was created (ISO timestamp) */
   createdAt: string;
   /** User who created this correction (for verification) */
   userId: string;
+
+  /** If set, this correction has been undone and should be ignored in apply-on-read.
+   *  Preserves audit trail - we don't delete corrections on undo. */
+  undoneAt?: string;
 }

--- a/src/hooks/useSpeakerCorrections.ts
+++ b/src/hooks/useSpeakerCorrections.ts
@@ -4,14 +4,14 @@
  * Manages speaker correction state for a conversation:
  * - Real-time subscription to speakerCorrections subcollection
  * - Apply-on-read logic: compute corrected speakers and segments
- * - Merge speakers via Cloud Function
- * - Undo last merge
+ * - Merge, reassign, and rename speakers via Cloud Functions
+ * - Undo support with audit trail preservation (sets undoneAt, doesn't delete)
  *
  * Pattern: Original conversation data stays immutable.
  * All corrections are applied at read time.
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   collection,
   query,
@@ -29,33 +29,56 @@ interface UseSpeakerCorrectionsOptions {
   originalSegments: Segment[];
 }
 
+/** Toast notification data for undo actions */
+export interface CorrectionToast {
+  correctionId: string;
+  message: string;
+  type: 'merge' | 'reassign' | 'rename';
+}
+
 interface UseSpeakerCorrectionsReturn {
-  /** Corrected speaker list with merges applied */
+  /** Corrected speaker list with all corrections applied */
   correctedSpeakers: Record<string, Speaker>;
   /** Segments with corrected speaker IDs */
   correctedSegments: Segment[];
-  /** Whether undo is available */
+  /** Whether undo is available (has active corrections) */
   canUndo: boolean;
+  /** Number of corrections in the undo stack */
+  undoStackSize: number;
   /** Merge two speakers (calls Cloud Function) */
   mergeSpeakers: (sourceSpeakerId: string, targetSpeakerId: string) => Promise<void>;
   /** Reassign specific segments to a different speaker (calls Cloud Function) */
   reassignSegments: (segmentIds: string[], toSpeakerId: string) => Promise<void>;
-  /** Undo the most recent merge */
-  undoLastMerge: () => Promise<void>;
-  /** Loading state for merge operations */
+  /** Rename a speaker (calls Cloud Function) */
+  renameSpeaker: (speakerId: string, newDisplayName: string) => Promise<void>;
+  /** Undo the most recent active correction (uses Cloud Function to preserve audit) */
+  undoLastCorrection: () => Promise<void>;
+  /** Loading state for correction operations */
   isLoading: boolean;
-  /** Error message if merge fails */
+  /** Error message if operation fails */
   error: string | null;
   /** Clear error state */
   clearError: () => void;
+  /** Latest toast notification (for UI display), cleared after read */
+  pendingToast: CorrectionToast | null;
+  /** Clear the pending toast */
+  clearPendingToast: () => void;
+  /** Recent merge visual feedback (cleared after 1.5s) */
+  recentMerge: { sourceSpeakerId: string; targetSpeakerId: string } | null;
+  /** Recent reassign segment IDs (cleared after 1.5s) */
+  recentReassignSegmentIds: string[];
 }
 
 /**
  * Firestore document type for speaker corrections
  */
-interface SpeakerCorrectionDoc extends Omit<SpeakerCorrection, 'createdAt'> {
+interface SpeakerCorrectionDoc extends Omit<SpeakerCorrection, 'createdAt' | 'undoneAt'> {
   createdAt: Timestamp;
+  undoneAt?: Timestamp;
 }
+
+// Maximum corrections tracked in undo stack
+const MAX_UNDO_STACK_SIZE = 20;
 
 /**
  * Hook to manage speaker corrections with apply-on-read logic.
@@ -68,9 +91,17 @@ export function useSpeakerCorrections({
   originalSpeakers,
   originalSegments
 }: UseSpeakerCorrectionsOptions): UseSpeakerCorrectionsReturn {
-  const [corrections, setCorrections] = useState<SpeakerCorrection[]>([]);
+  const [allCorrections, setAllCorrections] = useState<SpeakerCorrection[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pendingToast, setPendingToast] = useState<CorrectionToast | null>(null);
+
+  // Visual feedback state for corrections (cleared after 1.5s)
+  const [recentMerge, setRecentMerge] = useState<{ sourceSpeakerId: string; targetSpeakerId: string } | null>(null);
+  const [recentReassignSegmentIds, setRecentReassignSegmentIds] = useState<string[]>([]);
+
+  // Track undo stack for last N corrections (in-memory, not persisted)
+  const undoStackRef = useRef<string[]>([]);
 
   // Subscribe to speakerCorrections subcollection
   useEffect(() => {
@@ -94,12 +125,19 @@ export function useSpeakerCorrections({
             segmentIds: data.segmentIds,
             fromSpeakerId: data.fromSpeakerId,
             toSpeakerId: data.toSpeakerId,
+            // Rename correction fields
+            speakerId: data.speakerId,
+            newDisplayName: data.newDisplayName,
+            previousDisplayName: data.previousDisplayName,
+            // Common fields
             createdAt: data.createdAt.toDate().toISOString(),
-            userId: data.userId
+            userId: data.userId,
+            // Undo support
+            undoneAt: data.undoneAt?.toDate().toISOString()
           };
         });
 
-        setCorrections(loadedCorrections);
+        setAllCorrections(loadedCorrections);
       },
       (err) => {
         console.error('[useSpeakerCorrections] Subscription error:', err);
@@ -111,20 +149,41 @@ export function useSpeakerCorrections({
   }, [conversationId]);
 
   /**
+   * Active corrections = corrections that haven't been undone.
+   * These are what we apply in the apply-on-read logic.
+   */
+  const activeCorrections = useMemo(() => {
+    return allCorrections.filter(c => !c.undoneAt);
+  }, [allCorrections]);
+
+  /**
+   * Filter undo stack to remove correction IDs that are no longer active.
+   * This ensures the stack only contains valid IDs to undo.
+   */
+  useEffect(() => {
+    const activeIds = new Set(activeCorrections.map(c => c.correctionId));
+    undoStackRef.current = undoStackRef.current.filter(id => activeIds.has(id));
+  }, [activeCorrections]);
+
+  /**
    * Apply corrections to derive corrected speakers and segments.
    * This is the core apply-on-read logic - we never mutate the original data.
    */
   const { correctedSpeakers, correctedSegments } = useMemo(() => {
-    // Start with originals
-    let speakers = { ...originalSpeakers };
-    let segments = [...originalSegments];
+    // Start with deep copies of originals
+    let speakers: Record<string, Speaker> = {};
+    for (const [id, speaker] of Object.entries(originalSpeakers)) {
+      speakers[id] = { ...speaker };
+    }
+    let segments = originalSegments.map(seg => ({ ...seg }));
 
-    // Apply each correction in chronological order
-    for (const correction of corrections) {
+    // Apply each active correction in chronological order
+    for (const correction of activeCorrections) {
       if (correction.type === 'merge') {
         const { sourceSpeakerId, targetSpeakerId } = correction;
 
         if (!sourceSpeakerId || !targetSpeakerId) continue;
+        if (!speakers[sourceSpeakerId] || !speakers[targetSpeakerId]) continue;
 
         // Remove source speaker from list
         delete speakers[sourceSpeakerId];
@@ -147,6 +206,17 @@ export function useSpeakerCorrections({
             ? { ...seg, speakerId: toSpeakerId }
             : seg
         );
+      } else if (correction.type === 'rename') {
+        const { speakerId, newDisplayName } = correction;
+
+        if (!speakerId || !newDisplayName) continue;
+        if (!speakers[speakerId]) continue;
+
+        // Update the speaker's display name (preserve colorIndex)
+        speakers[speakerId] = {
+          ...speakers[speakerId],
+          displayName: newDisplayName
+        };
       }
     }
 
@@ -159,12 +229,42 @@ export function useSpeakerCorrections({
     }
 
     return { correctedSpeakers: speakers, correctedSegments: segments };
-  }, [originalSpeakers, originalSegments, corrections]);
+  }, [originalSpeakers, originalSegments, activeCorrections]);
 
   /**
-   * Check if undo is available (have corrections to undo)
+   * Check if undo is available (have corrections in the in-memory undo stack)
    */
-  const canUndo = corrections.length > 0;
+  const canUndo = undoStackRef.current.length > 0;
+  const undoStackSize = undoStackRef.current.length;
+
+  /**
+   * Add a correction to the undo stack (after successful creation)
+   */
+  const pushToUndoStack = useCallback((correctionId: string) => {
+    undoStackRef.current = [
+      correctionId,
+      ...undoStackRef.current.slice(0, MAX_UNDO_STACK_SIZE - 1)
+    ];
+  }, []);
+
+  /**
+   * Generate a human-readable message for a correction
+   */
+  const getCorrectionMessage = useCallback((
+    type: 'merge' | 'reassign' | 'rename',
+    details: { sourceName?: string; targetName?: string; segmentCount?: number; speakerName?: string; newName?: string }
+  ): string => {
+    switch (type) {
+      case 'merge':
+        return `Merged "${details.sourceName}" into "${details.targetName}"`;
+      case 'reassign':
+        return `Reassigned ${details.segmentCount} segment${details.segmentCount === 1 ? '' : 's'}`;
+      case 'rename':
+        return `Renamed speaker to "${details.newName}"`;
+      default:
+        return 'Speaker correction applied';
+    }
+  }, []);
 
   /**
    * Merge two speakers by calling Cloud Function.
@@ -176,15 +276,33 @@ export function useSpeakerCorrections({
     setIsLoading(true);
     setError(null);
 
+    const sourceName = correctedSpeakers[sourceSpeakerId]?.displayName || 'Speaker';
+    const targetName = correctedSpeakers[targetSpeakerId]?.displayName || 'Speaker';
+
     try {
-      const mergeSpeakersFunction = httpsCallable(functions, 'mergeSpeakers');
-      await mergeSpeakersFunction({
+      const mergeSpeakersFunction = httpsCallable<
+        { conversationId: string; sourceSpeakerId: string; targetSpeakerId: string },
+        { success: boolean; correctionId: string }
+      >(functions, 'mergeSpeakers');
+
+      const result = await mergeSpeakersFunction({
         conversationId,
         sourceSpeakerId,
         targetSpeakerId
       });
 
-      // Success - the onSnapshot listener will update our state automatically
+      // Add to undo stack and create toast
+      pushToUndoStack(result.data.correctionId);
+      setPendingToast({
+        correctionId: result.data.correctionId,
+        message: getCorrectionMessage('merge', { sourceName, targetName }),
+        type: 'merge'
+      });
+
+      // Set visual feedback for merge (cleared after 1.5s)
+      setRecentMerge({ sourceSpeakerId, targetSpeakerId });
+      setTimeout(() => setRecentMerge(null), 1500);
+
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to merge speakers';
       setError(errorMessage);
@@ -192,46 +310,10 @@ export function useSpeakerCorrections({
     } finally {
       setIsLoading(false);
     }
-  }, [conversationId, isLoading]);
-
-  /**
-   * Undo the most recent merge by deleting its correction record.
-   * Firestore listener will automatically update our state.
-   */
-  const undoLastMerge = useCallback(async () => {
-    if (!canUndo || isLoading) return;
-
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      const lastCorrection = corrections[corrections.length - 1];
-
-      // Dynamically import to avoid build-time resolution issues
-      const { doc, deleteDoc } = await import('firebase/firestore');
-      const correctionRef = doc(
-        db,
-        'conversations',
-        conversationId,
-        'speakerCorrections',
-        lastCorrection.correctionId
-      );
-
-      await deleteDoc(correctionRef);
-
-      // Success - the onSnapshot listener will update our state automatically
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to undo merge';
-      setError(errorMessage);
-      throw err;
-    } finally {
-      setIsLoading(false);
-    }
-  }, [conversationId, corrections, canUndo, isLoading]);
+  }, [conversationId, isLoading, correctedSpeakers, pushToUndoStack, getCorrectionMessage]);
 
   /**
    * Reassign specific segments to a different speaker by calling Cloud Function.
-   * The function writes to Firestore, and our listener picks it up automatically.
    */
   const reassignSegments = useCallback(async (segmentIds: string[], toSpeakerId: string) => {
     if (isLoading) return;
@@ -239,17 +321,112 @@ export function useSpeakerCorrections({
     setIsLoading(true);
     setError(null);
 
+    const targetName = correctedSpeakers[toSpeakerId]?.displayName || 'Speaker';
+
     try {
-      const reassignSegmentsFunction = httpsCallable(functions, 'reassignSegments');
-      await reassignSegmentsFunction({
+      const reassignSegmentsFunction = httpsCallable<
+        { conversationId: string; segmentIds: string[]; toSpeakerId: string },
+        { success: boolean; correctionId: string }
+      >(functions, 'reassignSegments');
+
+      const result = await reassignSegmentsFunction({
         conversationId,
         segmentIds,
         toSpeakerId
       });
 
-      // Success - the onSnapshot listener will update our state automatically
+      // Add to undo stack and create toast
+      pushToUndoStack(result.data.correctionId);
+      setPendingToast({
+        correctionId: result.data.correctionId,
+        message: getCorrectionMessage('reassign', { segmentCount: segmentIds.length, targetName }),
+        type: 'reassign'
+      });
+
+      // Set visual feedback for reassign (cleared after 1.5s)
+      setRecentReassignSegmentIds(segmentIds);
+      setTimeout(() => setRecentReassignSegmentIds([]), 1500);
+
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to reassign segments';
+      setError(errorMessage);
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [conversationId, isLoading, correctedSpeakers, pushToUndoStack, getCorrectionMessage]);
+
+  /**
+   * Rename a speaker by calling Cloud Function.
+   */
+  const renameSpeaker = useCallback(async (speakerId: string, newDisplayName: string) => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const renameSpeakerFunction = httpsCallable<
+        { conversationId: string; speakerId: string; newDisplayName: string },
+        { success: boolean; correctionId: string }
+      >(functions, 'renameSpeaker');
+
+      const result = await renameSpeakerFunction({
+        conversationId,
+        speakerId,
+        newDisplayName
+      });
+
+      // Add to undo stack and create toast
+      pushToUndoStack(result.data.correctionId);
+      setPendingToast({
+        correctionId: result.data.correctionId,
+        message: getCorrectionMessage('rename', { newName: newDisplayName }),
+        type: 'rename'
+      });
+
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to rename speaker';
+      setError(errorMessage);
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [conversationId, isLoading, pushToUndoStack, getCorrectionMessage]);
+
+  /**
+   * Undo the most recent correction from the in-memory undo stack by calling Cloud Function.
+   * This sets undoneAt instead of deleting, preserving audit trail.
+   */
+  const undoLastCorrection = useCallback(async () => {
+    if (undoStackRef.current.length === 0 || isLoading) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // Get the most recent correction ID from the in-memory undo stack
+      const correctionIdToUndo = undoStackRef.current[0];
+
+      const undoCorrectionFunction = httpsCallable<
+        { conversationId: string; correctionId: string },
+        { success: boolean }
+      >(functions, 'undoCorrection');
+
+      await undoCorrectionFunction({
+        conversationId,
+        correctionId: correctionIdToUndo
+      });
+
+      // Remove from undo stack
+      undoStackRef.current = undoStackRef.current.filter(
+        id => id !== correctionIdToUndo
+      );
+
+      // Success - the onSnapshot listener will update our state automatically
+
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to undo correction';
       setError(errorMessage);
       throw err;
     } finally {
@@ -264,15 +441,28 @@ export function useSpeakerCorrections({
     setError(null);
   }, []);
 
+  /**
+   * Clear pending toast
+   */
+  const clearPendingToast = useCallback(() => {
+    setPendingToast(null);
+  }, []);
+
   return {
     correctedSpeakers,
     correctedSegments,
     canUndo,
+    undoStackSize,
     mergeSpeakers,
     reassignSegments,
-    undoLastMerge,
+    renameSpeaker,
+    undoLastCorrection,
     isLoading,
     error,
-    clearError
+    clearError,
+    pendingToast,
+    clearPendingToast,
+    recentMerge,
+    recentReassignSegmentIds
   };
 }

--- a/src/pages/Viewer.tsx
+++ b/src/pages/Viewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { Person } from '@/config/types';
 import { useConversations } from '../contexts/ConversationContext';
 import { useAudioPlayer } from '../hooks/useAudioPlayer';
@@ -17,6 +17,7 @@ import { RenameSpeakerModal } from '../components/viewer/RenameSpeakerModal';
 import { SpeakerMergeModal } from '../components/viewer/SpeakerMergeModal';
 import { EditTitleModal } from '../components/viewer/EditTitleModal';
 import { KeyboardShortcutsModal } from '../components/viewer/KeyboardShortcutsModal';
+import { ToastContainer, useToasts } from '../components/shared/Toast';
 import { exportTranscript } from '../utils/exportTranscript';
 import { HelpCircle, X, PanelRight, AlertTriangle } from 'lucide-react';
 
@@ -187,22 +188,60 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
     messages: chatMessages
   });
 
-  // Speaker corrections (manual merge and reassignment)
+  // Toast notifications for speaker corrections
+  const { toasts, addToast, dismissToast } = useToasts();
+
+  // Speaker corrections (manual merge, reassign, and rename)
   const {
     correctedSpeakers,
     correctedSegments,
-    canUndo: canUndoMerge,
+    canUndo,
+    undoStackSize,
     mergeSpeakers,
     reassignSegments,
-    undoLastMerge,
-    isLoading: _mergeIsLoading,
-    error: _mergeError,
-    clearError: _mergeClearError
+    renameSpeaker,
+    undoLastCorrection,
+    isLoading: correctionsLoading,
+    error: _correctionsError,
+    clearError: _clearCorrectionsError,
+    pendingToast,
+    clearPendingToast,
+    recentMerge,
+    recentReassignSegmentIds
   } = useSpeakerCorrections({
     conversationId: conversation.conversationId,
     originalSpeakers: conversation.speakers,
     originalSegments: conversation.segments
   });
+
+  // Compute segment counts per speaker from corrected segments
+  const speakerSegmentCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const segment of correctedSegments) {
+      counts[segment.speakerId] = (counts[segment.speakerId] || 0) + 1;
+    }
+    return counts;
+  }, [correctedSegments]);
+
+  // Display toast when a correction is made
+  useEffect(() => {
+    if (pendingToast) {
+      addToast({
+        message: pendingToast.message,
+        type: 'info',
+        duration: 10000,
+        action: {
+          label: 'Undo',
+          onClick: () => {
+            undoLastCorrection().catch(err => {
+              console.error('[Viewer] Undo failed:', err);
+            });
+          }
+        }
+      });
+      clearPendingToast();
+    }
+  }, [pendingToast, addToast, clearPendingToast, undoLastCorrection]);
 
   /**
    * Handle speaker rename
@@ -245,24 +284,16 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
     }
   }, [reassignSegments, conversation.speakers]);
 
-  const saveSpeakerName = useCallback((newName: string) => {
+  const saveSpeakerName = useCallback(async (newName: string) => {
     if (editingSpeakerId && newName.trim()) {
-      const updatedConversation = {
-        ...conversation,
-        speakers: {
-          ...conversation.speakers,
-          [editingSpeakerId]: {
-            ...conversation.speakers[editingSpeakerId],
-            displayName: newName.trim()
-          }
-        }
-      };
-
-      setConversation(updatedConversation);
-      updateConversation(updatedConversation);
+      try {
+        await renameSpeaker(editingSpeakerId, newName.trim());
+      } catch (err) {
+        console.error('[Viewer] Rename via modal failed:', err);
+      }
     }
     setEditingSpeakerId(null);
-  }, [editingSpeakerId, conversation, updateConversation]);
+  }, [editingSpeakerId, renameSpeaker]);
 
   /**
    * Handle title edit - update local state and persist to Firestore
@@ -353,16 +384,33 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
   }, [mergingSpeakerId, mergeSpeakers]);
 
   /**
-   * Handle undo merge
+   * Handle undo (for any correction type)
    */
-  const handleUndoMerge = useCallback(async () => {
+  const handleUndo = useCallback(async () => {
     try {
-      await undoLastMerge();
+      await undoLastCorrection();
     } catch (err) {
-      // Error is handled by the hook and exposed via mergeError
-      console.error('[Viewer] Undo merge failed:', err);
+      // Error is handled by the hook and exposed via correctionsError
+      console.error('[Viewer] Undo correction failed:', err);
     }
-  }, [undoLastMerge]);
+  }, [undoLastCorrection]);
+
+  /**
+   * Handle speaker rename via correction (inline edit in sidebar)
+   * Uses the apply-on-read correction pattern via Cloud Function
+   */
+  const handleRenameSpeakerCorrection = useCallback(async (speakerId: string, newName: string) => {
+    try {
+      await renameSpeaker(speakerId, newName);
+      console.log('[Viewer] Renamed speaker via correction:', {
+        speakerId,
+        newName
+      });
+    } catch (err) {
+      console.error('[Viewer] Rename failed:', err);
+      throw err; // Re-throw so SpeakerCard can show validation error
+    }
+  }, [renameSpeaker]);
 
   return (
     <div className="flex flex-col h-screen-safe bg-slate-50">
@@ -449,6 +497,7 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
           selectedPersonId={selectedPersonId}
           personOccurrences={personOccurrences}
           highlightedSegmentId={highlightedSegmentId}
+          recentReassignSegmentIds={recentReassignSegmentIds}
           onSeek={seek}
           onTermClick={handleTermClickInTranscript}
           onRenameSpeaker={handleRenameSpeaker}
@@ -493,9 +542,14 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
             chatCumulativeCostUsd={chatCumulativeCostUsd}
             chatCostWarningLevel={chatCostWarningLevel}
             // Speaker corrections
-            canUndoMerge={canUndoMerge}
-            onUndoMerge={handleUndoMerge}
+            canUndo={canUndo}
+            undoStackSize={undoStackSize}
+            onUndo={handleUndo}
             onMergeSpeaker={handleMergeSpeaker}
+            onRenameSpeaker={handleRenameSpeakerCorrection}
+            isCorrectionsLoading={correctionsLoading}
+            recentMerge={recentMerge}
+            speakerSegmentCounts={speakerSegmentCounts}
           />
         </div>
 
@@ -571,9 +625,14 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
                 chatCumulativeCostUsd={chatCumulativeCostUsd}
                 chatCostWarningLevel={chatCostWarningLevel}
                 // Speaker corrections
-                canUndoMerge={canUndoMerge}
-                onUndoMerge={handleUndoMerge}
+                canUndo={canUndo}
+                undoStackSize={undoStackSize}
+                onUndo={handleUndo}
                 onMergeSpeaker={handleMergeSpeaker}
+                onRenameSpeaker={handleRenameSpeakerCorrection}
+                isCorrectionsLoading={correctionsLoading}
+                recentMerge={recentMerge}
+                speakerSegmentCounts={speakerSegmentCounts}
                 defaultTab="context"
               />
             </div>
@@ -648,6 +707,9 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
         isOpen={helpModalOpen}
         onClose={closeHelpModal}
       />
+
+      {/* Toast Notifications */}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </div>
   );
 };


### PR DESCRIPTION
## Release v2.7.0

### ✨ Manual Speaker Correction

This release adds comprehensive manual speaker correction capabilities, allowing users to fix diarization mistakes without re-processing their audio.

### Added
- **Manual Speaker Merge** - Correct diarization errors by merging speakers in the sidebar
  - New "Speakers" tab in Viewer sidebar shows all speakers with merge controls
  - 3-click workflow: Click "Merge" on source speaker → Select target → Confirm
  - Corrections persist via Firestore subcollection using apply-on-read pattern
  - Original transcript data remains immutable (corrections applied at render time)

- **Segment Speaker Reassignment** - Reassign individual or multiple segments to different speakers
  - Right-click (or long-press on mobile) any segment to reassign via context menu
  - Shift+Click to select multiple segments, then use floating action bar to bulk reassign
  - Speakers with zero remaining segments are automatically hidden from the speaker list

- **Inline Speaker Renaming** - Double-click any speaker name to edit directly in place
  - Enter to save, Escape to cancel, with validation (non-empty, <50 chars)
  - Renames stored as correction records using apply-on-read pattern

- **Multi-Step Undo Stack** - Undo merge, reassign, and rename corrections with a ~20 action in-memory stack
  - Toast-based undo appears after each correction with 10-second undo window
  - "Undo Last Change" button available in edit mode
  - Correction history preserved for audit (undo marks records inactive, doesn't delete)

- **Visual Feedback for Speaker Edits** - Merge fade/shrink animation, segment count animation on target, reassignment highlight

### Upgrade Notes

Requires Firebase deployment for Cloud Functions (`mergeSpeakers`, `reassignSegments`, `renameSpeaker`, `undoCorrection`).

---
Scope: `speaker_reconciliation_manual_speaker_merge_08_03`
Tag: `v2.7.0`
Build: `24`