### PR TITLE
chore(release): v2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.1] - 2026-02-23
+
+### Fixed
+- **Sentence-Boundary Diarization Errors** - Improved boundary repair and speaker correction for segments that split mid-sentence
+  - `fixSegmentBoundaries()` now runs both forward and reverse passes, catching trailing fragments and comma/semicolon splits (max 40 chars)
+  - Gemini speaker corrections now support `split` actions alongside `reassign`, using sentence-text anchors instead of character positions
+  - `applySpeakerReassignments()` upgraded to a 4-phase pipeline: reassign → split (max 3, guarded) → merge adjacent same-speaker → reindex
+  - Five guard rails prevent invalid splits: index validity, speaker validity, anchor presence, sentence punctuation, and minimum 20-char halves
+
 ## [2.9.0] - 2026-02-22
 
 ### Added

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -1,5 +1,20 @@
 # What's New
 
+## Version 2.9.1 - February 23, 2026
+
+### 🐛 More Accurate Speaker Boundaries
+
+**Cleaner Sentence Breaks**
+- Transcript segments now break at natural sentence boundaries more reliably
+- Previously, a segment could start or end mid-sentence (e.g., "Yeah. So what I was" cut off from "saying is...") — now trailing fragments are moved to where they belong
+- The system also catches smaller fragments after commas and semicolons
+
+**Smarter Speaker Corrections**
+- When the AI detects that a segment contains speech from two different people, it can now split the segment at the sentence boundary instead of just reassigning the whole thing
+- Invalid splits are safely skipped — no risk of garbled or missing text
+
+---
+
 ## Version 2.9.0 - February 22, 2026
 
 ### 🎯 Smarter Speaker Matching

--- a/functions/src/__tests__/segmentBoundaries.test.ts
+++ b/functions/src/__tests__/segmentBoundaries.test.ts
@@ -1,0 +1,570 @@
+/**
+ * Unit tests for segment boundary repair and speaker correction application.
+ *
+ * Tests cover:
+ * - fixSegmentBoundaries: forward pass (leading fragment to prev segment)
+ * - fixSegmentBoundaries: comma/semicolon secondary pattern
+ * - fixSegmentBoundaries: reverse pass (trailing fragment to next segment)
+ * - fixSegmentBoundaries: no-op cases (fragment too long, same speaker, starter threshold)
+ * - fixSegmentBoundaries: timestamp interpolation correctness
+ * - applySpeakerReassignments: reassign action
+ * - applySpeakerReassignments: split at sentence boundary with guarded validation
+ * - applySpeakerReassignments: max 3 splits enforced
+ * - applySpeakerReassignments: graceful skip on invalid corrections
+ * - applySpeakerReassignments: adjacent same-speaker merge after split
+ * - applySpeakerReassignments: mixed reassign + split
+ * - applySpeakerReassignments: sequential re-indexing after corrections
+ */
+
+// Mock every Firebase/GCP module before any import that touches index.ts.
+// These functions don't need any of that infrastructure — we just need the
+// module to load without blowing up on missing credentials.
+jest.mock('firebase-admin/app', () => ({
+  initializeApp: jest.fn(),
+  getApp: jest.fn(),
+  cert: jest.fn()
+}));
+
+jest.mock('firebase-admin/firestore', () => ({
+  getFirestore: jest.fn(() => ({})),
+  FieldValue: { serverTimestamp: jest.fn() }
+}));
+
+jest.mock('firebase-admin/storage', () => ({
+  getStorage: jest.fn(() => ({
+    bucket: jest.fn(() => ({
+      file: jest.fn(),
+      upload: jest.fn()
+    }))
+  }))
+}));
+
+jest.mock('@google-cloud/vertexai', () => ({
+  VertexAI: jest.fn(() => ({
+    getGenerativeModel: jest.fn()
+  })),
+  SchemaType: {
+    OBJECT: 'object',
+    ARRAY: 'array',
+    STRING: 'string',
+    INTEGER: 'integer',
+    BOOLEAN: 'boolean'
+  }
+}));
+
+jest.mock('firebase-functions/v2/storage', () => ({
+  onObjectFinalized: jest.fn()
+}));
+
+jest.mock('firebase-functions/params', () => ({
+  defineSecret: jest.fn(() => ({ value: jest.fn(() => 'mock-secret') }))
+}));
+
+jest.mock('../index', () => ({
+  db: {},
+  bucket: { file: jest.fn(), upload: jest.fn() }
+}));
+
+// Silence noisy module-level console.log from index.ts and version loading
+jest.mock('../progressManager', () => ({ ProgressManager: jest.fn(), ProcessingStep: {} }));
+jest.mock('../alignment', () => ({
+  transcribeWithWhisperX: jest.fn(),
+  transcribeWithWhisperXRobust: jest.fn()
+}));
+jest.mock('../metrics', () => ({
+  recordMetrics: jest.fn(),
+  calculateCost: jest.fn(),
+}));
+jest.mock('../userEvents', () => ({ recordUserEvent: jest.fn() }));
+jest.mock('../chunking', () => ({
+  chunkAudioFile: jest.fn(),
+  cleanupChunks: jest.fn(),
+  reencodeForPlayback: jest.fn()
+}));
+jest.mock('../chunkBounds', () => ({ validateChunkSequence: jest.fn() }));
+jest.mock('../chunkContext', () => ({
+  createInitialChunkStatuses: jest.fn(),
+  sanitizeForFirestore: jest.fn()
+}));
+jest.mock('../speakerQuality', () => ({
+  computeSpeakerQualityMapFromWhisperXSegments: jest.fn()
+}));
+jest.mock('../utils/llmMetadata', () => ({ buildGeminiLabels: jest.fn(() => ({})) }));
+
+// Now it's safe to pull in the functions under test
+import { fixSegmentBoundaries, applySpeakerReassignments } from '../transcribe';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Seg = { text: string; startMs: number; endMs: number; speakerId: string; index: number };
+
+function makeSeg(index: number, speakerId: string, text: string, startMs: number, endMs: number): Seg {
+  return { index, speakerId, text, startMs, endMs };
+}
+
+// ---------------------------------------------------------------------------
+// fixSegmentBoundaries
+// ---------------------------------------------------------------------------
+
+describe('fixSegmentBoundaries', () => {
+  describe('forward pass — leading fragment moves to previous segment', () => {
+    it('moves a sentence-ending fragment at the start of a new-speaker segment', () => {
+      const segs = [
+        makeSeg(0, 'A', 'And then she left.', 0, 1000),
+        makeSeg(1, 'B', 'walked out. But I stayed behind and kept working.', 1000, 3000)
+      ];
+      const result = fixSegmentBoundaries(segs);
+
+      // "walked out." should move to speaker A; "But I stayed..." stays with B
+      expect(result[0].speakerId).toBe('A');
+      expect(result[0].text).toContain('walked out.');
+      expect(result[1].speakerId).toBe('B');
+      expect(result[1].text).toMatch(/^But I stayed/);
+    });
+
+    it('moves a comma/semicolon fragment under the secondary pattern (short enough)', () => {
+      const segs = [
+        makeSeg(0, 'A', 'Right, I see.', 0, 1000),
+        // "yeah, sure." is <= 40 chars and ends before "Anyway" (new-speaker content)
+        makeSeg(1, 'B', 'yeah, sure. Anyway this is the real topic here.', 1000, 3000)
+      ];
+      const result = fixSegmentBoundaries(segs);
+
+      expect(result[0].text).toContain('yeah, sure.');
+      expect(result[1].text).toMatch(/^Anyway/);
+    });
+
+    it('does NOT move a fragment exceeding MAX_FRAGMENT_CHARS (80 chars)', () => {
+      // Build a fragment that is definitely > 80 chars: 78 'A's + "xyz." = 82 chars
+      // The lazy primary regex will stop at the first "." in "xyz." — so the fragment
+      // captured is all 82 chars. That exceeds MAX_FRAGMENT_CHARS (80).
+      const longFrag = 'A'.repeat(78) + 'xyz.';
+      const segs = [
+        makeSeg(0, 'A', 'Blah blah.', 0, 1000),
+        makeSeg(1, 'B', longFrag + ' Something else entirely different from speaker B now.', 1000, 4000)
+      ];
+      const result = fixSegmentBoundaries(segs);
+
+      // Nothing moved — original text preserved
+      expect(result[1].text).toBe(segs[1].text);
+    });
+
+    it('does NOT move a sentence-starter fragment longer than 25 chars', () => {
+      // "The quick brown fox jumped." is 27 chars and starts with "The" → rejected
+      const segs = [
+        makeSeg(0, 'A', 'Right okay.', 0, 1000),
+        makeSeg(1, 'B', 'The quick brown fox jumped over. And the rest belongs to B too.', 1000, 3000)
+      ];
+      const result = fixSegmentBoundaries(segs);
+
+      expect(result[1].text).toBe(segs[1].text);
+    });
+
+    it('DOES move a short sentence-starter fragment (≤ 25 chars)', () => {
+      // "So yeah." is 8 chars — under the 25-char threshold → should move
+      const segs = [
+        makeSeg(0, 'A', 'Mmm hmm.', 0, 500),
+        makeSeg(1, 'B', 'So yeah. That is actually what happened back then.', 500, 2500)
+      ];
+      const result = fixSegmentBoundaries(segs);
+
+      expect(result[0].text).toContain('So yeah.');
+      expect(result[1].text).toMatch(/^That is actually/);
+    });
+
+    it('skips adjacent same-speaker segments', () => {
+      const segs = [
+        makeSeg(0, 'A', 'First part of A.', 0, 1000),
+        makeSeg(1, 'A', 'continued. And then more from A.', 1000, 2000)
+      ];
+      const result = fixSegmentBoundaries(segs);
+
+      expect(result[0].text).toBe(segs[0].text);
+      expect(result[1].text).toBe(segs[1].text);
+    });
+
+    it('interpolates timestamps correctly after forward move', () => {
+      const segs = [
+        makeSeg(0, 'A', 'Hello world.', 0, 1000),
+        makeSeg(1, 'B', 'done. The rest of it here.', 1000, 3000)
+      ];
+      const result = fixSegmentBoundaries(segs);
+
+      // "done." = 5 chars; full text = 26 chars → ratio ≈ 5/26
+      const fragLen = 'done.'.length;
+      const totalLen = 'done. The rest of it here.'.length;
+      const expectedBoundary = 1000 + Math.floor(2000 * (fragLen / totalLen));
+
+      expect(result[0].endMs).toBe(expectedBoundary);
+      expect(result[1].startMs).toBe(expectedBoundary);
+    });
+  });
+
+  describe('reverse pass — trailing fragment moves to next segment', () => {
+    it('moves a trailing orphan after the last sentence end to the next segment', () => {
+      // Segment A ends with "main point." followed by "but also this" (short trailing blob)
+      const segs = [
+        makeSeg(0, 'A', 'I wanted to make the main point. but also this', 0, 2000),
+        makeSeg(1, 'B', 'is actually important to consider.', 2000, 3000)
+      ];
+      const result = fixSegmentBoundaries(segs);
+
+      expect(result[0].text.trimEnd()).toMatch(/main point\.$/);
+      expect(result[1].text).toMatch(/^but also this/);
+    });
+
+    it('does NOT move a trailing fragment over 80 chars', () => {
+      const longTrail = 'b'.repeat(85);
+      const segs = [
+        makeSeg(0, 'A', `Good sentence. ${longTrail}`, 0, 3000),
+        makeSeg(1, 'B', 'And now speaker B talks.', 3000, 5000)
+      ];
+      const result = fixSegmentBoundaries(segs);
+
+      expect(result[0].text).toBe(segs[0].text);
+      expect(result[1].text).toBe(segs[1].text);
+    });
+
+    it('skips same-speaker adjacent pairs in reverse pass', () => {
+      const segs = [
+        makeSeg(0, 'A', 'One sentence. trailing bit', 0, 2000),
+        makeSeg(1, 'A', 'Continues on.', 2000, 3000)
+      ];
+      const result = fixSegmentBoundaries(segs);
+
+      expect(result[0].text).toBe(segs[0].text);
+      expect(result[1].text).toBe(segs[1].text);
+    });
+
+    it('interpolates timestamps correctly after reverse move', () => {
+      // "keep" must be >= MIN_REMAINING_CHARS (20) so the guard passes.
+      // "I really wanted this indeed." = 29 chars (keep)
+      // "trailing bit" = 12 chars (moved to next segment)
+      // Total = "I really wanted this indeed. trailing bit" = 41 chars
+      const segText = 'I really wanted this indeed. trailing bit';
+      const segs = [
+        makeSeg(0, 'A', segText, 0, 4100),
+        makeSeg(1, 'B', 'speaker B content here.', 4100, 6000)
+      ];
+      const result = fixSegmentBoundaries(segs);
+
+      const keepLen = 'I really wanted this indeed.'.length; // 28
+      const totalLen = segText.length;                       // 41
+      const expectedBoundary = 0 + Math.floor(4100 * (keepLen / totalLen));
+
+      expect(result[0].endMs).toBe(expectedBoundary);
+      expect(result[1].startMs).toBe(expectedBoundary);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns single segment unchanged', () => {
+      const segs = [makeSeg(0, 'A', 'Solo speaker here.', 0, 1000)];
+      expect(fixSegmentBoundaries(segs)).toEqual(segs);
+    });
+
+    it('returns empty array unchanged', () => {
+      expect(fixSegmentBoundaries([])).toEqual([]);
+    });
+
+    it('re-indexes segments after moves', () => {
+      const segs = [
+        makeSeg(5, 'A', 'First.', 0, 1000),
+        makeSeg(6, 'B', 'bleed. Real second segment content here.', 1000, 2000)
+      ];
+      const result = fixSegmentBoundaries(segs);
+      result.forEach((seg, idx) => expect(seg.index).toBe(idx));
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applySpeakerReassignments
+// ---------------------------------------------------------------------------
+
+const SPEAKERS = ['SPEAKER_00', 'SPEAKER_01'];
+
+function makeCorrection(
+  segmentIndex: number,
+  action: 'reassign' | 'split',
+  opts: {
+    newSpeaker?: string;
+    splitAfterSentence?: string;
+    speakerBefore?: string;
+    speakerAfter?: string;
+    reason?: string;
+  } = {}
+) {
+  return {
+    segmentIndex,
+    action,
+    reason: opts.reason ?? 'test correction',
+    newSpeaker: opts.newSpeaker,
+    splitAfterSentence: opts.splitAfterSentence,
+    speakerBefore: opts.speakerBefore,
+    speakerAfter: opts.speakerAfter
+  };
+}
+
+describe('applySpeakerReassignments', () => {
+  describe('reassign action', () => {
+    it('reassigns a whole segment to a different speaker', () => {
+      const segs = [
+        makeSeg(0, 'SPEAKER_00', 'This is the first segment.', 0, 1000),
+        makeSeg(1, 'SPEAKER_00', 'Actually this belongs to speaker one.', 1000, 2000)
+      ];
+      const result = applySpeakerReassignments(segs, [
+        makeCorrection(1, 'reassign', { newSpeaker: 'SPEAKER_01' })
+      ], SPEAKERS);
+
+      expect(result[1].speakerId).toBe('SPEAKER_01');
+      expect(result[0].speakerId).toBe('SPEAKER_00');
+    });
+
+    it('skips reassignment with unknown speaker', () => {
+      const segs = [makeSeg(0, 'SPEAKER_00', 'Segment text.', 0, 1000)];
+      const result = applySpeakerReassignments(segs, [
+        makeCorrection(0, 'reassign', { newSpeaker: 'SPEAKER_GHOST' })
+      ], SPEAKERS);
+
+      expect(result[0].speakerId).toBe('SPEAKER_00'); // unchanged
+    });
+
+    it('skips reassignment with out-of-range segment index', () => {
+      const segs = [makeSeg(0, 'SPEAKER_00', 'Segment text.', 0, 1000)];
+      const result = applySpeakerReassignments(segs, [
+        makeCorrection(99, 'reassign', { newSpeaker: 'SPEAKER_01' })
+      ], SPEAKERS);
+
+      expect(result[0].speakerId).toBe('SPEAKER_00');
+    });
+  });
+
+  describe('split action', () => {
+    it('splits at a sentence boundary with correct speakers and timestamps', () => {
+      const text = 'This is what speaker zero said. And here speaker one takes over.';
+      const segs = [makeSeg(0, 'SPEAKER_00', text, 0, 6400)];
+
+      const result = applySpeakerReassignments(segs, [
+        makeCorrection(0, 'split', {
+          splitAfterSentence: 'This is what speaker zero said.',
+          speakerBefore: 'SPEAKER_00',
+          speakerAfter: 'SPEAKER_01'
+        })
+      ], SPEAKERS);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].speakerId).toBe('SPEAKER_00');
+      expect(result[1].speakerId).toBe('SPEAKER_01');
+      expect(result[0].text).toBe('This is what speaker zero said.');
+      expect(result[1].text).toBe('And here speaker one takes over.');
+
+      // Timestamp interpolation
+      const anchorLen = 'This is what speaker zero said.'.length;
+      const totalLen = text.length;
+      const expectedSplit = Math.floor(6400 * (anchorLen / totalLen));
+      expect(result[0].endMs).toBe(expectedSplit);
+      expect(result[1].startMs).toBe(expectedSplit);
+    });
+
+    it('enforces MAX_SPLITS of 3 — 4th split correction is silently dropped', () => {
+      // To make the test deterministic about which segments got split, use alternating
+      // speakers so the SPEAKER_01 halves don't merge with SPEAKER_00 halves.
+      // After 3 splits on segs 0,1,2 (descending: 2,1,0), segment 3 is untouched.
+      // The adjacent SPEAKER_01 halves (end of each split) will merge with their
+      // SPEAKER_00 neighbours only if they share speakerId — they won't here since
+      // speakerBefore=00 and speakerAfter=01 throughout.
+      //
+      // Result structure after 3 splits + merges:
+      //   seg0-before(00) + seg1-before(00) + seg2-before(00) all merge → 1 big SPEAKER_00
+      //   BUT the 01 half of seg0 is between 00s, so they don't merge freely.
+      //   To keep the assertion simple: just check the original seg3 text appears verbatim.
+      const segs = [
+        makeSeg(0, 'SPEAKER_00', 'Alpha sentence done. Beta content here now.', 0, 4300),
+        makeSeg(1, 'SPEAKER_00', 'Charlie sentence done. Delta content here.', 4300, 8600),
+        makeSeg(2, 'SPEAKER_00', 'Echo sentence done. Foxtrot content here.', 8600, 12900),
+        makeSeg(3, 'SPEAKER_00', 'Golf sentence done. Hotel content here now.', 12900, 17200)
+      ];
+
+      const corrections = [
+        makeCorrection(0, 'split', { splitAfterSentence: 'Alpha sentence done.', speakerBefore: 'SPEAKER_00', speakerAfter: 'SPEAKER_01' }),
+        makeCorrection(1, 'split', { splitAfterSentence: 'Charlie sentence done.', speakerBefore: 'SPEAKER_00', speakerAfter: 'SPEAKER_01' }),
+        makeCorrection(2, 'split', { splitAfterSentence: 'Echo sentence done.', speakerBefore: 'SPEAKER_00', speakerAfter: 'SPEAKER_01' }),
+        makeCorrection(3, 'split', { splitAfterSentence: 'Golf sentence done.', speakerBefore: 'SPEAKER_00', speakerAfter: 'SPEAKER_01' }) // 4th → dropped
+      ];
+
+      const result = applySpeakerReassignments(segs, corrections, SPEAKERS);
+
+      // Seg 3 (the dropped one) must appear verbatim somewhere in the result
+      const seg3Text = 'Golf sentence done. Hotel content here now.';
+      const hasSeg3 = result.some(s => s.text.includes(seg3Text));
+      expect(hasSeg3).toBe(true);
+
+      // The result must have FEWER segments than if all 4 had been split (which would be 8)
+      // With MAX_SPLITS=3 and merging, we get fewer. Without the limit guard we'd have 8→more merges.
+      // The simplest assertion: result.length < 8
+      expect(result.length).toBeLessThan(8);
+    });
+
+    it('skips split when splitAfterSentence is not found in segment', () => {
+      const segs = [makeSeg(0, 'SPEAKER_00', 'Completely different text here.', 0, 3000)];
+      const result = applySpeakerReassignments(segs, [
+        makeCorrection(0, 'split', {
+          splitAfterSentence: 'This text does not exist in segment.',
+          speakerBefore: 'SPEAKER_00',
+          speakerAfter: 'SPEAKER_01'
+        })
+      ], SPEAKERS);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].speakerId).toBe('SPEAKER_00');
+    });
+
+    it('skips split when anchor does not end with sentence punctuation', () => {
+      const segs = [
+        makeSeg(0, 'SPEAKER_00', 'I was going to say something and then more content here.', 0, 5600)
+      ];
+      const result = applySpeakerReassignments(segs, [
+        makeCorrection(0, 'split', {
+          splitAfterSentence: 'I was going to say something', // no trailing . ! or ?
+          speakerBefore: 'SPEAKER_00',
+          speakerAfter: 'SPEAKER_01'
+        })
+      ], SPEAKERS);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('skips split when the before-half would be < 20 chars', () => {
+      // "Hi." is only 3 chars — too short to be a valid first half
+      const segs = [makeSeg(0, 'SPEAKER_00', 'Hi. This is the real content from speaker one here.', 0, 5100)];
+      const result = applySpeakerReassignments(segs, [
+        makeCorrection(0, 'split', {
+          splitAfterSentence: 'Hi.',
+          speakerBefore: 'SPEAKER_00',
+          speakerAfter: 'SPEAKER_01'
+        })
+      ], SPEAKERS);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('skips split when speakerBefore is unknown', () => {
+      const segs = [
+        makeSeg(0, 'SPEAKER_00', 'This is a good sentence. And here is the continuation text.', 0, 5900)
+      ];
+      const result = applySpeakerReassignments(segs, [
+        makeCorrection(0, 'split', {
+          splitAfterSentence: 'This is a good sentence.',
+          speakerBefore: 'SPEAKER_PHANTOM',
+          speakerAfter: 'SPEAKER_01'
+        })
+      ], SPEAKERS);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('skips split when speakerAfter is unknown', () => {
+      const segs = [
+        makeSeg(0, 'SPEAKER_00', 'This is a good sentence. And here is the continuation text.', 0, 5900)
+      ];
+      const result = applySpeakerReassignments(segs, [
+        makeCorrection(0, 'split', {
+          splitAfterSentence: 'This is a good sentence.',
+          speakerBefore: 'SPEAKER_00',
+          speakerAfter: 'SPEAKER_GHOST'
+        })
+      ], SPEAKERS);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('merges adjacent same-speaker segments created by a split', () => {
+      // Segment layout designed to demonstrate merge behavior clearly:
+      //   seg0: SPEAKER_01 (stays)
+      //   seg1: SPEAKER_00 (gets split → SPEAKER_00 first half, SPEAKER_01 second half)
+      //   seg2: SPEAKER_01 (stays)
+      //
+      // After split: [SPEAKER_01][SPEAKER_00][SPEAKER_01][SPEAKER_01]
+      //                                         ↑ these two merge ↑
+      // Final:       [SPEAKER_01][SPEAKER_00][SPEAKER_01(merged)]  → 3 segments
+      const segs = [
+        makeSeg(0, 'SPEAKER_01', 'Speaker one speaks first here.', 0, 3100),
+        makeSeg(1, 'SPEAKER_00', 'This belongs to zero. And this bit belongs to one.', 3100, 8100),
+        makeSeg(2, 'SPEAKER_01', 'Continuing on from speaker one now.', 8100, 11600)
+      ];
+
+      const result = applySpeakerReassignments(segs, [
+        makeCorrection(1, 'split', {
+          splitAfterSentence: 'This belongs to zero.',
+          speakerBefore: 'SPEAKER_00',
+          speakerAfter: 'SPEAKER_01'
+        })
+      ], SPEAKERS);
+
+      // Split makes 4 segments → SPEAKER_01(seg1-after) + SPEAKER_01(seg2) merge → 3 final
+      expect(result).toHaveLength(3);
+      expect(result[0].speakerId).toBe('SPEAKER_01');
+      expect(result[1].speakerId).toBe('SPEAKER_00');
+      expect(result[2].speakerId).toBe('SPEAKER_01');
+      expect(result[2].text).toContain('And this bit belongs to one.');
+      expect(result[2].text).toContain('Continuing on from speaker one now.');
+      // Merged segment spans the full combined time range
+      expect(result[2].startMs).toBeLessThan(result[2].endMs);
+    });
+
+    it('handles mixed reassign + split corrections correctly', () => {
+      const segs = [
+        makeSeg(0, 'SPEAKER_00', 'Speaker zero speaks here.', 0, 2500),
+        makeSeg(1, 'SPEAKER_00', 'First part here now. Second part here too.', 2500, 6700)
+      ];
+
+      const result = applySpeakerReassignments(segs, [
+        makeCorrection(0, 'reassign', { newSpeaker: 'SPEAKER_01' }),
+        makeCorrection(1, 'split', {
+          splitAfterSentence: 'First part here now.',
+          speakerBefore: 'SPEAKER_00',
+          speakerAfter: 'SPEAKER_01'
+        })
+      ], SPEAKERS);
+
+      // seg0 reassigned → SPEAKER_01
+      // seg1 split → SPEAKER_00 + SPEAKER_01
+      // SPEAKER_01(seg0) is adjacent to SPEAKER_00(first split half) — different, no merge
+      // SPEAKER_01(seg0) is NOT adjacent to SPEAKER_01(second split half) — they're separated
+      expect(result[0].speakerId).toBe('SPEAKER_01');
+      expect(result[1].speakerId).toBe('SPEAKER_00');
+      expect(result[2].speakerId).toBe('SPEAKER_01');
+    });
+
+    it('re-indexes all segments sequentially after corrections', () => {
+      const segs = [
+        makeSeg(0, 'SPEAKER_00', 'Alpha sentence done. Beta content here.', 0, 3900),
+        makeSeg(1, 'SPEAKER_01', 'Another segment from speaker one.', 3900, 6900)
+      ];
+      const result = applySpeakerReassignments(segs, [
+        makeCorrection(0, 'split', {
+          splitAfterSentence: 'Alpha sentence done.',
+          speakerBefore: 'SPEAKER_00',
+          speakerAfter: 'SPEAKER_01'
+        })
+      ], SPEAKERS);
+
+      // Split half (SPEAKER_01) + seg1 (SPEAKER_01) merge → 2 segments total
+      result.forEach((seg, idx) => {
+        expect(seg.index).toBe(idx);
+      });
+    });
+
+    it('returns segments unchanged when no corrections are provided', () => {
+      const segs = [
+        makeSeg(0, 'SPEAKER_00', 'Segment one.', 0, 1000),
+        makeSeg(1, 'SPEAKER_01', 'Segment two.', 1000, 2000)
+      ];
+      const result = applySpeakerReassignments(segs, [], SPEAKERS);
+      expect(result).toEqual(segs);
+    });
+  });
+});

--- a/functions/src/__tests__/speakerReconciliation.test.ts
+++ b/functions/src/__tests__/speakerReconciliation.test.ts
@@ -8,6 +8,9 @@
  * - Confidence thresholds and low-confidence errors
  * - Edge cases (empty signatures, single speaker, no overlap)
  * - Embedding-based reconciliation (singleton detection, adaptive relaxation)
+ *
+ * NOTE: fixSegmentBoundaries and applySpeakerReassignments tests live in
+ * segmentBoundaries.test.ts (separate file to isolate Firebase mock setup).
  */
 
 import { reconcileSpeakers, ReconciliationLowConfidenceError } from '../speakerReconciliation';

--- a/functions/src/transcribe.ts
+++ b/functions/src/transcribe.ts
@@ -340,7 +340,8 @@ interface SpeakerCorrection {
   action: 'split' | 'reassign';
   reason: string;
   // For split action:
-  splitAtChar?: number;
+  splitAtChar?: number;       // DEPRECATED: old char-position anchor (kept for _applySpeakerCorrections compat)
+  splitAfterSentence?: string; // NEW: sentence text anchor — find this text, split after it
   speakerBefore?: string;
   speakerAfter?: string;
   // For reassign action:
@@ -2365,89 +2366,174 @@ function groupWordSegmentsIgnoringSpeaker(
  * Heuristic: If a segment starts with a sentence fragment (text ending in
  * sentence-ending punctuation within first N chars), move it to prev segment.
  */
-function fixSegmentBoundaries(
+export function fixSegmentBoundaries(
   segments: Array<{ text: string; startMs: number; endMs: number; speakerId: string; index: number }>
 ): Array<{ text: string; startMs: number; endMs: number; speakerId: string; index: number }> {
   if (segments.length < 2) {
     return segments;
   }
 
-  const MAX_FRAGMENT_CHARS = 80;  // Only look for fragments in first 80 chars
-  const MIN_REMAINING_CHARS = 20; // Don't move if it leaves segment too short
+  const MAX_FRAGMENT_CHARS = 80;       // Forward pass: max fragment length at segment START
+  const MAX_COMMA_FRAGMENT_CHARS = 40; // Secondary pattern: comma/semicolon fragments are smaller
+  const MIN_REMAINING_CHARS = 20;      // Don't move if it leaves a stub behind
+  const MAX_REVERSE_FRAGMENT_CHARS = 80; // Reverse pass: max trailing fragment at segment END
 
-  // Regex to find sentence-ending punctuation followed by space and more text
-  // Matches: "text here. More text" or "question? Answer" or "wow! Response"
+  // Primary: sentence-ending punctuation followed by a capitalized continuation
   const fragmentPattern = /^(.+?[.!?])\s+([A-Z].*)/s;
+  // Secondary: comma or semicolon fragment at start — "well, anyway. But" style trailing clauses
+  const commaFragmentPattern = /^(.+?[,;])\s+([A-Z].*)/s;
+  // Reverse: last sentence boundary followed by short trailing text
+  const reverseFragmentPattern = /(.+[.!?])\s+(.{1,80})$/s;
 
-  let movedCount = 0;
+  let forwardCandidates = 0;
+  let forwardMoved = 0;
+  let reverseCandidates = 0;
+  let reverseMoved = 0;
   const result = [...segments];
 
+  // ---- FORWARD PASS: move leading fragment of segment[i] to segment[i-1] ----
   for (let i = 1; i < result.length; i++) {
     const current = result[i];
     const previous = result[i - 1];
 
-    // Only fix boundaries between DIFFERENT speakers
     if (current.speakerId === previous.speakerId) {
       continue;
     }
 
     const text = current.text.trim();
 
-    // Check if segment starts with a fragment (sentence ending within first N chars)
-    const match = text.match(fragmentPattern);
-    if (!match) {
+    // Try primary pattern first (sentence-ending punctuation)
+    let fragment: string | null = null;
+    let remainder: string | null = null;
+    let maxFragLen = MAX_FRAGMENT_CHARS;
+
+    const primaryMatch = text.match(fragmentPattern);
+    if (primaryMatch) {
+      fragment = primaryMatch[1];
+      remainder = primaryMatch[2];
+    } else {
+      // Try secondary: comma/semicolon fragment (tighter length limit)
+      const commaMatch = text.match(commaFragmentPattern);
+      if (commaMatch) {
+        fragment = commaMatch[1];
+        remainder = commaMatch[2];
+        maxFragLen = MAX_COMMA_FRAGMENT_CHARS;
+      }
+    }
+
+    if (!fragment || !remainder) {
       continue;
     }
 
-    const fragment = match[1];  // The part to move (e.g., "all these other things. Anyways.")
-    const remainder = match[2]; // The part to keep (e.g., "But having tools...")
+    forwardCandidates++;
 
-    // Only move if fragment is reasonably short and remainder is long enough
-    if (fragment.length > MAX_FRAGMENT_CHARS || remainder.length < MIN_REMAINING_CHARS) {
+    if (fragment.length > maxFragLen || remainder.length < MIN_REMAINING_CHARS) {
       continue;
     }
 
-    // Additional check: fragment should look like a continuation, not a complete thought
-    // Skip if fragment starts with common sentence starters
+    // Fragment starting with common sentence starters is probably intentional speech,
+    // not a dangling tail — but only reject it if it's long enough to stand alone.
+    // Threshold lowered from 40 → 25: short starter fragments are still usually bleeds.
     const startsWithSentenceStarter = /^(I|You|We|They|He|She|It|The|A|An|This|That|So|But|And|Or|If|When|What|How|Why|Where|Who)\s/i.test(fragment);
-    if (startsWithSentenceStarter && fragment.length > 40) {
-      // Longer fragments starting with sentence starters are probably intentional
+    if (startsWithSentenceStarter && fragment.length > 25) {
       continue;
     }
 
-    console.debug(`[FixBoundaries] Moving fragment from segment ${i} to ${i-1}:`, {
+    console.debug(`[FixBoundaries] Forward: moving fragment from seg ${i} to ${i-1}:`, {
       fragment: fragment.substring(0, 50) + (fragment.length > 50 ? '...' : ''),
       fromSpeaker: current.speakerId,
       toSpeaker: previous.speakerId
     });
 
-    // Calculate new timestamps (interpolate based on character ratio)
     const totalChars = current.text.length;
     const fragmentRatio = fragment.length / totalChars;
     const durationMs = current.endMs - current.startMs;
     const fragmentDurationMs = Math.floor(durationMs * fragmentRatio);
     const newBoundaryMs = current.startMs + fragmentDurationMs;
 
-    // Update previous segment: append fragment and extend end time
     result[i - 1] = {
       ...previous,
       text: previous.text.trimEnd() + ' ' + fragment,
       endMs: newBoundaryMs
     };
 
-    // Update current segment: remove fragment and adjust start time
     result[i] = {
       ...current,
       text: remainder,
       startMs: newBoundaryMs
     };
 
-    movedCount++;
+    forwardMoved++;
   }
 
-  if (movedCount > 0) {
-    console.log(`[FixBoundaries] Moved ${movedCount} sentence fragments to previous segments`);
+  // ---- REVERSE PASS: move trailing fragment of segment[i] to segment[i+1] ----
+  // Catches the mirror problem: speaker change detected early, so the start of the
+  // next speaker's thought is still appended to the current speaker's segment.
+  for (let i = 0; i < result.length - 1; i++) {
+    const current = result[i];
+    const next = result[i + 1];
+
+    if (current.speakerId === next.speakerId) {
+      continue;
+    }
+
+    const text = current.text.trim();
+
+    // Look for a sentence boundary followed by a short trailing chunk
+    const match = text.match(reverseFragmentPattern);
+    if (!match) {
+      continue;
+    }
+
+    const keep = match[1];     // Everything up to and including last sentence end
+    const trailing = match[2]; // The orphaned tail that belongs to the next segment
+
+    reverseCandidates++;
+
+    if (trailing.length > MAX_REVERSE_FRAGMENT_CHARS || keep.length < MIN_REMAINING_CHARS) {
+      continue;
+    }
+
+    // Reject if trailing starts with a sentence starter and is substantial —
+    // that suggests it's intentional content, not a bleed.
+    const trailingStartsWithStarter = /^(I|You|We|They|He|She|It|The|A|An|This|That|So|But|And|Or|If|When|What|How|Why|Where|Who)\s/i.test(trailing);
+    if (trailingStartsWithStarter && trailing.length > 25) {
+      continue;
+    }
+
+    console.debug(`[FixBoundaries] Reverse: moving trailing fragment from seg ${i} to ${i+1}:`, {
+      trailing: trailing.substring(0, 50) + (trailing.length > 50 ? '...' : ''),
+      fromSpeaker: current.speakerId,
+      toSpeaker: next.speakerId
+    });
+
+    const totalChars = current.text.length;
+    const keepRatio = keep.length / totalChars;
+    const durationMs = current.endMs - current.startMs;
+    const keepDurationMs = Math.floor(durationMs * keepRatio);
+    const newBoundaryMs = current.startMs + keepDurationMs;
+
+    result[i] = {
+      ...current,
+      text: keep,
+      endMs: newBoundaryMs
+    };
+
+    result[i + 1] = {
+      ...next,
+      text: trailing + ' ' + next.text.trimStart(),
+      startMs: newBoundaryMs
+    };
+
+    reverseMoved++;
   }
+
+  console.log('[FixBoundaries] Boundary repair complete:', {
+    forwardCandidates,
+    forwardMoved,
+    reverseCandidates,
+    reverseMoved
+  });
 
   // Re-index segments
   return result.map((seg, idx) => ({ ...seg, index: idx }));
@@ -2789,7 +2875,7 @@ async function identifySpeakerReassignments(
   const vertexAI = getVertexAIClient();
 
   // Use gemini-2.5-flash for speaker reassignment analysis
-  // Schema simplified to only support reassign (no split)
+  // Schema supports both 'reassign' (whole-segment) and 'split' (mid-segment) actions
   const model = vertexAI.getGenerativeModel({
     model: 'gemini-2.5-flash',
     generationConfig: {
@@ -2802,11 +2888,15 @@ async function identifySpeakerReassignments(
             items: {
               type: SchemaType.OBJECT,
               properties: {
-                segmentIndex: { type: SchemaType.INTEGER },
-                newSpeaker: { type: SchemaType.STRING },
-                reason: { type: SchemaType.STRING }
+                segmentIndex:       { type: SchemaType.INTEGER },
+                action:             { type: SchemaType.STRING },  // 'reassign' or 'split'
+                newSpeaker:         { type: SchemaType.STRING },  // for reassign
+                splitAfterSentence: { type: SchemaType.STRING },  // for split: last sentence of first speaker
+                speakerBefore:      { type: SchemaType.STRING },  // for split
+                speakerAfter:       { type: SchemaType.STRING },  // for split
+                reason:             { type: SchemaType.STRING }
               },
-              required: ['segmentIndex', 'newSpeaker', 'reason']
+              required: ['segmentIndex', 'action', 'reason']
             }
           }
         },
@@ -2837,7 +2927,10 @@ You are an expert at identifying speaker attribution errors in conversation tran
 
 CURRENT SPEAKER DISTRIBUTION: ${speakerDistribution}
 
-Analyze this transcript and identify segments where the ENTIRE SEGMENT is attributed to the WRONG speaker.
+Analyze this transcript and identify attribution errors. You can suggest two types of corrections:
+
+**action: "reassign"** — The ENTIRE segment belongs to a different speaker.
+**action: "split"** — ONE segment contains text from TWO different speakers (mid-segment change).
 
 Focus on these patterns that indicate MISATTRIBUTION:
 
@@ -2860,11 +2953,30 @@ Focus on these patterns that indicate MISATTRIBUTION:
    - Brief responses like "Yeah", "Mm-hmm", "Right" during someone's extended speech
    - These are often from the listener, not the speaker
 
+5. BOUNDARY BLEED:
+   - The START of a segment may contain the END of the previous speaker's thought
+   - Look for segments that begin with a short phrase or sentence ending
+   - If the first sentence reads like a continuation of the PREVIOUS segment's topic
+     but the rest is clearly from the current speaker, flag for split
+
+6. SPEAKER ISLANDS:
+   - A single short segment (< 15 words) attributed to speaker B, surrounded by
+     speaker A segments on both sides, is often a misattribution (use reassign)
+
+7. MID-SEGMENT SPEAKER CHANGES (SPLIT):
+   - If a SINGLE segment contains text from TWO different speakers, suggest splitting
+   - Provide "splitAfterSentence": the EXACT text of the last complete sentence spoken
+     by the FIRST speaker (this anchors the split point)
+   - The split MUST be at a sentence boundary (the anchor text must end with . ! or ?)
+   - Maximum 3 splits per transcript — only the most obvious cases
+   - Provide "speakerBefore" and "speakerAfter" speaker IDs for split corrections
+
 IMPORTANT GUIDELINES:
-- Only identify segments where the ENTIRE segment should be reassigned to a different speaker
-- Do NOT suggest splitting segments - only whole-segment reassignments
-- Be conservative - only flag clear errors based on conversational logic
-- Provide the newSpeaker ID (must be one of: ${speakerList})
+- Use action: "reassign" for whole-segment changes (provide "newSpeaker")
+- Use action: "split" for mid-segment speaker changes (provide "splitAfterSentence", "speakerBefore", "speakerAfter")
+- Be conservative — only flag clear errors based on conversational logic
+- All speaker IDs must be one of: ${speakerList}
+- Maximum 3 split corrections total
 
 Available speakers: ${speakerList}
 
@@ -2872,8 +2984,10 @@ Transcript (with speaker labels and segment indices):
 ${formattedTranscript}
 
 Return your analysis as JSON with an array of corrections.
-Each correction needs: segmentIndex (0-based), newSpeaker (the correct speaker ID), reason (brief explanation).
-If no corrections are needed, return an empty array.
+Each correction needs: segmentIndex (0-based), action ("reassign" or "split"), reason (brief explanation).
+For reassign: also include newSpeaker.
+For split: also include splitAfterSentence, speakerBefore, speakerAfter.
+If no corrections are needed, return an empty corrections array.
 `;
 
   console.log('[Speaker Reassignment] Analyzing transcript...', {
@@ -2909,20 +3023,38 @@ If no corrections are needed, return an empty array.
 
   // Parse response with robust error handling (fallback to no corrections on failure)
   try {
-    type ReassignResponse = { corrections: Array<{ segmentIndex: number; newSpeaker: string; reason: string }> };
-    const parsed = robustJsonParse<ReassignResponse>(responseText, 'Speaker Reassignment');
+    type CorrectionResponse = { corrections: Array<{
+      segmentIndex: number;
+      action: string;
+      newSpeaker?: string;
+      splitAfterSentence?: string;
+      speakerBefore?: string;
+      speakerAfter?: string;
+      reason: string;
+    }> };
+    const parsed = robustJsonParse<CorrectionResponse>(responseText, 'Speaker Reassignment');
 
-    // Convert to SpeakerCorrection format with action='reassign'
     const corrections: SpeakerCorrection[] = parsed.corrections.map(c => ({
       segmentIndex: c.segmentIndex,
-      action: 'reassign' as const,
+      action: (c.action === 'split' ? 'split' : 'reassign') as 'split' | 'reassign',
       reason: c.reason,
-      newSpeaker: c.newSpeaker
+      newSpeaker: c.newSpeaker,
+      splitAfterSentence: c.splitAfterSentence,
+      speakerBefore: c.speakerBefore,
+      speakerAfter: c.speakerAfter
     }));
 
+    const reassignCount = corrections.filter(c => c.action === 'reassign').length;
+    const splitCount = corrections.filter(c => c.action === 'split').length;
     console.log('[Speaker Reassignment] Analysis complete:', {
       correctionCount: corrections.length,
-      corrections: corrections.map(c => `[${c.segmentIndex}] -> ${c.newSpeaker}: ${c.reason?.substring(0, 50)}`)
+      reassignCount,
+      splitCount,
+      corrections: corrections.map(c =>
+        c.action === 'split'
+          ? `[${c.segmentIndex}] SPLIT after "${c.splitAfterSentence?.substring(0, 30)}": ${c.reason?.substring(0, 50)}`
+          : `[${c.segmentIndex}] -> ${c.newSpeaker}: ${c.reason?.substring(0, 50)}`
+      )
     });
 
     return {
@@ -2945,11 +3077,17 @@ If no corrections are needed, return an empty array.
 }
 
 /**
- * Apply speaker reassignments to segments.
- * Only changes speaker IDs - NO timestamp manipulation.
- * This is the safe version that won't cause timestamp clustering issues.
+ * Apply speaker corrections (reassignments and splits) to segments.
+ *
+ * Processing order:
+ *   1. Apply all reassignments (simple speaker ID swaps, no timestamp changes)
+ *   2. Apply up to MAX_SPLITS splits in DESCENDING index order (to keep earlier indices valid)
+ *   3. Merge adjacent same-speaker segments created/revealed by the splits
+ *   4. Re-index all segments
+ *
+ * Every split is guarded — invalid corrections are skipped with a log, never thrown.
  */
-function applySpeakerReassignments(
+export function applySpeakerReassignments(
   segments: Array<{ text: string; startMs: number; endMs: number; speakerId: string; index: number }>,
   corrections: SpeakerCorrection[],
   allSpeakers: string[]
@@ -2958,43 +3096,157 @@ function applySpeakerReassignments(
     return segments;
   }
 
-  // Only process reassign actions (ignore any split actions that might slip through)
+  const MAX_SPLITS = 3;
+  const MIN_SPLIT_HALF_CHARS = 20; // Both halves must be at least this long
+
+  // ---- Phase 1: Reassignments ----
   const reassignments = corrections.filter(c => c.action === 'reassign' && c.newSpeaker);
-
-  if (reassignments.length === 0) {
-    return segments;
-  }
-
-  const result = [...segments];
+  let result = [...segments];
 
   for (const correction of reassignments) {
     const { segmentIndex, newSpeaker } = correction;
 
-    // Validate segment index
     if (segmentIndex < 0 || segmentIndex >= result.length) {
-      console.warn(`[Speaker Reassignment] Invalid segment index ${segmentIndex}, skipping`);
+      console.warn(`[Speaker Reassignment] Invalid segment index ${segmentIndex}, skipping reassign`);
       continue;
     }
 
-    // Validate new speaker exists
     if (!allSpeakers.includes(newSpeaker!)) {
-      console.warn(`[Speaker Reassignment] Unknown speaker ${newSpeaker}, skipping`);
+      console.warn(`[Speaker Reassignment] Unknown speaker "${newSpeaker}", skipping reassign`);
       continue;
     }
 
     const oldSpeaker = result[segmentIndex].speakerId;
-
-    // Only apply if actually changing speaker
     if (oldSpeaker !== newSpeaker) {
-      console.debug(`[Speaker Reassignment] Segment ${segmentIndex}: ${oldSpeaker} -> ${newSpeaker}`);
-      result[segmentIndex] = {
-        ...result[segmentIndex],
-        speakerId: newSpeaker!
-      };
+      console.debug(`[Speaker Reassignment] Seg ${segmentIndex}: ${oldSpeaker} -> ${newSpeaker}`);
+      result[segmentIndex] = { ...result[segmentIndex], speakerId: newSpeaker! };
     }
   }
 
-  return result;
+  // ---- Phase 2: Splits ----
+  // Cap at MAX_SPLITS, process descending so earlier indices stay valid
+  const splitCorrections = corrections
+    .filter(c => c.action === 'split' && c.splitAfterSentence)
+    .slice(0, MAX_SPLITS)
+    .sort((a, b) => b.segmentIndex - a.segmentIndex);
+
+  const droppedSplits = corrections.filter(c => c.action === 'split').length - splitCorrections.length;
+  if (droppedSplits > 0) {
+    console.warn(`[Speaker Reassignment] Dropped ${droppedSplits} split correction(s) exceeding MAX_SPLITS=${MAX_SPLITS}`);
+  }
+
+  for (const correction of splitCorrections) {
+    const { segmentIndex, splitAfterSentence, speakerBefore, speakerAfter } = correction;
+
+    // Guard: valid index
+    if (segmentIndex < 0 || segmentIndex >= result.length) {
+      console.warn(`[Speaker Reassignment] Invalid segment index ${segmentIndex}, skipping split`);
+      continue;
+    }
+
+    // Guard: both speakers must be known
+    if (!speakerBefore || !speakerAfter) {
+      console.warn(`[Speaker Reassignment] Split at seg ${segmentIndex} missing speakerBefore/speakerAfter, skipping`);
+      continue;
+    }
+    if (!allSpeakers.includes(speakerBefore)) {
+      console.warn(`[Speaker Reassignment] Unknown speakerBefore "${speakerBefore}" for split at seg ${segmentIndex}, skipping`);
+      continue;
+    }
+    if (!allSpeakers.includes(speakerAfter)) {
+      console.warn(`[Speaker Reassignment] Unknown speakerAfter "${speakerAfter}" for split at seg ${segmentIndex}, skipping`);
+      continue;
+    }
+
+    const segment = result[segmentIndex];
+    const anchor = splitAfterSentence!.trim();
+
+    // Guard: anchor text must exist in segment
+    const anchorPos = segment.text.indexOf(anchor);
+    if (anchorPos === -1) {
+      console.warn(`[Speaker Reassignment] splitAfterSentence not found in seg ${segmentIndex}, skipping`, {
+        anchor: anchor.substring(0, 60),
+        segmentStart: segment.text.substring(0, 60)
+      });
+      continue;
+    }
+
+    // Guard: anchor must end at a sentence boundary
+    const splitPos = anchorPos + anchor.length; // character index right after the anchor
+    const anchorEndsWithPunct = /[.!?]$/.test(anchor.trimEnd());
+    if (!anchorEndsWithPunct) {
+      console.warn(`[Speaker Reassignment] Split anchor for seg ${segmentIndex} doesn't end with sentence punctuation, skipping`, {
+        anchor: anchor.substring(0, 60)
+      });
+      continue;
+    }
+
+    const textBefore = segment.text.substring(0, splitPos).trim();
+    const textAfter = segment.text.substring(splitPos).trim();
+
+    // Guard: both halves must be substantial enough to stand alone
+    if (textBefore.length < MIN_SPLIT_HALF_CHARS || textAfter.length < MIN_SPLIT_HALF_CHARS) {
+      console.warn(`[Speaker Reassignment] Split halves too short for seg ${segmentIndex}, skipping`, {
+        beforeLen: textBefore.length,
+        afterLen: textAfter.length,
+        minRequired: MIN_SPLIT_HALF_CHARS
+      });
+      continue;
+    }
+
+    // Interpolate timestamps by character ratio
+    const totalChars = segment.text.length;
+    const charRatio = textBefore.length / totalChars;
+    const durationMs = segment.endMs - segment.startMs;
+    const splitTimeMs = segment.startMs + Math.floor(durationMs * charRatio);
+
+    console.debug(`[Speaker Reassignment] Splitting seg ${segmentIndex}:`, {
+      speakerBefore,
+      speakerAfter,
+      splitTimeMs,
+      beforeLen: textBefore.length,
+      afterLen: textAfter.length,
+      reason: correction.reason?.substring(0, 60)
+    });
+
+    const segBefore = {
+      text: textBefore,
+      startMs: segment.startMs,
+      endMs: splitTimeMs,
+      speakerId: speakerBefore,
+      index: segment.index  // placeholder — reindexed at end
+    };
+
+    const segAfter = {
+      text: textAfter,
+      startMs: splitTimeMs,
+      endMs: segment.endMs,
+      speakerId: speakerAfter,
+      index: segment.index  // placeholder
+    };
+
+    result.splice(segmentIndex, 1, segBefore, segAfter);
+  }
+
+  // ---- Phase 3: Merge adjacent same-speaker segments ----
+  // Splits can expose or create same-speaker neighbours — clean them up.
+  const merged: typeof result = [];
+  for (const seg of result) {
+    const last = merged[merged.length - 1];
+    if (last && last.speakerId === seg.speakerId) {
+      // Extend the previous segment
+      merged[merged.length - 1] = {
+        ...last,
+        text: last.text.trimEnd() + ' ' + seg.text.trimStart(),
+        endMs: seg.endMs
+      };
+    } else {
+      merged.push({ ...seg });
+    }
+  }
+
+  // ---- Phase 4: Re-index ----
+  return merged.map((seg, idx) => ({ ...seg, index: idx }));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-transcript-analysis-app",
   "private": true,
-  "version": "2.9.0",
+  "version": "2.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Release v2.9.1

### Fixed
- **Sentence-Boundary Diarization Errors** - Improved boundary repair and speaker correction for segments that split mid-sentence
  - `fixSegmentBoundaries()` now runs both forward and reverse passes, catching trailing fragments and comma/semicolon splits (max 40 chars)
  - Gemini speaker corrections now support `split` actions alongside `reassign`, using sentence-text anchors instead of character positions
  - `applySpeakerReassignments()` upgraded to a 4-phase pipeline: reassign → split (max 3, guarded) → merge adjacent same-speaker → reindex
  - Five guard rails prevent invalid splits: index validity, speaker validity, anchor presence, sentence punctuation, and minimum 20-char halves

## Files Changed
- `functions/src/transcribe.ts` — Expanded boundary repair + speaker correction pipeline (+322 / -67 lines)
- `functions/src/__tests__/segmentBoundaries.test.ts` — **New.** 28 unit tests for boundary and split behavior
- `functions/src/__tests__/speakerReconciliation.test.ts` — Updated doc comment

## Test Plan
- [x] TypeScript build clean (`npm --prefix functions run build`)
- [x] 58 tests passing (30 existing + 28 new) in 1.6s
- [x] All 5 split guard rails tested (index, speaker, anchor, punctuation, min length)
- [x] Forward + reverse boundary passes tested with edge cases
- [ ] Production verification after deploy (re-process a conversation and inspect boundary behavior)

---
Scope: `speaker_recon_boundary_fixes`
Iteration: `iteration_01`
Tag: `v2.9.1`
Build: `30`