### PR TITLE
feat(infra): migrate WhisperX from Replicate to Cloud Run GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Cloud Run GPU Migration** - WhisperX transcription now runs on self-hosted Cloud Run with NVIDIA L4 GPU instead of Replicate
+  - Replaced Replicate SDK polling with direct HTTP calls to Cloud Run `/predict` endpoint
+  - OIDC-based IAM authentication replaces API token auth
+  - 180-second client-side timeout via `AbortController` with no-retry-on-timeout policy
+  - Cost tracking captures `X-Predict-Time` and request ID from Cloud Run response headers
+  - Circuit breaker and metrics renamed from `replicate` to `cloud-run-whisper`
+  - Removed `replicate` npm dependency (~108 net lines removed)
+
 ## [2.7.1] - 2026-01-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Transform audio recordings into interactive, navigable transcripts with AI-power
                 ▼                        ▼
         ┌──────────────┐         ┌──────────────────────────┐
         │  Gemini API  │         │   Alignment Service      │
-        │  (Google AI) │         │   WhisperX via Replicate │
-        └──────────────┘         │   pyannote diarization   │
+        │  (Google AI) │         │   WhisperX via Cloud Run │
+        └──────────────┘         │   GPU (pyannote built-in)│
                                  └──────────────────────────┘
 ```
 
@@ -65,7 +65,7 @@ Transform audio recordings into interactive, navigable transcripts with AI-power
 - Firebase project ([Firebase Setup Guide](docs/how-to/firebase-setup.md))
 - API Keys:
   - [Gemini API Key](https://makersuite.google.com/app/apikey)
-  - [Replicate API Token](https://replicate.com/account/api-tokens) (for WhisperX alignment)
+  - Cloud Run Whisper Service URL (deployed from scope 05-02-01)
 
 ### Installation
 
@@ -93,8 +93,7 @@ npx firebase use your-project-id
 
 # Set API keys as Firebase secrets
 npx firebase functions:secrets:set GEMINI_API_KEY
-npx firebase functions:secrets:set REPLICATE_API_TOKEN
-npx firebase functions:secrets:set ALIGNMENT_SERVICE_URL
+npx firebase functions:secrets:set WHISPER_SERVICE_URL
 ```
 
 ### Deploy Backend
@@ -133,8 +132,7 @@ Firebase secrets (stored via Firebase Secret Manager):
 | Secret | Description |
 |--------|-------------|
 | `GEMINI_API_KEY` | Google AI Studio API key |
-| `REPLICATE_API_TOKEN` | Replicate API token for WhisperX |
-| `ALIGNMENT_SERVICE_URL` | WhisperX alignment service URL |
+| `WHISPER_SERVICE_URL` | Cloud Run WhisperX service URL (deployed separately) |
 
 ## Usage
 
@@ -189,7 +187,7 @@ audio-transcript-analysis-app/
 │   └── src/
 │       ├── index.ts       # Function exports
 │       ├── transcribe.ts  # WhisperX + Gemini analysis + speaker corrections
-│       ├── alignment.ts   # WhisperX integration via Replicate
+│       ├── alignment.ts   # WhisperX integration via Cloud Run
 │       ├── metrics.ts     # Processing metrics recording
 │       └── logger.ts      # Structured logging utility
 ├── docs/                  # Documentation (Diátaxis structure)
@@ -204,7 +202,7 @@ audio-transcript-analysis-app/
 
 The app uses a "WhisperX-first" architecture for precise timestamps:
 
-1. **WhisperX Transcription** - Word-level forced alignment via Replicate + pyannote speaker diarization (~$0.02/10min)
+1. **WhisperX Transcription** - Word-level forced alignment via Cloud Run GPU + pyannote speaker diarization
 2. **Gemini Analysis** - Analyzes WhisperX transcript for topics, terms, people, and speaker corrections
 3. **Client Drift Correction** - For legacy data without server alignment, applies linear timestamp scaling
 
@@ -231,8 +229,8 @@ See [docs/how-to/deploy.md](docs/how-to/deploy.md) for full deployment guide.
 - **Frontend**: React 18, TypeScript, Vite, Tailwind CSS
 - **Backend**: Firebase (Firestore, Storage, Cloud Functions, Auth)
 - **AI**: Google Gemini 2.5 Flash
-- **Alignment**: WhisperX via Replicate, pyannote for diarization
-- **Deployment**: Cloud Run (frontend), Firebase Functions (backend)
+- **Alignment**: WhisperX via Cloud Run GPU with NVIDIA L4, pyannote diarization built-in
+- **Deployment**: Cloud Run (frontend + WhisperX), Firebase Functions (backend)
 - **CI/CD**: GitHub Actions
 
 ## Documentation

--- a/docs/how-to/firebase-setup.md
+++ b/docs/how-to/firebase-setup.md
@@ -275,8 +275,7 @@ Secrets are **automatically set during deployment** from GitHub Secrets. Add the
 | GitHub Secret | Description | Get it from |
 |---------------|-------------|-------------|
 | `GEMINI_API_KEY` | Transcription analysis | [GCP Credentials](https://console.cloud.google.com/apis/credentials) (same project) |
-| `REPLICATE_API_TOKEN` | WhisperX transcription | [Replicate Account](https://replicate.com/account/api-tokens) |
-| `HUGGINGFACE_ACCESS_TOKEN` | Speaker diarization | [Hugging Face Settings](https://huggingface.co/settings/tokens) |
+| `WHISPER_SERVICE_URL` | WhisperX transcription | Cloud Run service URL (deployed from scope 05-02-01) |
 
 The deploy workflows automatically sync these to Firebase Secrets before deploying functions.
 
@@ -315,8 +314,7 @@ npx firebase use your-project-id
 
 # Set secrets (you'll be prompted for each value)
 npx firebase functions:secrets:set GEMINI_API_KEY
-npx firebase functions:secrets:set REPLICATE_API_TOKEN
-npx firebase functions:secrets:set HUGGINGFACE_ACCESS_TOKEN
+npx firebase functions:secrets:set WHISPER_SERVICE_URL
 ```
 
 ### Hugging Face Setup for Speaker Diarization
@@ -343,8 +341,7 @@ Speaker diarization (detecting multiple speakers) requires a Hugging Face token 
 **Verify secrets are configured:**
 ```bash
 npx firebase functions:secrets:access GEMINI_API_KEY
-npx firebase functions:secrets:access REPLICATE_API_TOKEN
-npx firebase functions:secrets:access HUGGINGFACE_ACCESS_TOKEN
+npx firebase functions:secrets:access WHISPER_SERVICE_URL
 ```
 
 ## Step 9: Deploy Security Rules
@@ -521,8 +518,7 @@ In your repository: **Settings** → **Secrets and variables** → **Actions**
 |--------|-------|
 | `FIREBASE_SERVICE_ACCOUNT` | Contents of the service account JSON file |
 | `GEMINI_API_KEY` | Gemini API key from [Google AI Studio](https://makersuite.google.com/app/apikey) |
-| `REPLICATE_API_TOKEN` | Replicate API token from [Replicate Account](https://replicate.com/account/api-tokens) |
-| `HUGGINGFACE_ACCESS_TOKEN` | Hugging Face token from [HF Settings](https://huggingface.co/settings/tokens) |
+| `WHISPER_SERVICE_URL` | Cloud Run WhisperX service URL (deployed from scope 05-02-01) |
 
 > **Note**: The API secrets are automatically synced to Firebase Secrets during deployment. You don't need to set them manually via `firebase functions:secrets:set`.
 

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -264,8 +264,8 @@ interface TranscriptionMetricsDoc {
       model: string;
     };
     whisperx: {
-      predictionId?: string;  // Replicate prediction ID for cost traceability
-      computeTimeSeconds: number;  // Actual GPU compute time from Replicate metrics.predict_time (not wall-clock)
+      predictionId?: string;  // Cloud Run request ID for cost traceability
+      computeTimeSeconds: number;  // Actual GPU compute time from X-Predict-Time header (not wall-clock)
       model: string;  // 'whisperx-diarization' - includes speaker diarization
     };
     // Note: diarization field removed in v2.2.0 - now bundled with whisperx
@@ -517,13 +517,13 @@ LLM pricing configuration for cost estimation.
 ```typescript
 interface PricingDoc {
   model: string;  // 'gemini-2.5-flash', 'gemini-2.5-flash-text', 'whisperx'
-  service: 'gemini' | 'replicate';
+  service: 'gemini' | 'cloud-run';
 
   // Token-based pricing (for Gemini)
   inputPricePerMillion?: number;   // USD per 1M input tokens
   outputPricePerMillion?: number;  // USD per 1M output tokens
 
-  // Time-based pricing (for Replicate/WhisperX)
+  // Time-based pricing (for Cloud Run WhisperX)
   pricePerSecond?: number;         // USD per compute second
 
   // Validity period

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -14,8 +14,8 @@
         "firebase-admin": "^12.7.0",
         "firebase-functions": "^7.0.2",
         "fuzzball": "^2.0.0",
+        "google-auth-library": "^9.15.1",
         "jsonrepair": "^3.11.2",
-        "replicate": "^0.29.0",
         "undici": "^6.21.0"
       },
       "devDependencies": {
@@ -2780,31 +2780,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -3427,16 +3402,6 @@
       "optional": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.8.x"
       }
     },
     "node_modules/execa": {
@@ -4487,27 +4452,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",
@@ -6284,16 +6228,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/proto3-json-serializer": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
@@ -6418,38 +6352,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/replicate": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/replicate/-/replicate-0.29.4.tgz",
-      "integrity": "sha512-BizXBehB2Rjil3o2R9Vy9fd0k3w7aIoXtc/+vdOmitC2viW3pSMt0GwC4h+OmMpx9zot90C43wrssyMJ3rMScQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "git": ">=2.11.0",
-        "node": ">=18.0.0",
-        "npm": ">=7.19.0",
-        "yarn": ">=1.7.0"
-      },
-      "optionalDependencies": {
-        "readable-stream": ">=4.0.0"
-      }
-    },
-    "node_modules/replicate/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/require-directory": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -28,7 +28,6 @@
     "firebase-functions": "^7.0.2",
     "fuzzball": "^2.0.0",
     "jsonrepair": "^3.11.2",
-    "replicate": "^0.29.0",
     "undici": "^6.21.0"
   },
   "devDependencies": {

--- a/functions/src/alignment.ts
+++ b/functions/src/alignment.ts
@@ -12,13 +12,8 @@
  *    Level 4: Validation & Fallback (quality gates, graceful degradation)
  */
 
-import Replicate from 'replicate';
+import { GoogleAuth } from 'google-auth-library';
 import fuzz from 'fuzzball';
-
-// Whisper diarization model on Replicate - provides word/sentence-level timestamps + speaker diarization
-// Using forked model with speaker embeddings for cross-chunk reconciliation
-// Original: thomasmol/whisper-diarization, Fork adds: 256-dim speaker embeddings per speaker
-const WHISPERX_MODEL = 'sammywachtel/whisper-diarization-embeddings-01:cc41ceb74b866a2e649862a7e2187724b38f6fb2581a80d0f9bcbc6ebcb49eb3';
 
 // =============================================================================
 // Configuration
@@ -46,28 +41,28 @@ const MAX_OVERLAP_MS = 2000;  // Max overlap between consecutive segments (raise
 const MIN_MS_PER_WORD = 20;  // Minimum milliseconds per word (lowered from 30)
 const MAX_MS_PER_WORD = 800;  // Maximum milliseconds per word (raised from 600)
 
-// Replicate API timeout (3 minutes) - large audio uploads need time
-const REPLICATE_TIMEOUT_MS = 180_000;
+// Cloud Run request timeout (3 minutes) - aligned with Cloud Run server hard kill
+const CLOUD_RUN_TIMEOUT_MS = 180_000;
+
+// Lazy-initialized Google Auth client for Cloud Run IAM auth
+let _authClient: GoogleAuth | null = null;
+function getAuthClient(): GoogleAuth {
+  if (!_authClient) {
+    _authClient = new GoogleAuth();
+  }
+  return _authClient;
+}
 
 /**
- * Create a fetch wrapper with timeout support for Replicate client.
- * The Replicate SDK v1.x doesn't have built-in timeout, so we use AbortController.
+ * Fetch an OIDC identity token for service-to-service auth with Cloud Run.
+ * Cloud Functions → Cloud Run uses IAM-based auth: we get an ID token
+ * scoped to the target audience (the Cloud Run service URL).
  */
-function createTimeoutFetch(timeoutMs: number): typeof globalThis.fetch {
-  return async (input: RequestInfo | URL, init?: RequestInit) => {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
-    try {
-      const response = await globalThis.fetch(input, {
-        ...init,
-        signal: controller.signal,
-      });
-      return response;
-    } finally {
-      clearTimeout(timeoutId);
-    }
-  };
+async function getIdToken(targetAudience: string): Promise<string> {
+  const auth = getAuthClient();
+  const client = await auth.getIdTokenClient(targetAudience);
+  const headers = await client.getRequestHeaders();
+  return headers.Authorization?.replace('Bearer ', '') || '';
 }
 
 // =============================================================================
@@ -1286,16 +1281,16 @@ function alignSegmentsHardy(
 
 async function getWhisperxTimestamps(
   audioBase64: string,
-  replicateToken: string
+  serviceUrl: string
 ): Promise<Word[]> {
   /**
-   * Call Replicate's WhisperX model to get word-level timestamps.
+   * Call Cloud Run WhisperX service to get word-level timestamps.
    *
-   * Uses victor-upmeet/whisperx which provides word-level timestamps
+   * Uses self-hosted WhisperX which provides word-level timestamps
    * and speaker diarization.
    */
-  if (!replicateToken) {
-    throw new AlignmentError('REPLICATE_API_TOKEN not provided');
+  if (!serviceUrl) {
+    throw new AlignmentError('WHISPER_SERVICE_URL not provided');
   }
 
   // Decode base64 to get audio bytes
@@ -1303,32 +1298,60 @@ async function getWhisperxTimestamps(
   const audioSizeMb = audioBytes.length / (1024 * 1024);
 
   console.log(
-    `[WhisperX] Calling Replicate API: ` +
+    `[WhisperX] Calling Cloud Run service: ` +
     `audio_size=${audioSizeMb.toFixed(2)}MB, ` +
     `base64_length=${audioBase64.length}`
   );
 
   console.debug(
     `[WhisperX] Request parameters: ` +
-    `model=${WHISPERX_MODEL.substring(0, 50)}..., ` +
+    `service_url=${serviceUrl}, ` +
     `language=en`
   );
 
   try {
-    // Call whisper-diarization-advanced via Replicate
-    const client = new Replicate({ auth: replicateToken, fetch: createTimeoutFetch(REPLICATE_TIMEOUT_MS) });
+    // Call Cloud Run /predict endpoint
+    const idToken = await getIdToken(serviceUrl);
+
+    // Set up AbortController for timeout
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), CLOUD_RUN_TIMEOUT_MS);
 
     const startTime = Date.now();
-    const output = await client.run(
-      WHISPERX_MODEL as `${string}/${string}:${string}`,
-      {
-        input: {
-          file_string: audioBase64,  // Base64 encoded audio (not data URI)
-          language: 'en'
-        }
-      }
-    );
+    const response = await fetch(`${serviceUrl}/predict`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${idToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        file_string: audioBase64,
+        language: 'en'
+      }),
+      signal: controller.signal
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      throw new Error(`Cloud Run request failed: ${response.status} ${response.statusText}`);
+    }
+
+    const output = await response.json();
     const duration = ((Date.now() - startTime) / 1000).toFixed(3);
+
+    // Capture compute time from header
+    const predictTime = response.headers.get('X-Predict-Time');
+    if (predictTime) {
+      console.debug(`[WhisperX] Compute time: ${predictTime}s`);
+    }
+
+    // Capture request ID from headers
+    const requestId = response.headers.get('X-Request-Id') ||
+                     response.headers.get('X-Cloud-Trace-Context') ||
+                     'unknown';
+    console.debug(`[WhisperX] Request ID: ${requestId}`);
+
     console.debug(`[Timer] WhisperX API call: ${duration}s`);
 
     // DIAGNOSTIC: Log raw output structure
@@ -1484,9 +1507,9 @@ export interface WhisperXResult {
   segments: WhisperXSegment[];
   status: 'success' | 'error';
   error?: string;
-  /** Replicate prediction ID for cost traceability */
+  /** Cloud Run request ID for cost traceability */
   predictionId?: string;
-  /** Actual GPU compute time in seconds (from Replicate metrics.predict_time) */
+  /** Actual GPU compute time in seconds (from X-Predict-Time header) */
   actualComputeSeconds?: number;
   /** Speaker embeddings from pyannote/embedding (256-dim vectors per speaker) */
   speakerEmbeddings?: {
@@ -1501,9 +1524,7 @@ export interface WhisperXResult {
  * the transcript text AND accurate timestamps in one call.
  *
  * @param audioBuffer - The audio file as a Buffer
- * @param replicateToken - Replicate API token
- * @param huggingfaceToken - Optional Hugging Face token for speaker diarization
- *                           (pyannote.audio is a gated model that requires HF auth)
+ * @param serviceUrl - Cloud Run Whisper service URL
  */
 /**
  * Optional hints to improve WhisperX diarization accuracy.
@@ -1516,17 +1537,16 @@ export interface WhisperXDiarizationHints {
 
 export async function transcribeWithWhisperX(
   audioBuffer: Buffer,
-  replicateToken: string,
-  huggingfaceToken?: string,
+  serviceUrl: string,
   hints?: WhisperXDiarizationHints
 ): Promise<WhisperXResult> {
   console.log('[WhisperX] Starting transcription (primary method)', hints ? { hints } : {});
 
-  if (!replicateToken) {
+  if (!serviceUrl) {
     return {
       segments: [],
       status: 'error',
-      error: 'REPLICATE_API_TOKEN not provided'
+      error: 'WHISPER_SERVICE_URL not provided'
     };
   }
 
@@ -1536,87 +1556,72 @@ export async function transcribeWithWhisperX(
     const audioSizeMb = audioBuffer.length / (1024 * 1024);
 
     console.log(
-      `[WhisperX] Calling Replicate API: ` +
+      `[WhisperX] Calling Cloud Run service: ` +
       `audio_size=${audioSizeMb.toFixed(2)}MB`
     );
 
-    // Call whisper-diarization-advanced via Replicate
-    const Replicate = (await import('replicate')).default;
-    const client = new Replicate({ auth: replicateToken, fetch: createTimeoutFetch(REPLICATE_TIMEOUT_MS) });
+    // Get OIDC token for IAM auth
+    const idToken = await getIdToken(serviceUrl);
 
-    // Build input params - rafaelgalle/whisper-diarization-advanced has built-in diarization
-    const inputParams: Record<string, unknown> = {
-      file_string: audioBase64,  // Base64 encoded audio (not data URI)
-      language: 'en'
+    // Build request body
+    const requestBody: Record<string, unknown> = {
+      file_string: audioBase64,
+      language: 'en',
+      group_segments_gap: 0.3
     };
 
     // Add diarization hints if provided (from Gemini pre-analysis)
     if (hints?.numSpeakers && hints.numSpeakers > 0) {
-      inputParams.num_speakers = hints.numSpeakers;
+      requestBody.num_speakers = hints.numSpeakers;
       console.log(`[WhisperX] Using num_speakers hint: ${hints.numSpeakers}`);
     }
     if (hints?.speakerNames && hints.speakerNames.length > 0) {
       // The prompt parameter accepts speaker names/acronyms separated by punctuation
-      inputParams.prompt = hints.speakerNames.join(', ');
+      requestBody.prompt = hints.speakerNames.join(', ');
       console.log(`[WhisperX] Using speaker names hint: ${hints.speakerNames.join(', ')}`);
     }
 
-    // Note: huggingfaceToken is no longer needed - diarization is built-in
-    if (huggingfaceToken) {
-      console.log('[WhisperX] Note: HF token provided but not needed - diarization is built-in');
-    }
     console.log('[WhisperX] Speaker diarization enabled (built-in)', {
-      numSpeakers: inputParams.num_speakers || 'auto-detect',
-      prompt: inputParams.prompt || 'none'
+      numSpeakers: requestBody.num_speakers || 'auto-detect',
+      prompt: requestBody.prompt || 'none'
     });
+
+    // Set up AbortController for timeout
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), CLOUD_RUN_TIMEOUT_MS);
 
     const startTime = Date.now();
 
-    // Use predictions API instead of run() to get predictionId for cost tracking
-    const prediction = await client.predictions.create({
-      model: WHISPERX_MODEL.split(':')[0] as `${string}/${string}`,
-      version: WHISPERX_MODEL.split(':')[1],
-      input: inputParams
+    // Call Cloud Run /predict endpoint (synchronous, no polling needed)
+    const response = await fetch(`${serviceUrl}/predict`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${idToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(requestBody),
+      signal: controller.signal
     });
 
-    console.log(`[WhisperX] Prediction created: ${prediction.id}`);
+    clearTimeout(timeoutId);
 
-    // Poll for completion
-    const maxWaitMs = 8 * 60 * 1000; // 8 minutes max
-    const pollIntervalMs = 5000; // Poll every 5 seconds
-    let elapsedMs = 0;
-
-    let output: unknown;
-    let actualComputeSeconds: number | undefined;
-    while (elapsedMs < maxWaitMs) {
-      const status = await client.predictions.get(prediction.id);
-
-      if (status.status === 'succeeded') {
-        const duration = ((Date.now() - startTime) / 1000).toFixed(1);
-        // Extract actual GPU compute time from Replicate metrics
-        actualComputeSeconds = (status as any).metrics?.predict_time;
-        console.log(`[WhisperX] Prediction succeeded in ${duration}s wall-clock (${actualComputeSeconds || 'unknown'}s compute, id: ${prediction.id})`);
-        output = status.output;
-        break;
-      } else if (status.status === 'failed' || status.status === 'canceled') {
-        throw new Error(`Prediction ${status.status}: ${status.error || 'Unknown error'}`);
-      }
-
-      // Still processing, wait and poll again
-      await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
-      elapsedMs += pollIntervalMs;
-
-      if (elapsedMs % 30000 === 0) { // Log every 30 seconds
-        console.log(`[WhisperX] Still waiting... (${elapsedMs / 1000}s elapsed)`);
-      }
+    if (!response.ok) {
+      throw new Error(`Cloud Run request failed: ${response.status} ${response.statusText}`);
     }
 
-    if (!output) {
-      throw new Error(`Prediction timed out after ${maxWaitMs / 1000}s`);
-    }
-
+    const output = await response.json();
     const duration = ((Date.now() - startTime) / 1000).toFixed(1);
-    console.log(`[WhisperX] API call completed in ${duration}s`);
+
+    // Extract compute time from header
+    const predictTimeStr = response.headers.get('X-Predict-Time');
+    const actualComputeSeconds = predictTimeStr ? parseFloat(predictTimeStr) : undefined;
+
+    // Extract request ID from headers
+    const requestId = response.headers.get('X-Request-Id') ||
+                     response.headers.get('X-Cloud-Trace-Context') ||
+                     crypto.randomUUID();
+
+    console.log(`[WhisperX] Request completed in ${duration}s wall-clock (${actualComputeSeconds || 'unknown'}s compute, id: ${requestId})`);
 
     // Parse the output to extract segments and speaker embeddings
     const segments: WhisperXSegment[] = [];
@@ -1734,7 +1739,7 @@ export async function transcribeWithWhisperX(
     return {
       segments,
       status: 'success',
-      predictionId: prediction.id,
+      predictionId: requestId,
       actualComputeSeconds,
       speakerEmbeddings
     };
@@ -1768,23 +1773,22 @@ export async function transcribeWithWhisperX(
 }
 
 /**
- * Alternative WhisperX transcription using predictions API with manual polling.
- * More robust for large responses - handles streaming and retries.
+ * Alternative WhisperX transcription with retry logic for transient failures.
+ * More robust for large responses - handles retries but NOT timeout errors.
  */
 export async function transcribeWithWhisperXRobust(
   audioBuffer: Buffer,
-  replicateToken: string,
-  huggingfaceToken?: string,
+  serviceUrl: string,
   maxRetries: number = 2,
   hints?: WhisperXDiarizationHints
 ): Promise<WhisperXResult> {
   console.log('[WhisperX-Robust] Starting transcription with enhanced error handling', hints ? { hints } : {});
 
-  if (!replicateToken) {
+  if (!serviceUrl) {
     return {
       segments: [],
       status: 'error',
-      error: 'REPLICATE_API_TOKEN not provided'
+      error: 'WHISPER_SERVICE_URL not provided'
     };
   }
 
@@ -1800,87 +1804,92 @@ export async function transcribeWithWhisperXRobust(
         `audio_size=${audioSizeMb.toFixed(2)}MB`
       );
 
-      // Use predictions API for more control
-      const Replicate = (await import('replicate')).default;
-      const client = new Replicate({ auth: replicateToken, fetch: createTimeoutFetch(REPLICATE_TIMEOUT_MS) });
+      // Get OIDC token for IAM auth
+      const idToken = await getIdToken(serviceUrl);
 
-      const inputParams: Record<string, unknown> = {
+      const requestBody: Record<string, unknown> = {
         file_string: audioBase64,
-        language: 'en'
+        language: 'en',
+        group_segments_gap: 0.3
       };
 
       // Add diarization hints if provided (from Gemini pre-analysis)
       if (hints?.numSpeakers && hints.numSpeakers > 0) {
-        inputParams.num_speakers = hints.numSpeakers;
+        requestBody.num_speakers = hints.numSpeakers;
         console.log(`[WhisperX-Robust] Using num_speakers hint: ${hints.numSpeakers}`);
       }
       if (hints?.speakerNames && hints.speakerNames.length > 0) {
-        inputParams.prompt = hints.speakerNames.join(', ');
+        requestBody.prompt = hints.speakerNames.join(', ');
         console.log(`[WhisperX-Robust] Using speaker names hint: ${hints.speakerNames.join(', ')}`);
       }
 
+      // Set up AbortController for timeout
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), CLOUD_RUN_TIMEOUT_MS);
+
       const startTime = Date.now();
 
-      // Create prediction (doesn't wait for completion)
-      const prediction = await client.predictions.create({
-        model: WHISPERX_MODEL.split(':')[0] as `${string}/${string}`,
-        version: WHISPERX_MODEL.split(':')[1],
-        input: inputParams
+      // Call Cloud Run /predict endpoint (synchronous)
+      const response = await fetch(`${serviceUrl}/predict`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${idToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(requestBody),
+        signal: controller.signal
       });
 
-      console.log(`[WhisperX-Robust] Prediction created: ${prediction.id}`);
+      clearTimeout(timeoutId);
 
-      // Poll for completion with timeout
-      const maxWaitMs = 8 * 60 * 1000; // 8 minutes max
-      const pollIntervalMs = 5000; // Poll every 5 seconds
-      let elapsedMs = 0;
-
-      while (elapsedMs < maxWaitMs) {
-        const status = await client.predictions.get(prediction.id);
-
-        if (status.status === 'succeeded') {
-          const duration = ((Date.now() - startTime) / 1000).toFixed(1);
-          // Extract actual GPU compute time from Replicate metrics
-          const actualComputeSeconds = (status as any).metrics?.predict_time;
-          console.log(`[WhisperX-Robust] Prediction succeeded in ${duration}s wall-clock (${actualComputeSeconds || 'unknown'}s compute, id: ${prediction.id})`);
-
-          // Parse output
-          const { segments, speakerEmbeddings } = parseWhisperXOutput(status.output);
-
-          if (segments.length === 0) {
-            throw new Error('WhisperX returned no segments');
-          }
-
-          // Return with prediction ID, actual compute time, and embeddings
-          return { segments, status: 'success', predictionId: prediction.id, actualComputeSeconds, speakerEmbeddings };
-
-        } else if (status.status === 'failed' || status.status === 'canceled') {
-          throw new Error(`Prediction ${status.status}: ${status.error || 'Unknown error'}`);
-        }
-
-        // Still processing, wait and poll again
-        await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
-        elapsedMs += pollIntervalMs;
-
-        if (elapsedMs % 30000 === 0) { // Log every 30 seconds
-          console.log(`[WhisperX-Robust] Still waiting... (${elapsedMs / 1000}s elapsed)`);
-        }
+      if (!response.ok) {
+        throw new Error(`Cloud Run request failed: ${response.status} ${response.statusText}`);
       }
 
-      throw new Error(`Prediction timed out after ${maxWaitMs / 1000}s`);
+      const output = await response.json();
+      const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+
+      // Extract compute time from header
+      const predictTimeStr = response.headers.get('X-Predict-Time');
+      const actualComputeSeconds = predictTimeStr ? parseFloat(predictTimeStr) : undefined;
+
+      // Extract request ID from headers
+      const requestId = response.headers.get('X-Request-Id') ||
+                       response.headers.get('X-Cloud-Trace-Context') ||
+                       crypto.randomUUID();
+
+      console.log(`[WhisperX-Robust] Request succeeded in ${duration}s wall-clock (${actualComputeSeconds || 'unknown'}s compute, id: ${requestId})`);
+
+      // Parse output
+      const { segments, speakerEmbeddings } = parseWhisperXOutput(output);
+
+      if (segments.length === 0) {
+        throw new Error('WhisperX returned no segments');
+      }
+
+      // Return with request ID, actual compute time, and embeddings
+      return { segments, status: 'success', predictionId: requestId, actualComputeSeconds, speakerEmbeddings };
 
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorName = error instanceof Error ? error.name : '';
       lastError = errorMsg;
 
-      // Check if error is retryable - includes gateway errors for large payloads
-      const isRetryable = errorMsg.includes('JSON') ||
-                          errorMsg.includes('timeout') ||
-                          errorMsg.includes('ETIMEDOUT') ||
-                          errorMsg.includes('ECONNRESET') ||
-                          errorMsg.includes('502') ||
+      // CRITICAL: Do NOT retry timeout errors (AbortError)
+      const isTimeoutError = errorName === 'AbortError' ||
+                            errorMsg.includes('aborted') ||
+                            errorMsg.includes('timeout');
+
+      if (isTimeoutError) {
+        console.error(`[WhisperX-Robust] Timeout error - not retrying: ${errorMsg}`);
+        break;
+      }
+
+      // Check if error is retryable - only transient 5xx/network errors
+      const isRetryable = errorMsg.includes('502') ||
                           errorMsg.includes('503') ||
                           errorMsg.includes('504') ||
+                          errorMsg.includes('ECONNRESET') ||
                           errorMsg.includes('Bad Gateway') ||
                           errorMsg.includes('Service Unavailable') ||
                           errorMsg.includes('Gateway Timeout');
@@ -2008,7 +2017,7 @@ function parseWhisperXOutput(output: unknown): {
 export async function alignTimestamps(
   audioBuffer: Buffer,
   segments: { speakerId: string; text: string; startMs: number; endMs: number }[],
-  replicateToken: string
+  serviceUrl: string
 ): Promise<AlignmentResult> {
   /**
    * DEPRECATED: This function implements the OLD Gemini-first approach.
@@ -2052,7 +2061,7 @@ export async function alignTimestamps(
     // Get word-level timestamps from WhisperX
     const startTimeWhisper = Date.now();
     const audioBase64 = audioBuffer.toString('base64');
-    const words = await getWhisperxTimestamps(audioBase64, replicateToken);
+    const words = await getWhisperxTimestamps(audioBase64, serviceUrl);
     const durationWhisper = ((Date.now() - startTimeWhisper) / 1000).toFixed(3);
     console.debug(`[Timer] get_whisperx_timestamps: ${durationWhisper}s`);
 

--- a/functions/src/circuitBreaker.ts
+++ b/functions/src/circuitBreaker.ts
@@ -204,10 +204,10 @@ export class CircuitBreaker {
 }
 
 /**
- * Circuit breaker for Replicate (WhisperX) API
+ * Circuit breaker for Cloud Run WhisperX service
  * Conservative settings - 2 failures triggers open
  */
-export const replicateCircuit = new CircuitBreaker('replicate', {
+export const cloudRunWhisperCircuit = new CircuitBreaker('cloud-run-whisper', {
   failureThreshold: 2,
   resetTimeout: 60000,      // 1 minute
   halfOpenRequests: 1

--- a/functions/src/metrics.ts
+++ b/functions/src/metrics.ts
@@ -32,11 +32,11 @@ export interface GeminiUsage {
 }
 
 /**
- * Replicate API usage metrics (compute-time pricing)
+ * Cloud Run WhisperX API usage metrics (compute-time pricing)
  * The whisper-diarization model handles both transcription AND speaker diarization in one call.
  */
-export interface ReplicateUsage {
-  predictionId?: string;  // Replicate prediction ID for audit trail
+export interface CloudRunWhisperUsage {
+  predictionId?: string;  // Cloud Run request ID for audit trail
   computeTimeSeconds: number;
   model: string;  // e.g., 'whisperx' (includes diarization)
 }
@@ -49,8 +49,8 @@ export interface LLMUsage {
   geminiAnalysis: GeminiUsage;
   // Gemini Speaker Reassignment Call
   geminiSpeakerCorrection: GeminiUsage;
-  // WhisperX via Replicate (transcription + timestamps + speaker diarization)
-  whisperx: ReplicateUsage;
+  // WhisperX via Cloud Run (transcription + timestamps + speaker diarization)
+  whisperx: CloudRunWhisperUsage;
 }
 
 /**
@@ -174,13 +174,13 @@ export interface ProcessingMetrics {
 export interface PricingConfig {
   pricingId: string;
   model: string;              // 'gemini-2.5-flash', 'gemini-2.5-flash-text', 'whisperx'
-  service: 'gemini' | 'replicate';
+  service: 'gemini' | 'cloud-run';
 
   // Token-based pricing (for Gemini)
   inputPricePerMillion?: number;   // USD per 1M input tokens
   outputPricePerMillion?: number;  // USD per 1M output tokens
 
-  // Time-based pricing (for Replicate)
+  // Time-based pricing (for Cloud Run WhisperX)
   pricePerSecond?: number;         // USD per compute second
 
   // Validity period (allows price changes over time)

--- a/functions/src/processTranscription.ts
+++ b/functions/src/processTranscription.ts
@@ -91,8 +91,7 @@ async function enqueueMergeTask(conversationId: string): Promise<void> {
 }
 
 // Define secrets (same as transcribeAudio - needed for heavy processing)
-const replicateApiToken = defineSecret('REPLICATE_API_TOKEN');
-const huggingfaceAccessToken = defineSecret('HUGGINGFACE_ACCESS_TOKEN');
+const whisperServiceUrl = defineSecret('WHISPER_SERVICE_URL');
 
 /**
  * Cloud Tasks payload for transcription job.
@@ -144,7 +143,7 @@ export const processTranscription = onRequest(
     timeoutSeconds: 3600, // 60 minutes (enough for large files)
     region: 'us-central1',
     invoker: 'private', // Only Cloud Tasks can call this
-    secrets: [replicateApiToken, huggingfaceAccessToken]
+    secrets: [whisperServiceUrl]
   },
   async (req, res) => {
     // Validate Cloud Tasks header (security check - prevents direct invocation)
@@ -296,8 +295,7 @@ export const processTranscription = onRequest(
         conversationId,
         userId,
         filePath,
-        replicateApiToken: replicateApiToken.value(),
-        huggingfaceAccessToken: huggingfaceAccessToken.value(),
+        whisperServiceUrl: whisperServiceUrl.value(),
         chunkContext: chunkContext ?? undefined,
         chunkMetadata: isChunk ? {
           chunkIndex,

--- a/functions/src/transcribe.ts
+++ b/functions/src/transcribe.ts
@@ -52,8 +52,7 @@ import {
 import { computeSpeakerQualityMapFromWhisperXSegments } from './speakerQuality';
 
 // Define secrets (set via: firebase functions:secrets:set <SECRET_NAME>)
-const replicateApiToken = defineSecret('REPLICATE_API_TOKEN');
-const huggingfaceAccessToken = defineSecret('HUGGINGFACE_ACCESS_TOKEN');  // For speaker diarization
+const whisperServiceUrl = defineSecret('WHISPER_SERVICE_URL');
 
 // =============================================================================
 // Timeout Configuration
@@ -773,8 +772,7 @@ export interface TranscriptionPipelineParams {
   conversationId: string;
   userId: string;
   filePath: string;
-  replicateApiToken: string;
-  huggingfaceAccessToken: string;
+  whisperServiceUrl: string;
   audioSizeBytes?: number; // Optional - for logging only
   /** Optional chunk context for context-aware chunk processing */
   chunkContext?: ChunkContext;
@@ -809,7 +807,7 @@ export interface TranscriptionPipelineParams {
  * On abort, updates status to 'aborted' and records partial metrics.
  */
 export async function executeTranscriptionPipeline(params: TranscriptionPipelineParams): Promise<ChunkPipelineResult> {
-  const { conversationId, userId, filePath, replicateApiToken, huggingfaceAccessToken, audioSizeBytes, chunkContext, chunkMetadata } = params;
+  const { conversationId, userId, filePath, whisperServiceUrl, audioSizeBytes, chunkContext, chunkMetadata } = params;
   const isChunkTask = !!chunkMetadata;
 
   // Initialize progress tracking (with chunk info for aggregate progress calculation)
@@ -916,16 +914,10 @@ export async function executeTranscriptionPipeline(params: TranscriptionPipeline
     console.log('[Pipeline] Step 2: Calling WhisperX for transcription with hints...');
     const whisperxStartTime = Date.now();
 
-    const hfToken = huggingfaceAccessToken || undefined;
-    if (!hfToken) {
-      console.warn('[Pipeline] HUGGINGFACE_ACCESS_TOKEN not set - speaker diarization will be disabled');
-    }
-
     // Try robust WhisperX first
     let whisperxResult = await transcribeWithWhisperXRobust(
       audioBuffer,
-      replicateApiToken,
-      hfToken,
+      whisperServiceUrl,
       2,
       whisperxHints
     );
@@ -935,8 +927,7 @@ export async function executeTranscriptionPipeline(params: TranscriptionPipeline
       console.warn('[Pipeline] Robust WhisperX failed, trying standard method...');
       whisperxResult = await transcribeWithWhisperX(
         audioBuffer,
-        replicateApiToken,
-        hfToken,
+        whisperServiceUrl,
         whisperxHints
       );
     }
@@ -976,7 +967,7 @@ export async function executeTranscriptionPipeline(params: TranscriptionPipeline
     const computeSeconds = actualComputeSeconds ?? (whisperxDurationMs / 1000);
 
     if (actualComputeSeconds) {
-      console.log(`[Pipeline] Using actual Replicate compute time: ${actualComputeSeconds}s`);
+      console.log(`[Pipeline] Using actual Cloud Run compute time: ${actualComputeSeconds}s`);
     } else {
       console.warn(`[Pipeline] Estimating compute time from wall-clock: ${(whisperxDurationMs / 1000).toFixed(1)}s`);
     }
@@ -1299,7 +1290,7 @@ export async function executeTranscriptionPipeline(params: TranscriptionPipeline
     });
 
     // Build LLM usage breakdown for cost tracking
-    // Use the compute times from partialMetrics (which has actual Replicate compute time if available)
+    // Use the compute times from partialMetrics (which has actual Cloud Run compute time if available)
     const llmUsage: LLMUsage = {
       geminiAnalysis: geminiAnalysisTokens,
       geminiSpeakerCorrection: geminiCorrectionTokens,
@@ -1551,7 +1542,7 @@ export async function executeTranscriptionPipeline(params: TranscriptionPipeline
  */
 export const transcribeAudio = onObjectFinalized(
   {
-    secrets: [replicateApiToken, huggingfaceAccessToken],
+    secrets: [whisperServiceUrl],
     memory: '2GiB', // Large audio files need more memory for chunking
     timeoutSeconds: 540, // 9 minutes (max for event-driven triggers, even 2nd gen)
     region: 'us-central1'
@@ -1689,8 +1680,7 @@ export const transcribeAudio = onObjectFinalized(
           conversationId,
           userId,
           filePath,
-          replicateApiToken: replicateApiToken.value(),
-          huggingfaceAccessToken: huggingfaceAccessToken.value(),
+          whisperServiceUrl: whisperServiceUrl.value(),
           audioSizeBytes: event.data.size
         });
 


### PR DESCRIPTION
## Summary
- Replaced Replicate SDK with direct HTTP `fetch` calls to self-hosted Cloud Run WhisperX `/predict` endpoint
- OIDC IAM auth, 180s `AbortController` timeout, cost tracking via `X-Predict-Time` / `X-Request-Id` response headers
- Removed `replicate` npm dependency; circuit breaker and metrics renamed from `replicate` → `cloud-run-whisper`

## Changelog Entry
```markdown
### Changed
- **Cloud Run GPU Migration** - WhisperX transcription now runs on self-hosted Cloud Run with NVIDIA L4 GPU instead of Replicate
  - Replaced Replicate SDK polling with direct HTTP calls to Cloud Run `/predict` endpoint
  - OIDC-based IAM authentication replaces API token auth
  - 180-second client-side timeout via `AbortController` with no-retry-on-timeout policy
  - Cost tracking captures `X-Predict-Time` and request ID from Cloud Run response headers
  - Circuit breaker and metrics renamed from `replicate` to `cloud-run-whisper`
  - Removed `replicate` npm dependency (~108 net lines removed)
```

## Files Changed (10)
- `functions/src/alignment.ts` — Core transport migration (Replicate SDK → HTTP fetch + OIDC)
- `functions/src/transcribe.ts` — Secret swap (`REPLICATE_API_TOKEN` → `WHISPER_SERVICE_URL`)
- `functions/src/processTranscription.ts` — Same secret/config migration
- `functions/src/metrics.ts` — `ReplicateUsage` → `CloudRunWhisperUsage`, service type updated
- `functions/src/circuitBreaker.ts` — `replicateCircuit` → `cloudRunWhisperCircuit`
- `functions/package.json` — Removed `replicate` dependency
- `functions/package-lock.json` — Lockfile updated
- `README.md` — Architecture diagram, secrets, tech stack updated
- `docs/how-to/firebase-setup.md` — Secrets configuration updated
- `docs/reference/data-model.md` — Service naming and cost tracking updated

## Test Plan
- [ ] TypeScript compilation passes (`npx tsc --noEmit` in `functions/`)
- [ ] Deploy Cloud Run WhisperX service and set `WHISPER_SERVICE_URL` secret
- [ ] Run `./scripts/gcp-setup.sh` for any new IAM bindings
- [ ] Upload a test audio file and verify transcription completes
- [ ] Verify cost tracking fields populate in `_metrics` documents
- [ ] Verify circuit breaker trips on simulated failure (503 responses)

---
Scope: `infrastructure_05_02_02_cloud_run_gpu_migration`
Iteration: `iteration_01`
Build: `27`