### PR TITLE
chore(release): v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.0] - 2026-02-22
+
+### Added
+- **Name-Boosted Speaker Reconciliation** - Speakers identified with the same name across different audio chunks now receive a similarity boost during voice-matching
+  - Configurable boost amount (default 0.15) nudges borderline voice matches over the merge threshold when identity is confirmed by name
+  - Normalizes names by stripping role suffixes (e.g., "Sam (Team Member)" → "sam") and lowercasing before comparison
+  - Skips generic placeholder names ("Speaker 1", "Unknown") to avoid false merges
+  - Only applies to cross-chunk pairs — same-chunk speakers with matching names stay separate
+  - Per-boost logging and `nameBoostCount` in reconciliation metadata for observability
+  - `signalsUsed` metadata now includes `"names"` when name boosts are applied, distinguishing name-assisted runs from embeddings-only
+
+### Changed
+- **Expanded Speaker Role Recognition** - Added 13 active-participant roles to the People-list confirming-role whitelist
+  - New roles: presenter, participant, team member, lead, consultant, facilitator, analyst, manager, director, engineer, developer, designer, owner
+  - Speakers with these roles are no longer rejected when their name matches someone in the People list (talked about vs. present)
+  - Fixes cases like "Terry (Team Member)" being rejected because "team member" wasn't in the allowed roles
+
 ## [2.8.0] - 2026-02-20
 
 ### Added

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -1,5 +1,20 @@
 # What's New
 
+## Version 2.9.0 - February 22, 2026
+
+### 🎯 Smarter Speaker Matching
+
+**Name-Aware Voice Matching**
+- When the system identifies the same person by name across different parts of a long recording, it now uses that as a tiebreaker for voice matching
+- Previously, speakers with borderline voice similarity could end up split into separate entries even when both were clearly "Sam" — now matching names nudge the system toward merging them correctly
+- Generic labels like "Speaker 1" are ignored to prevent false merges
+
+**Better Role Recognition**
+- Speakers with roles like "Team Member", "Engineer", "Presenter", or "Consultant" are now correctly recognized as active participants
+- Previously, if someone named "Terry" was both a speaker and mentioned in conversation, their name could be rejected unless they had a role like "Host" or "Guest" — this is now fixed for 13 additional roles
+
+---
+
 ## Version 2.8.0 - February 20, 2026
 
 ### 🚀 Faster Transcription with Dedicated GPU

--- a/functions/src/__tests__/speakerReconciliation.test.ts
+++ b/functions/src/__tests__/speakerReconciliation.test.ts
@@ -547,18 +547,28 @@ describe('speakerReconciliation', () => {
 
     /**
      * Helper to create a minimal chunk artifact with embeddings.
+     * Optionally populates speaker display names for name-boost tests.
      */
     function createChunkArtifact(
       chunkIndex: number,
-      speakers: { [speakerId: string]: number[] }
+      embeddings: { [speakerId: string]: number[] },
+      speakerDisplayNames?: { [speakerId: string]: string }
     ): ChunkArtifact {
+      // Build speakers map — populate display names when the caller cares about them
+      const speakers: Record<string, { speakerId: string; displayName: string; colorIndex: number }> = {};
+      if (speakerDisplayNames) {
+        for (const [speakerId, displayName] of Object.entries(speakerDisplayNames)) {
+          speakers[speakerId] = { speakerId, displayName, colorIndex: 0 };
+        }
+      }
+
       return {
         conversationId: 'test-conv',
         userId: 'test-user',
         chunkIndex,
         totalChunks: 2,
         segments: [],
-        speakers: {},
+        speakers,
         terms: {},
         termOccurrences: [],
         topics: [],
@@ -581,7 +591,7 @@ describe('speakerReconciliation', () => {
         },
         createdAt: new Date().toISOString(),
         storagePath: `chunks/chunk-${chunkIndex}.wav`,
-        speakerEmbeddings: speakers
+        speakerEmbeddings: embeddings
       };
     }
 
@@ -719,6 +729,139 @@ describe('speakerReconciliation', () => {
           // Over-fragmentation detected - should have triggered relaxation
           expect(result.relaxationTriggered).toBe(true);
         }
+      });
+    });
+
+    describe('name boost behavior', () => {
+      it('should apply name boost and produce higher similarity for same-name cross-chunk pairs', () => {
+        // Use very similar embeddings (score: 0.95) so the merge is clear and robust
+        // against the noise in generateEmbedding. The key behavior tested here is:
+        // (a) nameBoostCount is non-zero when names match, and
+        // (b) named speakers merge while a sanity check verifies boost was applied.
+        const embeddingA = generateEmbedding(8001);
+        const embeddingB = generateEmbedding(8002, { to: embeddingA, score: 0.95 });
+
+        const chunkArtifacts = [
+          createChunkArtifact(0, { SPEAKER_00: embeddingA }, { SPEAKER_00: 'Sam Wachtel' }),
+          createChunkArtifact(1, { SPEAKER_00: embeddingB }, { SPEAKER_00: 'Sam Wachtel' })
+        ];
+
+        const resultNoNames = reconcileSpeakersWithEmbeddings([
+          createChunkArtifact(0, { SPEAKER_00: embeddingA }),
+          createChunkArtifact(1, { SPEAKER_00: embeddingB })
+        ]);
+
+        const result = reconcileSpeakersWithEmbeddings(chunkArtifacts);
+
+        // Named run must have applied exactly one boost (the cross-chunk same-name pair)
+        expect(result.nameBoostCount).toBe(1);
+        // Unnamed run must have applied zero boosts
+        expect(resultNoNames.nameBoostCount).toBe(0);
+
+        // With score: 0.95, the embeddings are close enough to merge in both cases
+        expect(result.clusterDetails.length).toBe(1);
+        expect(result.speakerIdMap.get('SPEAKER_00_chunk0')).toBe(result.speakerIdMap.get('SPEAKER_00_chunk1'));
+      });
+
+      it('should NOT merge speakers with low embedding similarity when names differ', () => {
+        const embeddingA = generateEmbedding(8011);
+        const embeddingB = generateEmbedding(8012, { to: embeddingA, score: 0.50 });
+
+        const chunkArtifacts = [
+          createChunkArtifact(0, { SPEAKER_00: embeddingA }, { SPEAKER_00: 'Alice' }),
+          createChunkArtifact(1, { SPEAKER_00: embeddingB }, { SPEAKER_00: 'Bob' })
+        ];
+
+        const result = reconcileSpeakersWithEmbeddings(chunkArtifacts);
+
+        // Different names — no boost — they stay separate
+        expect(result.nameBoostCount).toBe(0);
+        expect(result.clusterDetails.length).toBe(2);
+      });
+
+      it('should NOT boost generic placeholder names like "Speaker 1" or "Unknown"', () => {
+        const embeddingA = generateEmbedding(8021);
+        const embeddingB = generateEmbedding(8022, { to: embeddingA, score: 0.50 });
+        const embeddingC = generateEmbedding(8023, { to: embeddingA, score: 0.50 });
+
+        const chunkArtifacts = [
+          createChunkArtifact(0, { SPEAKER_00: embeddingA }, { SPEAKER_00: 'Speaker 1' }),
+          createChunkArtifact(1, { SPEAKER_00: embeddingB }, { SPEAKER_00: 'Speaker 1' }),
+          createChunkArtifact(2, { SPEAKER_00: embeddingC }, { SPEAKER_00: 'Unknown' })
+        ];
+
+        const result = reconcileSpeakersWithEmbeddings(chunkArtifacts);
+
+        // Generic names are skip-listed — zero boosts, all clusters stay separate
+        expect(result.nameBoostCount).toBe(0);
+      });
+
+      it('should strip role suffixes before comparing names', () => {
+        // "Sam (New Team Member)" and "Sam (expert)" should both normalize to "sam"
+        // The key behavior: nameBoostCount is 1 (boost fired) vs 0 (no boost without names).
+        // We use score: 0.95 for reliable cosine, not to test the merge-on-boost edge case.
+        const embeddingA = generateEmbedding(8031);
+        const embeddingB = generateEmbedding(8032, { to: embeddingA, score: 0.95 });
+
+        const chunkArtifacts = [
+          createChunkArtifact(0, { SPEAKER_00: embeddingA }, { SPEAKER_00: 'Sam (New Team Member)' }),
+          createChunkArtifact(1, { SPEAKER_00: embeddingB }, { SPEAKER_00: 'Sam (expert)' })
+        ];
+
+        const resultNoNames = reconcileSpeakersWithEmbeddings([
+          createChunkArtifact(0, { SPEAKER_00: embeddingA }),
+          createChunkArtifact(1, { SPEAKER_00: embeddingB })
+        ]);
+
+        const result = reconcileSpeakersWithEmbeddings(chunkArtifacts);
+
+        // Role suffixes stripped — "sam" === "sam" — boost fires once
+        expect(result.nameBoostCount).toBe(1);
+        // No display names → no boost
+        expect(resultNoNames.nameBoostCount).toBe(0);
+
+        // Both runs should merge (score is high enough without the boost too),
+        // but the named run proves the normalization worked
+        expect(result.clusterDetails.length).toBe(1);
+      });
+
+      it('should NOT boost same-chunk speaker pairs even when names match', () => {
+        // Two speakers in the SAME chunk happen to be named the same — that's two
+        // different people, not a cross-chunk identity match. Don't boost them.
+        const embeddingA = generateEmbedding(8041);
+        const embeddingB = generateEmbedding(8042, { to: embeddingA, score: 0.50 });
+
+        // Both in chunk 0
+        const chunkArtifacts = [
+          createChunkArtifact(0, {
+            SPEAKER_00: embeddingA,
+            SPEAKER_01: embeddingB
+          }, {
+            SPEAKER_00: 'Alex',
+            SPEAKER_01: 'Alex' // Different Alex, same chunk
+          })
+        ];
+
+        const result = reconcileSpeakersWithEmbeddings(chunkArtifacts);
+
+        // Same-chunk guard fires — no boost applied
+        expect(result.nameBoostCount).toBe(0);
+      });
+
+      it('should report nameBoostCount of zero when no speakers have display names', () => {
+        // Existing test pattern — chunk artifacts with empty speakers maps
+        // (the original createChunkArtifact call with no display names)
+        const embeddingA = generateEmbedding(8051);
+        const embeddingB = generateEmbedding(8052, { to: embeddingA, score: 0.50 });
+
+        const chunkArtifacts = [
+          createChunkArtifact(0, { SPEAKER_00: embeddingA }),   // no display names
+          createChunkArtifact(1, { SPEAKER_00: embeddingB })    // no display names
+        ];
+
+        const result = reconcileSpeakersWithEmbeddings(chunkArtifacts);
+
+        expect(result.nameBoostCount).toBe(0);
       });
     });
 

--- a/functions/src/chunkMerge.ts
+++ b/functions/src/chunkMerge.ts
@@ -659,9 +659,14 @@ export async function mergeChunks(conversationId: string): Promise<void> {
       };
 
       // Build extended reconciliation metadata for observability
+      const embeddingSignals: string[] = ['embeddings'];
+      if (reconciliationMethod === 'embeddings' && reconciliationResult.nameBoostCount > 0) {
+        embeddingSignals.push('names');
+      }
+
       reconciliationMetadata = {
         signalsUsed: reconciliationMethod === 'embeddings'
-          ? ['embeddings']
+          ? embeddingSignals
           : ['name', 'topic', 'term'],
         fallbackTriggered: false,
         speakerMatchConfidences: reconciliationResult.clusterDetails.map((c: any) => ({
@@ -676,7 +681,8 @@ export async function mergeChunks(conversationId: string): Promise<void> {
           estimatedUniqueSpeakers: reconciliationResult.estimatedUniqueSpeakers,
           relaxationTriggered: reconciliationResult.relaxationTriggered,
           finalEdgeThreshold: reconciliationResult.finalEdgeThreshold,
-          relaxationIterations: reconciliationResult.relaxationIterations
+          relaxationIterations: reconciliationResult.relaxationIterations,
+          nameBoostCount: reconciliationResult.nameBoostCount
         })
       };
 

--- a/functions/src/speakerReconciliationEmbeddings.ts
+++ b/functions/src/speakerReconciliationEmbeddings.ts
@@ -50,6 +50,8 @@ export interface EmbeddingReconciliationResult {
   finalEdgeThreshold: number;
   /** Number of relaxation iterations performed */
   relaxationIterations: number;
+  /** Number of cross-chunk same-name pairs that received a similarity boost */
+  nameBoostCount: number;
 }
 
 export interface EmbeddingClusterDetails {
@@ -107,6 +109,14 @@ export const EmbeddingReconciliationConfig = {
    * from reconciliation to prevent low-quality audio from causing false merges.
    */
   QUALITY_FLOOR: 0.3,
+
+  /**
+   * Name boost: added to cross-chunk similarity when both speakers share the same
+   * normalized display name. Treats confirmed identity as a tiebreaker nudge —
+   * won't rescue truly incompatible embeddings, but helps borderline pairs merge.
+   * Capped at 1.0 to keep values sane.
+   */
+  NAME_BOOST: 0.15,
 };
 
 // ============================================================================
@@ -130,6 +140,92 @@ function estimateUniqueSpeakers(chunkArtifacts: ChunkArtifact[]): number {
   }
 
   return maxUniqueSpeakers;
+}
+
+/**
+ * Normalize a speaker display name for same-identity comparison.
+ *
+ * Strips parenthesized role suffixes (e.g. "Sam (New Team Member)" → "sam"),
+ * lowercases, and trims whitespace. Returns null for generic placeholder names
+ * like "Speaker 1" or "Unknown" — boosting those would merge every anonymous
+ * speaker in a meeting, which is exactly the wrong thing.
+ */
+function normalizeSpeakerName(displayName: string): string | null {
+  if (!displayName) return null;
+
+  // Generic names that tell us nothing about identity — skip them
+  if (/^speaker\s*\d*/i.test(displayName.trim()) || /^unknown$/i.test(displayName.trim())) {
+    return null;
+  }
+
+  // Strip parenthesized role/title suffixes: "Sam (Lead Engineer)" → "Sam"
+  const stripped = displayName.replace(/\s*\([^)]*\)\s*/g, '').trim().toLowerCase();
+
+  return stripped.length > 0 ? stripped : null;
+}
+
+/**
+ * Apply name-based similarity boosts to cross-chunk speaker pairs.
+ *
+ * When two speakers from different chunks share the same normalized display name,
+ * we nudge their similarity up by NAME_BOOST. This helps borderline pairs that
+ * voice embeddings alone can't confidently merge — especially when audio quality
+ * is uneven across chunks. Won't rescue truly different speakers (the embedding
+ * signal is still dominant), but it's a useful tiebreaker.
+ *
+ * Same-chunk pairs are deliberately excluded — two different people named "Alex"
+ * in the same chunk should stay separate, and embedding similarity already handles
+ * the cross-chunk case when voices are clearly different.
+ *
+ * @returns Total number of boosts applied (for observability)
+ */
+function applyNameBoosts(
+  similarityMatrix: number[][],
+  entries: EmbeddingEntry[],
+  chunkArtifacts: ChunkArtifact[]
+): number {
+  let boostCount = 0;
+
+  for (let i = 0; i < entries.length; i++) {
+    for (let j = i + 1; j < entries.length; j++) {
+      // Same-chunk pairs are never merged anyway — skip the lookup overhead
+      if (entries[i].chunkIndex === entries[j].chunkIndex) continue;
+
+      // Look up display names from the chunk artifacts
+      const artifactI = chunkArtifacts.find(a => a.chunkIndex === entries[i].chunkIndex);
+      const artifactJ = chunkArtifacts.find(a => a.chunkIndex === entries[j].chunkIndex);
+
+      if (!artifactI || !artifactJ) continue;
+
+      const speakerI = artifactI.speakers[entries[i].speakerId];
+      const speakerJ = artifactJ.speakers[entries[j].speakerId];
+
+      if (!speakerI?.displayName || !speakerJ?.displayName) continue;
+
+      const nameI = normalizeSpeakerName(speakerI.displayName);
+      const nameJ = normalizeSpeakerName(speakerJ.displayName);
+
+      if (!nameI || !nameJ || nameI !== nameJ) continue;
+
+      // Same normalized name in different chunks — apply the boost, cap at 1.0
+      const before = similarityMatrix[i][j];
+      const boosted = Math.min(1.0, before + EmbeddingReconciliationConfig.NAME_BOOST);
+      similarityMatrix[i][j] = boosted;
+      similarityMatrix[j][i] = boosted;
+
+      console.log('[EmbeddingReconciliation] Name boost applied:', {
+        entryI: entries[i].originalId,
+        entryJ: entries[j].originalId,
+        name: nameI,
+        before: before.toFixed(3),
+        after: boosted.toFixed(3)
+      });
+
+      boostCount++;
+    }
+  }
+
+  return boostCount;
 }
 
 /**
@@ -161,7 +257,8 @@ export function reconcileSpeakersWithEmbeddings(
       estimatedUniqueSpeakers: 0,
       relaxationTriggered: false,
       finalEdgeThreshold: 0,
-      relaxationIterations: 0
+      relaxationIterations: 0,
+      nameBoostCount: 0
     };
   }
 
@@ -191,6 +288,13 @@ export function reconcileSpeakersWithEmbeddings(
   console.log('[EmbeddingReconciliation] Applied temporal/boundary boosts:', {
     speakerAppearanceCount: speakerAppearances.size,
     chunkBoundsCount: chunkBounds.size
+  });
+
+  // Step 3.6: Apply name-based similarity boosts for cross-chunk same-name pairs
+  const nameBoostCount = applyNameBoosts(similarityMatrix, embeddingEntries, chunkArtifacts);
+
+  console.log('[EmbeddingReconciliation] Applied name boosts:', {
+    nameBoostCount
   });
 
   // Step 4: Iterative agglomerative clustering with adaptive thresholds
@@ -345,7 +449,8 @@ export function reconcileSpeakersWithEmbeddings(
     cohesionThreshold: cohesionThreshold.toFixed(3),
     qualityExclusions,
     relaxationTriggered,
-    relaxationIterations
+    relaxationIterations,
+    nameBoostCount
   });
 
   return {
@@ -359,7 +464,8 @@ export function reconcileSpeakersWithEmbeddings(
     estimatedUniqueSpeakers,
     relaxationTriggered,
     finalEdgeThreshold: edgeThreshold,
-    relaxationIterations
+    relaxationIterations,
+    nameBoostCount
   };
 }
 

--- a/functions/src/transcribe.ts
+++ b/functions/src/transcribe.ts
@@ -3203,7 +3203,9 @@ function mergeWhisperXAndGeminiData(
           // EXCEPTION: If we have a speaker role (host, guest, interviewer, etc.), trust the identification
           // because someone can be both a speaker AND mentioned (e.g., Bill Gates being interviewed)
           const hasConfirmingRole = speakerNote.role &&
-            ['host', 'guest', 'interviewer', 'interviewee', 'speaker', 'expert', 'panelist', 'moderator', 'co-host']
+            ['host', 'guest', 'interviewer', 'interviewee', 'speaker', 'expert', 'panelist', 'moderator', 'co-host',
+             'presenter', 'participant', 'team member', 'lead', 'consultant', 'facilitator', 'analyst', 'manager',
+             'director', 'engineer', 'developer', 'designer', 'owner']
               .some(role => speakerNote.role!.toLowerCase().includes(role));
 
           if (mentionedPeopleNames.has(inferredLower) && !hasConfirmingRole) {

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -505,6 +505,8 @@ export interface ReconciliationMetadata {
   finalEdgeThreshold?: number;
   /** Number of relaxation iterations performed */
   relaxationIterations?: number;
+  /** Number of cross-chunk same-name pairs that received a similarity boost */
+  nameBoostCount?: number;
 }
 
 // =============================================================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audio-transcript-analysis-app",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audio-transcript-analysis-app",
-      "version": "2.7.1",
+      "version": "2.8.0",
       "dependencies": {
         "@google/genai": "^1.33.0",
         "dotenv": "^17.2.3",
@@ -236,7 +236,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -631,7 +630,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -675,7 +673,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -697,8 +694,7 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.14.tgz",
       "integrity": "sha512-3DB258dhqdsArOI1fIt7cb9RpUOgcDg5hXWVgVHAeqVQ/qxtFy605QKs4gx6mFq3jWsSPqDN8TgSEsqC3OfV9Q==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-tools": {
       "version": "0.2.19",
@@ -1461,7 +1457,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.13.tgz",
       "integrity": "sha512-OZiDAEK/lDB6xy/XzYAyJJkaDqmQ+BCtOEPLqFvxWKUz5JbBmej7IiiRHdtiIOD/twW7O5AxVsfaaGA/V1bNsA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.9",
         "@firebase/logger": "0.4.2",
@@ -1519,7 +1514,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.43.tgz",
       "integrity": "sha512-HM96ZyIblXjAC7TzE8wIk2QhHlSvksYkQ4Ukh1GmEenzkucSNUmUX4QvoKrqeWsLEQ8hdcojABeCV8ybVyZmeg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.10.13",
         "@firebase/component": "0.6.9",
@@ -1532,8 +1526,7 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.2.tgz",
       "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/app/node_modules/idb": {
       "version": "7.1.1",
@@ -1972,7 +1965,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
       "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -3399,7 +3391,6 @@
       "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.7",
         "ajv": "^8.17.1",
@@ -3785,7 +3776,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4750,7 +4740,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5026,7 +5017,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5190,7 +5180,6 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -5564,7 +5553,6 @@
       "integrity": "sha512-rkoPH+RqWopVxDnCBE/ysIdfQ2A7j1eDmW8tCxxrR9nnFBa9jKf86VgsSAzxBd1x+ny0GC4JgiD3SNfRHv3pOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.16",
         "fflate": "^0.8.2",
@@ -5639,7 +5627,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6433,7 +6420,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7690,7 +7676,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/csv-parse": {
       "version": "5.6.0",
@@ -8044,7 +8031,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -8171,6 +8159,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/end-of-stream": {
@@ -8417,7 +8416,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8900,7 +8898,6 @@
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -12187,6 +12184,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -12298,7 +12296,6 @@
       "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -14364,7 +14361,6 @@
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -14484,7 +14480,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14536,7 +14531,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14612,7 +14606,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14708,6 +14701,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -14723,6 +14717,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -14733,6 +14728,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15060,7 +15056,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15070,7 +15065,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15117,7 +15111,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -15285,8 +15278,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -16983,7 +16975,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17400,7 +17391,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -17476,7 +17466,6 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",
@@ -18169,7 +18158,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-transcript-analysis-app",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Release v2.9.0

### Added
- **Name-Boosted Speaker Reconciliation** — Cross-chunk same-name pairs get a configurable similarity boost (default 0.15), helping borderline voice matches merge when identity is confirmed by name. Normalizes names by stripping role suffixes, skips generic placeholders, only boosts cross-chunk pairs. Per-boost logging and `nameBoostCount` in reconciliation metadata for observability.

### Changed
- **Expanded Speaker Role Recognition** — 13 active-participant roles added to the People-list confirming-role whitelist (team member, presenter, engineer, consultant, etc.). Fixes cases where speakers with these roles were incorrectly rejected.

## Test Plan
- [x] TypeScript build clean (`tsc` exits 0)
- [x] 30/30 unit tests pass (24 existing + 6 new name-boost tests)
- [x] Pre-commit hooks pass (ESLint, Prettier, TypeScript, secrets detection)
- [ ] Deploy to staging and re-process a multi-speaker conversation to verify improved clustering

---
Scope: `speaker_recon_name_boost`
Iteration: `iteration_01`
Tag: `v2.9.0`
Build: `29`