### PR TITLE
chore(release): v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.0] - 2026-02-20
+
 ### Added
 - **Cloud Run GPU Whisper Service** - Standalone FastAPI container for Whisper diarization on Cloud Run with GPU
   - CUDA 12 + cuDNN 9 base image with pre-cached models (~20GB) for offline inference
@@ -15,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 180-second hard timeout returns HTTP 504 with structured logging
   - `X-Predict-Time` header on all response paths (200, 503, 504, 500)
   - `/health` endpoint for Cloud Run readiness probes
+- **Whisper GPU deploy script** (`scripts/deploy-whisper.sh`) - One-command build + deploy with `--build-only`, `--deploy-only`, `--no-cache`, and `--tag` options
 
 ### Changed
 - **Cloud Run GPU Migration** - WhisperX transcription now runs on self-hosted Cloud Run with NVIDIA L4 GPU instead of Replicate
@@ -26,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed `replicate` npm dependency (~108 net lines removed)
 - **Segment Gap Tuning** - `group_segments_gap` set to 0.3s (down from 1.0s default)
   - Preserves short speaker switches like acknowledgments ("Yeah", "Mm-hmm") that were being merged into adjacent segments
+- **GCP setup script** - Added Artifact Registry, Cloud Run GPU IAM, and Whisper service URL auto-detection; replaced Replicate/HuggingFace token prompts
+- **CI pipeline** - Replaced `REPLICATE_API_TOKEN` and `HUGGINGFACE_ACCESS_TOKEN` secrets with single `WHISPER_SERVICE_URL`
+- **Dockerfile security** - HuggingFace token now passed via BuildKit secret mount instead of `ARG` (never baked into image layers)
+
+### Fixed
+- **Speaker corrections validation** - Backend `reassignSegments` and `mergeSpeakers` now validate against effective state (with prior corrections applied) instead of raw Firestore data
+  - Previously, reassigning a segment A→B then back B→A would fail with "already belongs to target speaker" because the backend still saw the raw ownership
+  - New `computeEffectiveState()` helper replays active corrections server-side, mirroring the client's apply-on-read logic
 
 ## [2.7.1] - 2026-01-30
 

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -1,5 +1,22 @@
 # What's New
 
+## Version 2.8.0 - February 20, 2026
+
+### 🚀 Faster Transcription with Dedicated GPU
+
+**Self-Hosted Whisper Processing**
+- Transcription now runs on a dedicated GPU server instead of a third-party API
+- The same Whisper Large v3 Turbo + pyannote speaker diarization you know, now faster and more reliable
+- Finer gap detection (0.3s) preserves quick acknowledgments like "Yeah" and "Mm-hmm" that were previously merged into neighboring segments
+
+### 🐛 Bug Fix: Speaker Corrections
+
+**Reassign-Then-Undo No Longer Breaks**
+- Fixed a bug where reassigning a segment to a different speaker and then trying to move it back would fail
+- The backend now correctly tracks your corrections, so multi-step speaker edits work as expected
+
+---
+
 ## Version 2.7.0 - January 30, 2026
 
 ### ✨ Manual Speaker Correction

--- a/cloud-run-whisper/Dockerfile
+++ b/cloud-run-whisper/Dockerfile
@@ -50,12 +50,16 @@ print(f'Whisper cached to {path}')" && \
     test -f /models/faster-whisper-large-v3-turbo/model.bin
 
 # pyannote diarization + speaker embedding models
-# HF_TOKEN needed at build time to access gated models
-ARG HF_TOKEN
-RUN HF_HOME=/models HF_TOKEN=${HF_TOKEN} python3 -c "\
+# Token passed via BuildKit secret mount — never baked into image layers.
+# Build with: docker build --secret id=hf_token,env=HF_TOKEN ...
+RUN --mount=type=secret,id=hf_token \
+    HF_HOME=/models \
+    HF_TOKEN=$(cat /run/secrets/hf_token) \
+    python3 -c "\
+import os; token = os.environ['HF_TOKEN']; \
 from pyannote.audio import Pipeline, Model; \
-Pipeline.from_pretrained('pyannote/speaker-diarization-3.1', use_auth_token='${HF_TOKEN}'); \
-Model.from_pretrained('pyannote/wespeaker-voxceleb-resnet34-LM', use_auth_token='${HF_TOKEN}'); \
+Pipeline.from_pretrained('pyannote/speaker-diarization-3.1', use_auth_token=token); \
+Model.from_pretrained('pyannote/wespeaker-voxceleb-resnet34-LM', use_auth_token=token); \
 print('Pyannote models cached')" && \
     echo "=== Model cache contents ===" && \
     ls -la /models/ && \

--- a/docs/how-to/deploy.md
+++ b/docs/how-to/deploy.md
@@ -259,6 +259,147 @@ gcloud tasks list \
   --project=$PROJECT_ID
 ```
 
+## Whisper GPU Service (Cloud Run)
+
+The WhisperX transcription service runs on Cloud Run with an NVIDIA L4 GPU for fast audio transcription and speaker diarization.
+
+### Quick Deploy
+
+```bash
+# Full build + deploy (reads GCP_PROJECT_ID from .env)
+./scripts/deploy-whisper.sh
+
+# Build and push image only (no deploy)
+./scripts/deploy-whisper.sh --build-only
+
+# Deploy an already-pushed image (no build)
+./scripts/deploy-whisper.sh --deploy-only
+
+# Rebuild without Docker cache (after Dockerfile changes)
+./scripts/deploy-whisper.sh --no-cache
+
+# Deploy with a specific image tag
+./scripts/deploy-whisper.sh --tag v1.2.3
+```
+
+The script reads configuration from `.env` (or environment variables):
+- `GCP_PROJECT_ID` (required)
+- `WHISPER_REGION` (default: `us-east4`)
+- `WHISPER_SERVICE_NAME` (default: `whisperx-service`)
+
+### Manual Build and Push
+
+```bash
+PROJECT_ID="your-project-id"
+REGION="us-east4"  # GPU quota region — may differ from main project region
+IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/whisper-gpu/whisperx:latest"
+
+# Authenticate Docker with Artifact Registry
+gcloud auth configure-docker ${REGION}-docker.pkg.dev --quiet
+
+# Build for linux/amd64 (required by Cloud Run, even if building on ARM Mac)
+# HF_TOKEN needed for gated pyannote models — passed via BuildKit secret (not baked into layers)
+export HF_TOKEN="hf_..."  # your HuggingFace access token
+DOCKER_BUILDKIT=1 docker build --platform linux/amd64 \
+  --secret id=hf_token,env=HF_TOKEN \
+  -t "$IMAGE" cloud-run-whisper/
+
+# Push to Artifact Registry
+docker push "$IMAGE"
+```
+
+> **Note:** The Artifact Registry repository `whisper-gpu` is created automatically by `gcp-setup.sh`. If it doesn't exist, run the setup script first.
+
+### Deploy to Cloud Run with GPU
+
+```bash
+PROJECT_ID="your-project-id"
+REGION="us-east4"  # GPU quota region — may differ from main project region
+IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/whisper-gpu/whisperx:latest"
+
+gcloud run deploy whisperx-service \
+  --project=$PROJECT_ID \
+  --region=$REGION \
+  --image=$IMAGE \
+  --gpu=1 \
+  --gpu-type=nvidia-l4 \
+  --no-gpu-zonal-redundancy \
+  --memory=16Gi \
+  --timeout=300 \
+  --concurrency=1 \
+  --min-instances=0 \
+  --max-instances=3 \
+  --no-allow-unauthenticated
+```
+
+**Flag Breakdown:**
+
+| Flag | Value | Why |
+|------|-------|-----|
+| `--gpu=1` | 1 GPU | WhisperX needs GPU for inference |
+| `--gpu-type=nvidia-l4` | NVIDIA L4 | Cost-effective inference GPU |
+| `--no-gpu-zonal-redundancy` | Single zone | Lower quota requirement, fine for batch workloads |
+| `--memory=16Gi` | 16 GiB | WhisperX + pyannote models need headroom |
+| `--timeout=300` | 5 min | Hard limit per request (Cloud Run backstop) |
+| `--concurrency=1` | 1 req/instance | GPU can't safely share across concurrent requests |
+| `--min-instances=0` | Scale to zero | No cost when idle |
+| `--max-instances=3` | Max 3 instances | Cost safeguard — caps GPU spend |
+| `--no-allow-unauthenticated` | IAM auth | Only Cloud Functions runtime SA can invoke |
+
+### Verify the Deployment
+
+```bash
+PROJECT_ID="your-project-id"
+REGION="us-central1"
+
+# Check service status
+gcloud run services describe whisperx-service \
+  --project=$PROJECT_ID \
+  --region=$REGION \
+  --format="value(status.url)"
+
+# Check revisions
+gcloud run revisions list \
+  --service=whisperx-service \
+  --project=$PROJECT_ID \
+  --region=$REGION
+```
+
+### Set Up Monitoring Alert (Request Duration > 120s)
+
+Create a Cloud Monitoring alert policy that fires when Whisper Cloud Run requests exceed 120 seconds. This provides an early warning before the 300s hard timeout:
+
+```bash
+PROJECT_ID="your-project-id"
+
+gcloud alpha monitoring policies create \
+  --project=$PROJECT_ID \
+  --display-name="Whisper Cloud Run: Request duration > 120s" \
+  --condition-display-name="Request latency exceeds 120s" \
+  --condition-filter='resource.type="cloud_run_revision" AND resource.labels.service_name="whisperx-service" AND metric.type="run.googleapis.com/request_latencies"' \
+  --condition-threshold-value=120000 \
+  --condition-threshold-duration=0s \
+  --condition-threshold-comparison=COMPARISON_GT \
+  --aggregation-alignment-period=60s \
+  --aggregation-per-series-aligner=ALIGN_PERCENTILE_99 \
+  --notification-channels=[] \
+  --documentation="Whisper Cloud Run p99 request latency exceeded 120s. Investigate whether audio files are unusually large or if GPU performance has degraded. The hard timeout is 300s."
+```
+
+> **Note:** Replace `--notification-channels=[]` with your notification channel ID to receive alerts. Create a notification channel in the [Cloud Console](https://console.cloud.google.com/monitoring/alerting/notifications) first, then reference it by ID.
+
+Alternatively, create the alert via the Cloud Console:
+
+1. Go to **Cloud Console** → **Monitoring** → **Alerting** → **Create Policy**
+2. **Add Condition:**
+   - Resource type: `Cloud Run Revision`
+   - Metric: `Request Latencies` (`run.googleapis.com/request_latencies`)
+   - Filter: `service_name = "whisperx-service"`
+   - Aggregation: 99th percentile, 1-minute alignment
+   - Threshold: Above 120,000 ms
+3. **Add Notification Channel** (email, Slack, PagerDuty, etc.)
+4. **Name:** "Whisper Cloud Run: Request duration > 120s"
+
 ## Workload Identity Federation Setup
 
 Cloud Run deployment uses Workload Identity Federation for secure, keyless authentication from GitHub Actions. This must be configured in the **same project** as your Firebase backend.

--- a/docs/how-to/firebase-setup.md
+++ b/docs/how-to/firebase-setup.md
@@ -45,14 +45,17 @@ The script is **idempotent** - safe to rerun if it fails partway through. It wil
 4. Enables all required APIs (including Generative Language API for Gemini)
 5. Configures IAM bindings (deployment SA, runtime SA)
 6. Initializes Firestore database
-7. Detects Firebase Storage bucket (provides setup instructions if not found)
-8. Configures Storage bucket permissions for Eventarc triggers (if bucket exists)
-9. Configures CORS for audio file access (if bucket exists)
-10. Sets up Workload Identity Federation for GitHub Actions (if `github-repo` provided)
-11. Creates GitHub Actions service account with Cloud Run permissions
-12. Optionally creates service account key for Firebase CI/CD (interactive prompt)
-13. Optionally creates Gemini API key in-project and stores in Secret Manager (interactive prompt)
-14. Optionally registers Firebase Web App (interactive prompt)
+7. Creates Cloud Tasks queue for transcription
+8. Creates Artifact Registry repository for Whisper GPU container images
+9. Grants IAM roles for Whisper Cloud Run GPU service (runtime SA → `roles/run.invoker`, Cloud Build SA → Artifact Registry + Cloud Run permissions)
+10. Detects Firebase Storage bucket (provides setup instructions if not found)
+11. Configures Storage bucket permissions for Eventarc triggers (if bucket exists)
+12. Configures CORS for audio file access (if bucket exists)
+13. Sets up Workload Identity Federation for GitHub Actions (if `github-repo` provided)
+14. Creates GitHub Actions service account with Cloud Run permissions
+15. Optionally creates service account key for Firebase CI/CD (interactive prompt)
+16. Optionally creates Gemini API key in-project and stores in Secret Manager (interactive prompt)
+17. Optionally registers Firebase Web App (interactive prompt)
 
 > **Note:** The Gemini API key is created within your GCP project (not via AI Studio), keeping all resources in one place. Service agent IAM bindings are configured automatically by the GitHub Actions workflow on each deployment.
 

--- a/functions/src/speakerCorrections.ts
+++ b/functions/src/speakerCorrections.ts
@@ -57,6 +57,114 @@ interface UndoCorrectionResponse {
   success: boolean;
 }
 
+/** Minimal shape of a correction doc — only fields the replay helper cares about */
+interface ActiveCorrection {
+  type: 'merge' | 'reassign' | 'rename';
+  // merge
+  sourceSpeakerId?: string;
+  targetSpeakerId?: string;
+  // reassign
+  segmentIds?: string[];
+  toSpeakerId?: string;
+  // rename
+  speakerId?: string;
+  newDisplayName?: string;
+}
+
+/**
+ * Replay active corrections to derive the effective speaker map and
+ * segment-to-speaker mapping. Mirrors the client-side apply-on-read
+ * logic in useSpeakerCorrections.ts (the useMemo at ~line 172).
+ *
+ * We need this because raw Firestore data doesn't reflect prior
+ * corrections — a segment reassigned A→B still shows speakerId=A
+ * in the raw doc. Without replay, the backend rejects valid moves
+ * like B→A ("already belongs to target speaker").
+ */
+async function computeEffectiveState(
+  conversationId: string,
+  rawSpeakers: Record<string, any>,
+  rawSegments: Array<{ segmentId: string; speakerId: string; [key: string]: any }>
+): Promise<{
+  effectiveSpeakers: Record<string, any>;
+  effectiveSegmentSpeaker: Map<string, string>;
+}> {
+  // Fetch all corrections, ordered chronologically
+  const correctionsSnap = await db
+    .collection('conversations')
+    .doc(conversationId)
+    .collection('speakerCorrections')
+    .orderBy('createdAt', 'asc')
+    .get();
+
+  // Filter to active only (not undone)
+  const active: ActiveCorrection[] = [];
+  for (const doc of correctionsSnap.docs) {
+    const data = doc.data();
+    if (data.undoneAt) continue;
+    active.push({
+      type: data.type,
+      sourceSpeakerId: data.sourceSpeakerId,
+      targetSpeakerId: data.targetSpeakerId,
+      segmentIds: data.segmentIds,
+      toSpeakerId: data.toSpeakerId,
+      speakerId: data.speakerId,
+      newDisplayName: data.newDisplayName,
+    });
+  }
+
+  // Deep-copy speakers so we don't mutate the raw data
+  const speakers: Record<string, any> = {};
+  for (const [id, speaker] of Object.entries(rawSpeakers)) {
+    speakers[id] = { ...speaker };
+  }
+
+  // Build mutable segment-to-speaker map
+  const segSpeaker = new Map<string, string>();
+  for (const seg of rawSegments) {
+    segSpeaker.set(seg.segmentId, seg.speakerId);
+  }
+
+  // Replay corrections in order — same logic as client hook
+  for (const c of active) {
+    if (c.type === 'merge') {
+      if (!c.sourceSpeakerId || !c.targetSpeakerId) continue;
+      if (!speakers[c.sourceSpeakerId] || !speakers[c.targetSpeakerId]) continue;
+
+      delete speakers[c.sourceSpeakerId];
+      for (const [segId, spkId] of segSpeaker) {
+        if (spkId === c.sourceSpeakerId) {
+          segSpeaker.set(segId, c.targetSpeakerId);
+        }
+      }
+    } else if (c.type === 'reassign') {
+      if (!c.segmentIds || !c.toSpeakerId) continue;
+      for (const segId of c.segmentIds) {
+        if (segSpeaker.has(segId)) {
+          segSpeaker.set(segId, c.toSpeakerId);
+        }
+      }
+    } else if (c.type === 'rename') {
+      if (!c.speakerId || !c.newDisplayName) continue;
+      if (!speakers[c.speakerId]) continue;
+      speakers[c.speakerId] = {
+        ...speakers[c.speakerId],
+        displayName: c.newDisplayName,
+      };
+    }
+  }
+
+  // Prune speakers with zero segments (matches client behavior)
+  const speakersWithSegments = new Set(segSpeaker.values());
+  for (const speakerId of Object.keys(speakers)) {
+    if (!speakersWithSegments.has(speakerId)) {
+      delete speakers[speakerId];
+    }
+  }
+
+  return { effectiveSpeakers: speakers, effectiveSegmentSpeaker: segSpeaker };
+}
+
 /**
  * Merge two speakers by writing a correction record.
  *
@@ -119,12 +227,16 @@ export const mergeSpeakers = onCall<MergeSpeakersRequest>(
         throw new HttpsError('permission-denied', 'You do not have access to this conversation');
       }
 
-      // Validate that both speakers exist in the conversation
-      const speakers = conversation.speakers || {};
-      if (!speakers[sourceSpeakerId]) {
+      // Validate against effective state (raw data doesn't reflect prior corrections)
+      const { effectiveSpeakers } = await computeEffectiveState(
+        conversationId,
+        conversation.speakers || {},
+        conversation.segments || []
+      );
+      if (!effectiveSpeakers[sourceSpeakerId]) {
         throw new HttpsError('invalid-argument', `Source speaker '${sourceSpeakerId}' not found`);
       }
-      if (!speakers[targetSpeakerId]) {
+      if (!effectiveSpeakers[targetSpeakerId]) {
         throw new HttpsError('invalid-argument', `Target speaker '${targetSpeakerId}' not found`);
       }
 
@@ -244,31 +356,30 @@ export const reassignSegments = onCall<ReassignSegmentsRequest>(
         throw new HttpsError('permission-denied', 'You do not have access to this conversation');
       }
 
-      // Validate segments exist and all belong to the same speaker
-      const segments = conversation.segments || [];
-
-      interface SegmentData {
-        segmentId: string;
-        speakerId: string;
-        [key: string]: any;
-      }
-
-      const segmentMap = new Map<string, SegmentData>(
-        segments.map((s: any) => [s.segmentId, s as SegmentData])
+      // Validate against effective state (raw data doesn't reflect prior corrections)
+      const { effectiveSpeakers, effectiveSegmentSpeaker } = await computeEffectiveState(
+        conversationId,
+        conversation.speakers || {},
+        conversation.segments || []
       );
 
+      // Validate target speaker exists in effective state
+      if (!effectiveSpeakers[toSpeakerId]) {
+        throw new HttpsError('invalid-argument', `Target speaker '${toSpeakerId}' not found`);
+      }
+
+      // Validate segments exist and all effectively belong to the same speaker
       let fromSpeakerId: string | null = null;
 
       for (const segmentId of segmentIds) {
-        const segment = segmentMap.get(segmentId);
-        if (!segment) {
+        const effectiveOwner = effectiveSegmentSpeaker.get(segmentId);
+        if (!effectiveOwner) {
           throw new HttpsError('invalid-argument', `Segment '${segmentId}' not found`);
         }
 
-        // All segments must belong to the same speaker
         if (fromSpeakerId === null) {
-          fromSpeakerId = segment.speakerId;
-        } else if (segment.speakerId !== fromSpeakerId) {
+          fromSpeakerId = effectiveOwner;
+        } else if (effectiveOwner !== fromSpeakerId) {
           throw new HttpsError(
             'invalid-argument',
             'All segments must belong to the same speaker'
@@ -278,12 +389,6 @@ export const reassignSegments = onCall<ReassignSegmentsRequest>(
 
       if (!fromSpeakerId) {
         throw new HttpsError('invalid-argument', 'Could not determine source speaker');
-      }
-
-      // Validate target speaker exists
-      const speakers = conversation.speakers || {};
-      if (!speakers[toSpeakerId]) {
-        throw new HttpsError('invalid-argument', `Target speaker '${toSpeakerId}' not found`);
       }
 
       // Don't allow reassigning to the same speaker

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-transcript-analysis-app",
   "private": true,
-  "version": "2.7.1",
+  "version": "2.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/deploy-whisper.sh
+++ b/scripts/deploy-whisper.sh
@@ -1,0 +1,292 @@
+#!/bin/bash
+# =============================================================================
+# Whisper GPU Service Deployment Script
+#
+# Builds and deploys the WhisperX transcription container to Cloud Run
+# with NVIDIA L4 GPU. The service handles audio transcription and speaker
+# diarization, called by Cloud Functions via IAM-authenticated HTTPS.
+#
+# Usage:
+#   ./scripts/deploy-whisper.sh                # Build, push, and deploy
+#   ./scripts/deploy-whisper.sh --build-only   # Build and push only (no deploy)
+#   ./scripts/deploy-whisper.sh --deploy-only  # Deploy existing image (no build)
+#   ./scripts/deploy-whisper.sh --no-cache     # Build without Docker cache
+#
+# Prerequisites:
+#   - Docker installed and running
+#   - gcloud CLI authenticated
+#   - Artifact Registry repo created (run gcp-setup.sh first)
+#
+# =============================================================================
+
+set -euo pipefail
+
+# Colors (disabled in CI or non-interactive)
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    NC=''
+fi
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+log_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
+
+# Load from .env if present
+if [ -f ".env" ]; then
+    set -a
+    source .env
+    set +a
+fi
+
+PROJECT_ID="${GCP_PROJECT_ID:-}"
+REGION="${WHISPER_REGION:-us-east4}"
+SERVICE_NAME="${WHISPER_SERVICE_NAME:-whisperx-service}"
+AR_REPO="${WHISPER_AR_REPO:-whisper-gpu}"
+IMAGE_TAG="${WHISPER_IMAGE_TAG:-latest}"
+
+# HuggingFace token — needed at build time for gated pyannote models.
+# Accepts either name so you don't have to remember which one you set.
+HF_TOKEN="${HF_TOKEN:-${HUGGINGFACE_ACCESS_TOKEN:-}}"
+
+IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/whisperx:${IMAGE_TAG}"
+
+# Script directory (for finding cloud-run-whisper/ relative to repo root)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_CONTEXT="${REPO_ROOT}/cloud-run-whisper"
+
+# -----------------------------------------------------------------------------
+# Parse Arguments
+# -----------------------------------------------------------------------------
+
+DO_BUILD=true
+DO_DEPLOY=true
+DOCKER_EXTRA_ARGS=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --build-only)
+            DO_DEPLOY=false
+            shift
+            ;;
+        --deploy-only)
+            DO_BUILD=false
+            shift
+            ;;
+        --no-cache)
+            DOCKER_EXTRA_ARGS="--no-cache"
+            shift
+            ;;
+        --tag)
+            IMAGE_TAG="$2"
+            IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/whisperx:${IMAGE_TAG}"
+            shift 2
+            ;;
+        --help)
+            echo "Usage: $0 [options]"
+            echo ""
+            echo "Options:"
+            echo "  --build-only   Build and push image only (skip deploy)"
+            echo "  --deploy-only  Deploy existing image only (skip build)"
+            echo "  --no-cache     Build without Docker layer cache"
+            echo "  --tag TAG      Image tag (default: latest)"
+            echo "  --help         Show this help message"
+            echo ""
+            echo "Environment variables (set in .env or export):"
+            echo "  GCP_PROJECT_ID         GCP project ID (required)"
+            echo "  WHISPER_REGION         Cloud Run region (default: us-east4)"
+            echo "  WHISPER_SERVICE_NAME   Service name (default: whisperx-service)"
+            echo "  WHISPER_AR_REPO        Artifact Registry repo (default: whisper-gpu)"
+            echo "  WHISPER_IMAGE_TAG      Image tag (default: latest)"
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1 (use --help for usage)"
+            exit 1
+            ;;
+    esac
+done
+
+# -----------------------------------------------------------------------------
+# Validation
+# -----------------------------------------------------------------------------
+
+if [ -z "$PROJECT_ID" ]; then
+    log_error "GCP_PROJECT_ID is not set. Set it in .env or export it."
+    exit 1
+fi
+
+if [ "$DO_BUILD" = true ] && [ ! -d "$BUILD_CONTEXT" ]; then
+    log_error "Build context not found: $BUILD_CONTEXT"
+    log_error "Expected cloud-run-whisper/ directory at repo root."
+    exit 1
+fi
+
+echo ""
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BLUE}  Whisper GPU Service Deployment${NC}"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo "  Project:  $PROJECT_ID"
+echo "  Region:   $REGION"
+echo "  Service:  $SERVICE_NAME"
+echo "  Image:    $IMAGE"
+echo "  Build:    $DO_BUILD"
+echo "  Deploy:   $DO_DEPLOY"
+echo ""
+
+# -----------------------------------------------------------------------------
+# Preflight Checks
+# -----------------------------------------------------------------------------
+
+log_info "Running preflight checks..."
+
+if ! command -v gcloud &> /dev/null; then
+    log_error "gcloud CLI not found. Install: https://cloud.google.com/sdk/docs/install"
+    exit 1
+fi
+
+if ! gcloud auth print-identity-token &> /dev/null; then
+    log_error "Not authenticated. Run: gcloud auth login"
+    exit 1
+fi
+
+if [ "$DO_BUILD" = true ]; then
+    if ! command -v docker &> /dev/null; then
+        log_error "Docker not found. Install: https://docs.docker.com/get-docker/"
+        exit 1
+    fi
+
+    if ! docker info &> /dev/null; then
+        log_error "Docker daemon not running. Start Docker and try again."
+        exit 1
+    fi
+
+    if [ -z "$HF_TOKEN" ]; then
+        log_error "HF_TOKEN is required for building (pyannote models are gated)."
+        log_error "Set HF_TOKEN in .env or export it:"
+        log_error "  export HF_TOKEN=hf_..."
+        log_error "Get a token at: https://huggingface.co/settings/tokens"
+        exit 1
+    fi
+fi
+
+# Verify Artifact Registry repo exists
+if ! gcloud artifacts repositories describe "$AR_REPO" \
+    --location="$REGION" \
+    --project="$PROJECT_ID" &>/dev/null; then
+    log_error "Artifact Registry repo '$AR_REPO' not found in $REGION."
+    log_error "Run ./scripts/gcp-setup.sh to create it."
+    exit 1
+fi
+
+log_success "Preflight checks passed"
+
+# -----------------------------------------------------------------------------
+# Build and Push
+# -----------------------------------------------------------------------------
+
+if [ "$DO_BUILD" = true ]; then
+    log_info "Configuring Docker for Artifact Registry..."
+    gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+    log_info "Building image from $BUILD_CONTEXT..."
+    log_warning "This may take a while — the Whisper image is ~20GB with cached models."
+    DOCKER_BUILDKIT=1 docker build --platform linux/amd64 \
+        --secret id=hf_token,env=HF_TOKEN \
+        $DOCKER_EXTRA_ARGS -t "$IMAGE" "$BUILD_CONTEXT"
+    log_success "Image built: $IMAGE"
+
+    log_info "Pushing image to Artifact Registry..."
+    docker push "$IMAGE"
+    log_success "Image pushed: $IMAGE"
+fi
+
+# -----------------------------------------------------------------------------
+# Deploy to Cloud Run
+# -----------------------------------------------------------------------------
+
+if [ "$DO_DEPLOY" = true ]; then
+    log_info "Deploying to Cloud Run with GPU..."
+
+    gcloud run deploy "$SERVICE_NAME" \
+        --project="$PROJECT_ID" \
+        --region="$REGION" \
+        --image="$IMAGE" \
+        --gpu=1 \
+        --gpu-type=nvidia-l4 \
+        --no-gpu-zonal-redundancy \
+        --memory=16Gi \
+        --timeout=300 \
+        --concurrency=1 \
+        --min-instances=0 \
+        --max-instances=3 \
+        --no-allow-unauthenticated \
+        --quiet
+
+    log_success "Deployed $SERVICE_NAME to Cloud Run"
+
+    # -------------------------------------------------------------------------
+    # Store service URL in Secret Manager
+    # -------------------------------------------------------------------------
+    # Cloud Functions reference this via defineSecret('WHISPER_SERVICE_URL').
+    # If the secret doesn't exist, `firebase deploy` prompts interactively —
+    # which breaks CI/CD. So we store it automatically after every deploy.
+
+    SERVICE_URL=$(gcloud run services describe "$SERVICE_NAME" \
+        --project="$PROJECT_ID" \
+        --region="$REGION" \
+        --format="value(status.url)")
+
+    SECRET_NAME="WHISPER_SERVICE_URL"  # pragma: allowlist secret
+
+    # Check current value — only update if it actually changed
+    CURRENT_SECRET=$(gcloud secrets versions access latest \
+        --secret="$SECRET_NAME" \
+        --project="$PROJECT_ID" 2>/dev/null) || CURRENT_SECRET=""
+
+    if [ "$CURRENT_SECRET" = "$SERVICE_URL" ]; then
+        log_success "Secret $SECRET_NAME already up to date"
+    elif [ -z "$CURRENT_SECRET" ] && ! gcloud secrets describe "$SECRET_NAME" \
+            --project="$PROJECT_ID" &>/dev/null; then
+        # Secret doesn't exist yet — create it
+        echo -n "$SERVICE_URL" | gcloud secrets create "$SECRET_NAME" \
+            --data-file=- \
+            --project="$PROJECT_ID" \
+            --replication-policy="automatic"
+        log_success "Created secret $SECRET_NAME"
+    else
+        # Secret exists but value changed (or first version)
+        echo -n "$SERVICE_URL" | gcloud secrets versions add "$SECRET_NAME" \
+            --data-file=- \
+            --project="$PROJECT_ID"
+        log_success "Updated secret $SECRET_NAME"
+    fi
+
+    echo ""
+    echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${GREEN}  Deployment Complete${NC}"
+    echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo "  Service URL: $SERVICE_URL"
+    echo "  Secret:      $SECRET_NAME (stored in Secret Manager)"
+    echo ""
+    echo "  Health check:"
+    echo "    TOKEN=\$(gcloud auth print-identity-token)"
+    echo "    curl -H \"Authorization: Bearer \$TOKEN\" ${SERVICE_URL}/health"
+    echo ""
+fi


### PR DESCRIPTION
## Release v2.8.0

### Added
- **Cloud Run GPU Whisper Service** — Standalone FastAPI container for WhisperX diarization on Cloud Run with NVIDIA L4 GPU, replacing Replicate
- **Whisper deploy script** (`scripts/deploy-whisper.sh`) — One-command build + deploy with `--build-only`, `--deploy-only`, `--no-cache`, and `--tag` options

### Changed
- **Cloud Run GPU Migration** — WhisperX transcription on self-hosted Cloud Run replaces Replicate (OIDC auth, direct HTTP calls, 180s client timeout)
- **GCP setup script** — Added Artifact Registry, Cloud Run GPU IAM, Whisper service URL auto-detection; replaced Replicate/HuggingFace token prompts
- **CI pipeline** — Single `WHISPER_SERVICE_URL` secret replaces `REPLICATE_API_TOKEN` + `HUGGINGFACE_ACCESS_TOKEN`
- **Dockerfile security** — HuggingFace token via BuildKit secret mount (never baked into image layers)
- **Segment gap tuning** — 0.3s gap preserves quick acknowledgments that were being merged

### Fixed
- **Speaker corrections validation** — `reassignSegments` and `mergeSpeakers` now validate against effective state (with prior corrections applied) instead of raw Firestore data. Fixes reassign A→B then B→A failing with "already belongs to target speaker."

## Test Plan
- [ ] Deploy functions and verify speaker reassign round-trip (A→B→A) works
- [ ] Deploy Whisper GPU service and verify transcription end-to-end
- [ ] Verify CI pipeline passes with new `WHISPER_SERVICE_URL` secret
- [ ] Run `cd functions && npm test` (174 tests pass)

---
Tag: `v2.8.0`
Build: `28`