### PR TITLE
chore(release): v2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.2] - 2026-02-25
+
+### Added
+- **Transcript Selection Mode Toggle** - Explicit opt-in selection mode resolves click ambiguity between audio navigation and multi-segment speaker reassignment
+  - Default clicks always seek audio playback — no accidental segment selection
+  - Press `S` or click the "Select" button to enter selection mode for multi-segment operations
+  - Click or Shift+Click segments to build selection, then reassign via the floating bar
+  - `Escape` exits selection mode and clears selections; "Done" button exits but preserves selections
+  - Selection count badge and mode indicator visible while selection mode is active
+  - Keyboard shortcuts (`S` toggle, `Esc` exit) added to the help modal (`?` key)
+
 ## [2.9.1] - 2026-02-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Firebase secrets (stored via Firebase Secret Manager):
 3. **Wait for Processing** - Cloud Function processes audio (1-3 min depending on length)
 4. **View Transcript** - Interactive viewer with speaker labels and timestamps
 5. **Navigate** - Click any segment to jump to that point in audio
-6. **Fix Speakers** - Click speaker badge to reassign segment to different speaker
+6. **Fix Speakers** - Press `S` to enter selection mode, click/Shift+Click segments, then reassign via the floating bar. Default clicks always seek audio.
 7. **Explore** - Use sidebar to browse terms, topics, and people mentioned
 
 ## Project Structure

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -1,5 +1,27 @@
 # What's New
 
+## Version 2.9.2 - February 25, 2026
+
+### 🎯 Selection Mode for Speaker Fixes
+
+**Clicks Do What You Expect**
+- Clicking a transcript segment now always jumps to that point in the audio — no more accidentally selecting segments when you just want to navigate
+- The previous behavior (where a click could toggle multi-select) caused confusion when you expected playback and got a purple highlight instead
+
+**Explicit Selection Mode**
+- Press `S` on your keyboard or click the "Select" button to enter selection mode
+- In selection mode, click segments to select them (purple highlight), then use the floating bar to reassign them to a different speaker
+- Shift+Click selects a range of segments at once
+- Press `Escape` to exit selection mode and clear your selections
+- Click "Done" to exit but keep your selections for later
+
+**Always Know What Mode You're In**
+- A visible indicator shows when selection mode is active
+- Selected segment count is displayed so you always know how many segments you've picked
+- The `?` help modal now lists the new `S` and `Esc` shortcuts
+
+---
+
 ## Version 2.9.1 - February 23, 2026
 
 ### 🐛 More Accurate Speaker Boundaries

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -37,42 +37,44 @@ Technical architecture of the Audio Transcript Analysis App.
 │                                                    │ onFinalized  │
 │                                                    ▼              │
 │  ┌──────────────────────────────────────────────────────────────┐ │
-│  │                    Cloud Functions                           │ │
+│  │                Cloud Functions (18 total)                    │ │
 │  │                                                              │ │
-│  │  ┌──────────────────────┐  ┌──────────────────────┐          │ │
-│  │  │  transcribeAudio     │  │  chatWithConversation│          │ │
-│  │  │  (Storage trigger)   │  │  (HTTPS callable)    │          │ │
-│  │  │  - validates file    │  └──────────────────────┘          │ │
-│  │  │  - enqueues task     │  ┌──────────────────────┐          │ │
-│  │  │  - 540s timeout      │  │  retryTranscription  │          │ │
-│  │  └──────────┬───────────┘  │  (HTTPS callable)    │          │ │
-│  │             │              └──────────────────────┘          │ │
-│  │             ▼                                                │ │
-│  │  ┌──────────────────────┐                                    │ │
-│  │  │  Cloud Tasks Queue   │                                    │ │
+│  │  ┌──────────────────────┐  ┌──────────────────────────────┐  │ │
+│  │  │  transcribeAudio     │  │  Callables (HTTPS)           │  │ │
+│  │  │  (Storage trigger)   │  │  ┌────────────────────────┐  │  │ │
+│  │  │  - validates file    │  │  │ chatWithConversation   │  │  │ │
+│  │  │  - enqueues task     │  │  │ retryTranscription     │  │  │ │
+│  │  │  - 540s timeout      │  │  │ mergeSpeakers          │  │  │ │
+│  │  └──────────┬───────────┘  │  │ reassignSegments       │  │  │ │
+│  │             │              │  │ renameSpeaker          │  │  │ │
+│  │             ▼              │  │ undoCorrection         │  │  │ │
+│  │  ┌──────────────────────┐  │  └────────────────────────┘  │  │ │
+│  │  │  Cloud Tasks Queue   │  └──────────────────────────────┘  │ │
 │  │  │  transcription-queue │                                    │ │
-│  │  └──────────┬───────────┘                                    │ │
-│  │             ▼                                                │ │
-│  │  ┌─────────────────────────────────────────────────────────┐ │ │
-│  │  │  processTranscription (HTTP Function, private)          │ │ │
-│  │  │  - 3600s timeout (60 min for large files)               │ │ │
-│  │  │  - 2GiB memory                                          │ │ │
-│  │  │  ┌────────────────┐                                     │ │ │
-│  │  │  │  alignment     │                                     │ │ │
-│  │  │  │  module        │                                     │ │ │
-│  │  │  └────────────────┘                                     │ │ │
-│  │  └──────────┬──────────────────────────────────────────────┘ │ │
-│  │             │                                                │ │
-│  └─────────────┼────────────────────────────────────────────────┘ │
-│                │                                                  │
-└────────────────┼──────────────────────────────────────────────────┘
-                 │
-         ┌───────┴───────┐
-         ▼               ▼
-┌────────────────┐  ┌────────────────┐
-│  Vertex AI     │  │  Replicate     │
-│  (Gemini)      │  │  (WhisperX)    │
-└────────────────┘  └────────────────┘
+│  │  └──────────┬───────────┘  ┌──────────────────────────────┐  │ │
+│  │             │              │  Background                  │  │ │
+│  │             ▼              │  ┌────────────────────────┐  │  │ │
+│  │  ┌────────────────────┐    │  │ onConversation*        │  │  │ │
+│  │  │  processTranscr.   │    │  │ computeDailyStats      │  │  │ │
+│  │  │  (private, 60 min) │    │  │ syncBillingCosts       │  │  │ │
+│  │  └──────────┬─────────┘    │  │ handleReconAlert       │  │  │ │
+│  │             │              │  └────────────────────────┘  │  │ │
+│  │             ▼              └──────────────────────────────┘  │ │
+│  │  ┌────────────────────┐                                      │ │
+│  │  │  processMerge      │  See cloud-functions-flow.md         │ │
+│  │  │  (private, 10 min) │  for detailed flow diagrams.        │ │
+│  │  └────────────────────┘                                      │ │
+│  │                                                              │ │
+│  └──────────────────────────────────────────────────────────────┘ │
+│                                                                   │
+└───────────────────────────────────────────────────────────────────┘
+                                 │
+                         ┌───────┴───────┐
+                         ▼               ▼
+                  ┌────────────────┐  ┌────────────────┐
+                  │  Vertex AI     │  │  Replicate     │
+                  │  (Gemini)      │  │  (WhisperX)    │
+                  └────────────────┘  └────────────────┘
 ```
 
 ## Component Architecture
@@ -174,17 +176,25 @@ audio-transcript-analysis-app/
 │       ├── TimeSeriesChart.tsx
 │       ├── LLMUsageBreakdown.tsx
 │       └── MetricsTable.tsx
-├── functions/              # Cloud Functions (Node.js)
+├── functions/              # Cloud Functions (Node.js) — 18 functions, 8 modules
 │   └── src/
-│       ├── index.ts        # Function exports
-│       ├── transcribe.ts   # WhisperX + Gemini analysis
-│       ├── alignment.ts    # WhisperX integration via Replicate
-│       ├── metrics.ts      # Processing metrics recording
-│       ├── userEvents.ts   # User activity event tracking
-│       ├── statsTriggers.ts    # Firestore triggers for stats
-│       ├── statsAggregator.ts  # Scheduled daily aggregation
-│       ├── pricing.ts      # Pricing lookup and cost calculation
-│       └── logger.ts       # Structured logging utility
+│       ├── index.ts                    # Function exports + Firebase Admin init
+│       ├── transcribe.ts               # transcribeAudio (Storage trigger) + Gemini pipeline
+│       ├── processTranscription.ts     # processTranscription (Cloud Tasks)
+│       ├── chunkMerge.ts               # processMerge + processReprocessing (Cloud Tasks)
+│       ├── chat.ts                     # chatWithConversation (HTTPS callable)
+│       ├── retry.ts                    # retryTranscription (HTTPS callable)
+│       ├── speakerCorrections.ts       # merge/reassign/rename/undo (HTTPS callables)
+│       ├── statsTriggers.ts            # onConversation* (Firestore triggers)
+│       ├── statsAggregator.ts          # computeDailyStats + triggerStatsComputation
+│       ├── billingSync.ts              # syncBillingCosts + triggerBillingSync + diagnose
+│       ├── handleReconciliationAlert.ts # Pub/Sub circuit breaker
+│       ├── alignment.ts                # WhisperX integration via Replicate
+│       ├── chunking.ts                 # Audio splitting + silence detection
+│       ├── metrics.ts                  # Processing metrics recording
+│       ├── userEvents.ts               # User activity event tracking
+│       ├── pricing.ts                  # Pricing lookup and cost calculation
+│       └── logger.ts                   # Structured logging utility
 ├── types.ts                # TypeScript types
 ├── utils.ts                # Helper functions
 └── firebase-config.ts      # Firebase initialization

--- a/docs/reference/cloud-functions-flow.md
+++ b/docs/reference/cloud-functions-flow.md
@@ -4,20 +4,45 @@ Comprehensive flow diagram showing all Google Cloud Functions, their triggers, i
 
 ## Overview
 
-The application uses **10 Cloud Functions** to handle audio processing, chat, analytics, and billing:
+The application uses **18 Cloud Functions** across 8 source modules to handle audio processing, chat, speaker corrections, analytics, billing, and alerting:
 
-| Function | Trigger | Memory | Timeout | Purpose |
-|----------|---------|--------|---------|---------|
-| `transcribeAudio` | Storage `onObjectFinalized` | 2GiB | 9 min | Entry point for uploads, chunks large files |
-| `processTranscription` | Cloud Tasks HTTP | 2GiB | 60 min | Process each chunk via Gemini + WhisperX |
-| `processMerge` | Cloud Tasks HTTP | 1GiB | 10 min | Stitch chunks, reconcile speakers |
-| `processReprocessing` | Cloud Tasks HTTP | 512MiB | 10 min | Fallback: re-chunk in sequential mode |
-| `chatWithConversation` | HTTPS Callable | 512MiB | 10 min | LLM chat with timestamp citations |
-| `retryTranscription` | HTTPS Callable | 512MiB | 60 sec | Resume or restart failed jobs |
-| `computeDailyStats` | Scheduler (2 AM) | 256MiB | 9 min | Aggregate usage statistics |
-| `syncBillingCosts` | Scheduler (4 AM) | 512MiB | 9 min | Sync actual costs from BigQuery |
-| `triggerBillingSync` | HTTPS Callable | 512MiB | 9 min | Manual billing sync trigger (admin) |
-| `diagnoseBillingLabels` | HTTPS Callable | 512MiB | 60 sec | Diagnostic for billing label issues |
+### Transcription Pipeline
+
+| Function | File | Trigger | Memory | Timeout | Purpose |
+|----------|------|---------|--------|---------|---------|
+| `transcribeAudio` | `transcribe.ts` | Storage `onObjectFinalized` | 2GiB | 9 min | Entry point for uploads, chunks large files |
+| `processTranscription` | `processTranscription.ts` | Cloud Tasks HTTP | 2GiB | 60 min | Process each chunk via Gemini + WhisperX |
+| `processMerge` | `chunkMerge.ts` | Cloud Tasks HTTP | 1GiB | 10 min | Stitch chunks, reconcile speakers |
+| `processReprocessing` | `chunkMerge.ts` | Cloud Tasks HTTP | 512MiB | 10 min | Fallback: re-chunk in sequential mode |
+
+### User-Facing Callables
+
+| Function | File | Trigger | Memory | Timeout | Purpose |
+|----------|------|---------|--------|---------|---------|
+| `chatWithConversation` | `chat.ts` | HTTPS Callable | 512MiB | 5 min | LLM chat with timestamp citations |
+| `retryTranscription` | `retry.ts` | HTTPS Callable | 512MiB | 60 sec | Resume or restart failed jobs |
+| `mergeSpeakers` | `speakerCorrections.ts` | HTTPS Callable | 256MiB | 30 sec | Merge two speakers into one |
+| `reassignSegments` | `speakerCorrections.ts` | HTTPS Callable | 256MiB | 30 sec | Move segments to a different speaker |
+| `renameSpeaker` | `speakerCorrections.ts` | HTTPS Callable | 256MiB | 30 sec | Change a speaker's display name |
+| `undoCorrection` | `speakerCorrections.ts` | HTTPS Callable | 256MiB | 30 sec | Undo a previous correction |
+
+### Stats & Analytics
+
+| Function | File | Trigger | Memory | Timeout | Purpose |
+|----------|------|---------|--------|---------|---------|
+| `onConversationCreated` | `statsTriggers.ts` | Firestore `onDocumentCreated` | default | default | Record creation event |
+| `onConversationDeleted` | `statsTriggers.ts` | Firestore `onDocumentDeleted` | default | default | Record deletion event |
+| `computeDailyStats` | `statsAggregator.ts` | Scheduler (2 AM UTC) | 512MiB | 5 min | Aggregate usage statistics |
+| `triggerStatsComputation` | `statsAggregator.ts` | HTTPS Callable | 512MiB | 5 min | Manual stats trigger (admin) |
+
+### Billing & Alerting
+
+| Function | File | Trigger | Memory | Timeout | Purpose |
+|----------|------|---------|--------|---------|---------|
+| `syncBillingCosts` | `billingSync.ts` | Scheduler (4 AM UTC) | 512MiB | 9 min | Sync actual costs from BigQuery |
+| `triggerBillingSync` | `billingSync.ts` | HTTPS Callable | 512MiB | 9 min | Manual billing sync trigger (admin) |
+| `diagnoseBillingLabels` | `billingSync.ts` | HTTPS Callable | 512MiB | 60 sec | Diagnostic for billing label issues |
+| `handleReconciliationAlert` | `handleReconciliationAlert.ts` | Pub/Sub `reconciliation-alerts` | 256MB | 60 sec | Auto-disable reconciliation on errors |
 
 ## Complete Flow Diagram
 
@@ -30,16 +55,16 @@ The application uses **10 Cloud Functions** to handle audio processing, chat, an
 │ CLIENT (React App)                                                              │
 │                                                                                 │
 │  ┌────────────────┐  ┌────────────────┐  ┌────────────────┐  ┌───────────────┐ │
-│  │ Upload         │  │ chatWith       │  │ getSignedUrl   │  │ retry         │ │
-│  │ Audio File     │  │ Conversation   │  │ (Callable)     │  │ Transcription │ │
+│  │ Upload         │  │ chatWith       │  │ Speaker        │  │ retry         │ │
+│  │ Audio File     │  │ Conversation   │  │ Corrections    │  │ Transcription │ │
 │  └───────┬────────┘  └───────┬────────┘  └───────┬────────┘  └───────┬───────┘ │
 │          │                   │                   │                   │         │
 └──────────┼───────────────────┼───────────────────┼───────────────────┼─────────┘
            │                   │                   │                   │
            ▼                   ▼                   ▼                   ▼
 ┌────────────────────┐ ┌────────────────────┐ ┌────────────────────┐ ┌────────────────────┐
-│ Firebase Storage   │ │ Gemini API         │ │ Firebase Storage   │ │ Cloud Tasks        │
-│ (audio/{userId})   │ │ + Firestore        │ │ (signed URL)       │ │ Queue              │
+│ Firebase Storage   │ │ Gemini API         │ │ Firestore          │ │ Cloud Tasks        │
+│ (audio/{userId})   │ │ + Firestore        │ │ (corrections sub)  │ │ Queue              │
 └─────────┬──────────┘ └────────────────────┘ └────────────────────┘ └─────────┬──────────┘
           │                                                                    │
           │ onObjectFinalized                                                  │
@@ -115,7 +140,7 @@ The application uses **10 Cloud Functions** to handle audio processing, chat, an
                                                     ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │ processMerge (Cloud Tasks HTTP)                                             │
-│ Memory: 512MiB | Timeout: 10 min                                            │
+│ Memory: 1GiB | Timeout: 10 min                                               │
 │ ┌─────────────────────────────────────────────────────────────────────────┐ │
 │ │ 1. Load all chunk artifacts from subcollection                          │ │
 │ │ 2. Deduplicate segments in overlap regions                              │ │
@@ -167,10 +192,32 @@ The application uses **10 Cloud Functions** to handle audio processing, chat, an
                                               └────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────────────┐
-│ SUPPORTING FUNCTIONS                                                            │
+│ SPEAKER CORRECTIONS (speakerCorrections.ts)                                     │
+│ All: HTTPS Callable | 256MiB | 30 sec | Apply-on-read pattern                  │
+│                                                                                 │
+│  Client (Viewer page)                                                           │
+│          │                                                                      │
+│          ├─► mergeSpeakers ──────► speakerCorrections/{id} (type: merge)        │
+│          │   Merge speaker A into B                                             │
+│          │                                                                      │
+│          ├─► reassignSegments ──► speakerCorrections/{id} (type: reassign)      │
+│          │   Move segments to a different speaker                               │
+│          │                                                                      │
+│          ├─► renameSpeaker ─────► speakerCorrections/{id} (type: rename)        │
+│          │   Change display name (validated: non-empty, <50 chars)              │
+│          │                                                                      │
+│          └─► undoCorrection ────► Sets undoneAt timestamp (preserves audit)     │
+│                                                                                 │
+│  Client applies corrections at read time — no reprocessing needed.              │
+│  Server replays active corrections to validate new operations.                  │
+└─────────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│ STATS & ANALYTICS                                                               │
 │                                                                                 │
 │ ┌─────────────────────────┐ ┌─────────────────────────┐ ┌─────────────────────┐ │
 │ │ onConversationCreated   │ │ onConversationDeleted   │ │ computeDailyStats   │ │
+│ │ statsTriggers.ts        │ │ statsTriggers.ts        │ │ statsAggregator.ts  │ │
 │ │ (Firestore trigger)     │ │ (Firestore trigger)     │ │ (Scheduler: 2AM)    │ │
 │ │                         │ │                         │ │                     │ │
 │ │ Records user event      │ │ Records user event      │ │ Aggregates global & │ │
@@ -183,7 +230,29 @@ The application uses **10 Cloud Functions** to handle audio processing, chat, an
 └─────────────────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────────────┐
+│ RECONCILIATION ALERTING (handleReconciliationAlert.ts)                           │
+│ Pub/Sub: reconciliation-alerts | 256MB | 60 sec                                 │
+│                                                                                 │
+│  Cloud Monitoring                                                               │
+│  (log-based metric: reconciliation errors > 5% in 5 min)                        │
+│          │                                                                      │
+│          ▼                                                                      │
+│  Alert policy fires ──► Pub/Sub topic: reconciliation-alerts                    │
+│                                    │                                            │
+│                                    ▼                                            │
+│                         handleReconciliationAlert                               │
+│                                    │                                            │
+│                                    ▼                                            │
+│                         Disables context-aware reconciliation                   │
+│                         (feature flag in Firestore)                             │
+│                                                                                 │
+│  On OPEN incident: auto-disables to prevent cascading failures.                 │
+│  Manual re-enable required after investigation.                                 │
+└─────────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────────┐
 │ RETRY FLOW (retryTranscription → Cloud Tasks)                                   │
+│ retry.ts | HTTPS Callable | 512MiB | 60 sec                                    │
 │                                                                                 │
 │  Failed/Aborted Job                                                             │
 │          │                                                                      │
@@ -319,14 +388,48 @@ Allows users to retry failed or aborted jobs.
 - Max 3 retries enforced
 - Increments `taskGeneration` to invalidate stale Cloud Tasks
 
-### 7. Stats Functions
+### 7. Speaker Correction Functions
+
+**File:** `functions/src/speakerCorrections.ts`
+
+Four lightweight callables that let users fix diarization errors from the Viewer UI. All use the **apply-on-read pattern**: corrections are written to a `speakerCorrections` subcollection and the client applies them at read time (no reprocessing required). The server replays active corrections before each write to validate operations against the effective speaker state.
+
+- **`mergeSpeakers`**: Merge speaker A into speaker B (all A's segments become B's)
+- **`reassignSegments`**: Move specific segments to a different speaker
+- **`renameSpeaker`**: Change a speaker's display name (validated: non-empty, <50 chars)
+- **`undoCorrection`**: Mark a correction as undone (sets `undoneAt` timestamp, preserves audit trail)
+
+**Shared Characteristics:**
+- Auth required, ownership verified
+- 256MiB memory, 30 sec timeout
+- Returns `correctionId` for undo tracking (except `undoCorrection`)
+
+### 8. Stats Functions
 
 **Files:** `functions/src/statsTriggers.ts`, `functions/src/statsAggregator.ts`
 
-- `onConversationCreated`: Records user event on conversation creation
-- `onConversationDeleted`: Records user event on conversation deletion
-- `computeDailyStats`: Scheduled (2 AM UTC) aggregation of global and daily stats
-- `triggerStatsComputation`: Admin manual trigger for stats computation
+- `onConversationCreated`: Firestore trigger — records user event on conversation creation
+- `onConversationDeleted`: Firestore trigger — records user event on conversation deletion
+- `computeDailyStats`: Scheduled (2 AM UTC) — aggregates rolling windows (7-day, 30-day active users), processing stats, LLM usage
+- `triggerStatsComputation`: HTTPS Callable — admin manual trigger, same logic as scheduled version
+
+### 9. handleReconciliationAlert (Pub/Sub)
+
+**File:** `functions/src/handleReconciliationAlert.ts`
+
+Circuit breaker that auto-disables context-aware speaker reconciliation when Cloud Monitoring detects elevated error rates.
+
+**Alert Pipeline:**
+1. Log-based metric counts `reconciliation_error` events
+2. Alert policy fires when error rate exceeds 5% in a 5-minute window
+3. Alert publishes to `reconciliation-alerts` Pub/Sub topic
+4. This function receives the alert and disables the feature flag in Firestore
+
+**Behavior:**
+- On `OPEN` incident: disables context-aware reconciliation to prevent cascading failures
+- On `CLOSED` incident: logs only (manual re-enable required after investigation)
+
+**Setup:** Requires manual creation of Pub/Sub topic, log-based metrics, and alert policy (documented in rollout runbook).
 
 ## Billing Sync Functions (v2.2.0+)
 

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -168,7 +168,7 @@ interface SpeakerCorrectionDoc {
 - Persists across reloads and devices
 - **Merge workflow**: Click merge button → Select target speaker → Confirm
 - **Reassign workflow (single segment)**: Right-click/long-press segment → Select target speaker
-- **Reassign workflow (multiple segments)**: Shift+Click to select range → Choose target speaker from floating bar
+- **Reassign workflow (multiple segments)**: Press `S` to enter selection mode → Click/Shift+Click to select segments → Choose target speaker from floating bar → Press `Escape` or click "Done" to exit
 - **Rename workflow**: Double-click speaker name in sidebar → Edit inline → Enter to save, Escape to cancel
 - Non-destructive (original data unchanged)
 - Audit trail preserved even after undo

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-transcript-analysis-app",
   "private": true,
-  "version": "2.9.1",
+  "version": "2.9.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/__tests__/components/viewer/TranscriptView.test.tsx
+++ b/src/__tests__/components/viewer/TranscriptView.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * Tests for TranscriptView selection mode gating
+ *
+ * Verifies that clicks behave differently based on isSelectionMode:
+ * - Navigation mode (default): clicks seek audio
+ * - Selection mode: clicks toggle segment selection
+ * - Clear signal resets all selections
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TranscriptView } from '@/components/viewer/TranscriptView';
+import { Conversation } from '@/config/types';
+
+// Minimal conversation fixture — just enough to render without blowing up
+const makeConversation = (segmentCount = 3): Conversation => ({
+  conversationId: 'test-convo',
+  userId: 'user1',
+  title: 'Test Conversation',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  durationMs: 60000,
+  status: 'complete',
+  speakers: {
+    s1: { speakerId: 's1', displayName: 'Alice', colorIndex: 0 },
+    s2: { speakerId: 's2', displayName: 'Bob', colorIndex: 1 }
+  },
+  segments: Array.from({ length: segmentCount }, (_, i) => ({
+    segmentId: `seg-${i}`,
+    index: i,
+    speakerId: i % 2 === 0 ? 's1' : 's2',
+    startMs: i * 5000,
+    endMs: (i + 1) * 5000,
+    text: `Segment ${i} text content here`
+  })),
+  terms: {},
+  termOccurrences: [],
+  topics: [],
+  people: []
+});
+
+describe('TranscriptView - Selection Mode Gating', () => {
+  const defaultProps = {
+    conversation: makeConversation(),
+    activeSegmentIndex: -1,
+    personOccurrences: {} as Record<string, { start: number; end: number; personId: string }[]>,
+    onSeek: vi.fn(),
+    onTermClick: vi.fn(),
+    onRenameSpeaker: vi.fn(),
+    onReassignSpeaker: vi.fn(),
+    onReassignSegments: vi.fn()
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders segments in navigation mode by default', () => {
+    render(<TranscriptView {...defaultProps} />);
+
+    // All segments should render
+    expect(screen.getByText('Segment 0 text content here')).toBeInTheDocument();
+    expect(screen.getByText('Segment 1 text content here')).toBeInTheDocument();
+    expect(screen.getByText('Segment 2 text content here')).toBeInTheDocument();
+  });
+
+  it('shows compact Select button when not in selection mode', () => {
+    render(<TranscriptView {...defaultProps} isSelectionMode={false} />);
+
+    expect(screen.getByText('Select')).toBeInTheDocument();
+  });
+
+  it('calls onToggleSelectionMode when Select button is clicked', () => {
+    const onToggle = vi.fn();
+    render(
+      <TranscriptView
+        {...defaultProps}
+        isSelectionMode={false}
+        onToggleSelectionMode={onToggle}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Select'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows full selection bar with "Click segments to select" when in selection mode with no selections', () => {
+    render(
+      <TranscriptView
+        {...defaultProps}
+        isSelectionMode={true}
+      />
+    );
+
+    expect(screen.getByText('Click segments to select')).toBeInTheDocument();
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  it('shows Done button that calls onToggleSelectionMode', () => {
+    const onToggle = vi.fn();
+    render(
+      <TranscriptView
+        {...defaultProps}
+        isSelectionMode={true}
+        onToggleSelectionMode={onToggle}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Done'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears selections when selectionClearSignal increments', () => {
+    const { rerender } = render(
+      <TranscriptView
+        {...defaultProps}
+        isSelectionMode={true}
+        selectionClearSignal={0}
+      />
+    );
+
+    // Click a segment to select it (first non-active segment div)
+    const segmentDivs = document.querySelectorAll('[class*="border-l-"]');
+    fireEvent.click(segmentDivs[0]);
+
+    // Should show "1 segment selected"
+    expect(screen.getByText('1 segment selected')).toBeInTheDocument();
+
+    // Bump the clear signal
+    rerender(
+      <TranscriptView
+        {...defaultProps}
+        isSelectionMode={true}
+        selectionClearSignal={1}
+      />
+    );
+
+    // Should show zero-selection prompt again
+    expect(screen.getByText('Click segments to select')).toBeInTheDocument();
+  });
+
+  it('shows segment count after clicking in selection mode', () => {
+    render(
+      <TranscriptView
+        {...defaultProps}
+        isSelectionMode={true}
+      />
+    );
+
+    // Click first segment
+    const segmentDivs = document.querySelectorAll('[class*="border-l-"]');
+    fireEvent.click(segmentDivs[0]);
+
+    expect(screen.getByText('1 segment selected')).toBeInTheDocument();
+
+    // Click second segment
+    fireEvent.click(segmentDivs[1]);
+
+    expect(screen.getByText('2 segments selected')).toBeInTheDocument();
+  });
+
+  it('shows Reassign dropdown when segments are selected in selection mode', () => {
+    render(
+      <TranscriptView
+        {...defaultProps}
+        isSelectionMode={true}
+      />
+    );
+
+    // Click a segment to select it
+    const segmentDivs = document.querySelectorAll('[class*="border-l-"]');
+    fireEvent.click(segmentDivs[0]);
+
+    // Reassign button should appear
+    expect(screen.getByText('Reassign to...')).toBeInTheDocument();
+  });
+
+  it('toggles selection off with second click in selection mode', () => {
+    render(
+      <TranscriptView
+        {...defaultProps}
+        isSelectionMode={true}
+      />
+    );
+
+    const segmentDivs = document.querySelectorAll('[class*="border-l-"]');
+
+    // Select
+    fireEvent.click(segmentDivs[0]);
+    expect(screen.getByText('1 segment selected')).toBeInTheDocument();
+
+    // Deselect
+    fireEvent.click(segmentDivs[0]);
+    expect(screen.getByText('Click segments to select')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/__tests__/hooks/useKeyboardShortcuts.test.tsx
@@ -173,4 +173,104 @@ describe('useKeyboardShortcuts', () => {
 
     expect(result.current.helpModalOpen).toBe(false);
   });
+
+  it('should call toggleSelectionMode on S key', () => {
+    const toggleSelectionMode = vi.fn();
+    renderHook(() => useKeyboardShortcuts({
+      togglePlay: vi.fn(),
+      seekBack: vi.fn(),
+      seekForward: vi.fn(),
+      toggleSelectionMode
+    }));
+
+    const event = new KeyboardEvent('keydown', { key: 's' });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(toggleSelectionMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call toggleSelectionMode on uppercase S key', () => {
+    const toggleSelectionMode = vi.fn();
+    renderHook(() => useKeyboardShortcuts({
+      togglePlay: vi.fn(),
+      seekBack: vi.fn(),
+      seekForward: vi.fn(),
+      toggleSelectionMode
+    }));
+
+    const event = new KeyboardEvent('keydown', { key: 'S' });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(toggleSelectionMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call toggleSelectionMode when typing in input field', () => {
+    const toggleSelectionMode = vi.fn();
+    renderHook(() => useKeyboardShortcuts({
+      togglePlay: vi.fn(),
+      seekBack: vi.fn(),
+      seekForward: vi.fn(),
+      toggleSelectionMode
+    }));
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    const event = new KeyboardEvent('keydown', { key: 's', bubbles: true });
+    Object.defineProperty(event, 'target', { value: input, enumerable: true });
+
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(toggleSelectionMode).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+
+  it('should call exitSelectionMode on Escape when help modal is closed', () => {
+    const exitSelectionMode = vi.fn();
+    renderHook(() => useKeyboardShortcuts({
+      togglePlay: vi.fn(),
+      seekBack: vi.fn(),
+      seekForward: vi.fn(),
+      exitSelectionMode
+    }));
+
+    const event = new KeyboardEvent('keydown', { key: 'Escape' });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(exitSelectionMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close help modal on Escape before calling exitSelectionMode', () => {
+    const exitSelectionMode = vi.fn();
+    const { result } = renderHook(() => useKeyboardShortcuts({
+      togglePlay: vi.fn(),
+      seekBack: vi.fn(),
+      seekForward: vi.fn(),
+      exitSelectionMode
+    }));
+
+    // Open help modal first
+    const openEvent = new KeyboardEvent('keydown', { key: '?' });
+    act(() => {
+      document.dispatchEvent(openEvent);
+    });
+    expect(result.current.helpModalOpen).toBe(true);
+
+    // Escape should close modal, NOT call exitSelectionMode
+    const escEvent = new KeyboardEvent('keydown', { key: 'Escape' });
+    act(() => {
+      document.dispatchEvent(escEvent);
+    });
+
+    expect(result.current.helpModalOpen).toBe(false);
+    expect(exitSelectionMode).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/viewer/KeyboardShortcutsModal.tsx
+++ b/src/components/viewer/KeyboardShortcutsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { X, Play, SkipBack, SkipForward, HelpCircle } from 'lucide-react';
+import { X, Play, SkipBack, SkipForward, HelpCircle, MousePointerClick } from 'lucide-react';
 
 interface KeyboardShortcutsModalProps {
   isOpen: boolean;
@@ -39,6 +39,13 @@ export const KeyboardShortcutsModal: React.FC<KeyboardShortcutsModalProps> = ({
         { keys: ['Space'], description: 'Play / Pause', icon: <Play size={16} /> },
         { keys: ['←', 'J'], description: 'Seek back 5 seconds', icon: <SkipBack size={16} /> },
         { keys: ['→', 'K'], description: 'Seek forward 5 seconds', icon: <SkipForward size={16} /> }
+      ]
+    },
+    {
+      category: 'Selection',
+      items: [
+        { keys: ['S'], description: 'Toggle selection mode', icon: <MousePointerClick size={16} /> },
+        { keys: ['Esc'], description: 'Exit selection & clear', icon: <X size={16} /> }
       ]
     },
     {

--- a/src/components/viewer/TranscriptSegment.tsx
+++ b/src/components/viewer/TranscriptSegment.tsx
@@ -309,7 +309,7 @@ export const TranscriptSegment: React.FC<TranscriptSegmentProps> = ({
                 </span>
               );
             }
-            return <span key={i} onClick={() => onSeek(segment.startMs + 1)} className="cursor-pointer">{part.text}</span>;
+            return <span key={i} onClick={onSegmentClick ? undefined : () => onSeek(segment.startMs + 1)} className={onSegmentClick ? undefined : "cursor-pointer"}>{part.text}</span>;
           })}
         </p>
       </div>

--- a/src/components/viewer/TranscriptSelectionBar.tsx
+++ b/src/components/viewer/TranscriptSelectionBar.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Speaker } from '@/config/types';
 import { SPEAKER_DOT_COLORS } from '@/config/constants';
-import { X, ChevronDown } from 'lucide-react';
+import { X, ChevronDown, MousePointerClick } from 'lucide-react';
 import { cn } from '@/utils';
 
 interface TranscriptSelectionBarProps {
   selectedSegmentIds: Set<string>;
   allSpeakers: Speaker[];
+  isSelectionMode?: boolean;
+  onToggleSelectionMode?: () => void;
   onReassign: (toSpeakerId: string) => void;
   onClear: () => void;
 }
@@ -14,12 +16,16 @@ interface TranscriptSelectionBarProps {
 /**
  * TranscriptSelectionBar - Floating action bar for multi-segment operations
  *
- * Appears when segments are selected via Shift+Click.
- * Provides UI for bulk reassignment to a different speaker.
+ * Three-state rendering:
+ * 1. Not in selection mode, no selections → compact "Select" toggle button
+ * 2. In selection mode (0 or more selections) → full bar with controls
+ * 3. Not in selection mode, selections exist → "Resume" bar with count
  */
 export const TranscriptSelectionBar: React.FC<TranscriptSelectionBarProps> = ({
   selectedSegmentIds,
   allSpeakers,
+  isSelectionMode = false,
+  onToggleSelectionMode,
   onReassign,
   onClear
 }) => {
@@ -40,64 +46,153 @@ export const TranscriptSelectionBar: React.FC<TranscriptSelectionBarProps> = ({
     }
   }, [showDropdown]);
 
+  // Close dropdown when exiting selection mode
+  useEffect(() => {
+    if (!isSelectionMode) {
+      setShowDropdown(false);
+    }
+  }, [isSelectionMode]);
+
   const handleSpeakerSelect = (speakerId: string) => {
     onReassign(speakerId);
     setShowDropdown(false);
   };
 
-  if (selectedSegmentIds.size === 0) return null;
+  const count = selectedSegmentIds.size;
 
+  // State 1: Not in selection mode, no selections → compact toggle button
+  if (!isSelectionMode && count === 0) {
+    return (
+      <div className="fixed bottom-20 right-4 z-30 animate-in fade-in duration-200">
+        <button
+          onClick={onToggleSelectionMode}
+          className="flex items-center gap-2 px-3 py-2 bg-slate-800 hover:bg-slate-700 text-white text-sm rounded-lg shadow-lg transition-colors"
+          title="Enter selection mode (S)"
+        >
+          <MousePointerClick size={16} />
+          <span>Select</span>
+        </button>
+      </div>
+    );
+  }
+
+  // State 3: Not in selection mode, but selections exist → resume bar
+  if (!isSelectionMode && count > 0) {
+    return (
+      <div
+        className="fixed bottom-20 left-1/2 -translate-x-1/2 z-30 bg-slate-800 text-white rounded-lg shadow-2xl px-4 py-3 flex items-center gap-3 animate-in slide-in-from-bottom duration-200"
+        style={{ minWidth: '280px' }}
+      >
+        <div className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-full bg-purple-500 flex items-center justify-center text-xs font-semibold">
+            {count}
+          </div>
+          <span className="text-sm text-slate-300">
+            {count === 1 ? 'segment selected' : 'segments selected'}
+          </span>
+        </div>
+
+        <div className="flex-1" />
+
+        <button
+          onClick={onToggleSelectionMode}
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-purple-600 hover:bg-purple-500 rounded text-sm font-medium transition-colors"
+        >
+          <MousePointerClick size={14} />
+          Resume
+        </button>
+
+        <button
+          onClick={onClear}
+          className="p-1.5 hover:bg-slate-700 rounded transition-colors"
+          aria-label="Clear selection"
+          title="Clear selection"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    );
+  }
+
+  // State 2: In selection mode → full bar with all controls
   return (
     <div
       className="fixed bottom-20 left-1/2 -translate-x-1/2 z-30 bg-slate-900 text-white rounded-lg shadow-2xl px-4 py-3 flex items-center gap-4 animate-in slide-in-from-bottom duration-200"
-      style={{ minWidth: '320px' }}
+      style={{ minWidth: '340px' }}
     >
-      {/* Selection count */}
+      {/* Mode indicator + count */}
       <div className="flex items-center gap-2">
-        <div className="w-8 h-8 rounded-full bg-blue-500 flex items-center justify-center text-sm font-semibold">
-          {selectedSegmentIds.size}
-        </div>
+        {count > 0 ? (
+          <div className="w-8 h-8 rounded-full bg-purple-500 flex items-center justify-center text-sm font-semibold">
+            {count}
+          </div>
+        ) : (
+          <div className="w-8 h-8 rounded-full bg-slate-700 flex items-center justify-center">
+            <MousePointerClick size={16} className="text-purple-400" />
+          </div>
+        )}
         <span className="text-sm font-medium">
-          {selectedSegmentIds.size === 1 ? '1 segment selected' : `${selectedSegmentIds.size} segments selected`}
+          {count === 0
+            ? 'Click segments to select'
+            : count === 1
+              ? '1 segment selected'
+              : `${count} segments selected`}
         </span>
       </div>
 
-      {/* Reassign dropdown */}
-      <div className="flex-1 relative" ref={dropdownRef}>
-        <button
-          onClick={() => setShowDropdown(!showDropdown)}
-          className="w-full px-3 py-1.5 bg-slate-700 hover:bg-slate-600 rounded text-sm flex items-center justify-between gap-2 transition-colors"
-        >
-          <span>Reassign to...</span>
-          <ChevronDown size={14} className={cn("transition-transform", showDropdown && "rotate-180")} />
-        </button>
+      {/* Reassign dropdown — only when segments are selected */}
+      {count > 0 && (
+        <div className="flex-1 relative" ref={dropdownRef}>
+          <button
+            onClick={() => setShowDropdown(!showDropdown)}
+            className="w-full px-3 py-1.5 bg-slate-700 hover:bg-slate-600 rounded text-sm flex items-center justify-between gap-2 transition-colors"
+          >
+            <span>Reassign to...</span>
+            <ChevronDown size={14} className={cn("transition-transform", showDropdown && "rotate-180")} />
+          </button>
 
-        {showDropdown && (
-          <div className="absolute bottom-full left-0 right-0 mb-2 bg-white text-slate-900 border border-slate-200 rounded-lg shadow-lg max-h-64 overflow-y-auto">
-            <div className="px-3 py-2 text-xs text-slate-500 border-b border-slate-100 font-medium">
-              Select speaker:
+          {showDropdown && (
+            <div className="absolute bottom-full left-0 right-0 mb-2 bg-white text-slate-900 border border-slate-200 rounded-lg shadow-lg max-h-64 overflow-y-auto">
+              <div className="px-3 py-2 text-xs text-slate-500 border-b border-slate-100 font-medium">
+                Select speaker:
+              </div>
+              {allSpeakers.map((speaker) => (
+                <button
+                  key={speaker.speakerId}
+                  onClick={() => handleSpeakerSelect(speaker.speakerId)}
+                  className="w-full px-3 py-2 text-left text-sm hover:bg-slate-50 flex items-center gap-2 transition-colors"
+                >
+                  <span className={cn("w-2 h-2 rounded-full", SPEAKER_DOT_COLORS[speaker.colorIndex % SPEAKER_DOT_COLORS.length])} />
+                  <span className="flex-1">{speaker.displayName}</span>
+                </button>
+              ))}
             </div>
-            {allSpeakers.map((speaker) => (
-              <button
-                key={speaker.speakerId}
-                onClick={() => handleSpeakerSelect(speaker.speakerId)}
-                className="w-full px-3 py-2 text-left text-sm hover:bg-slate-50 flex items-center gap-2 transition-colors"
-              >
-                <span className={cn("w-2 h-2 rounded-full", SPEAKER_DOT_COLORS[speaker.colorIndex % SPEAKER_DOT_COLORS.length])} />
-                <span className="flex-1">{speaker.displayName}</span>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
 
-      {/* Clear button */}
+      {/* Spacer when no dropdown */}
+      {count === 0 && <div className="flex-1" />}
+
+      {/* Clear button — only when segments are selected */}
+      {count > 0 && (
+        <button
+          onClick={onClear}
+          className="p-1.5 hover:bg-slate-700 rounded transition-colors"
+          aria-label="Clear selection"
+          title="Clear selection"
+        >
+          <X size={16} />
+        </button>
+      )}
+
+      {/* Exit selection mode */}
       <button
-        onClick={onClear}
-        className="p-2 hover:bg-slate-700 rounded transition-colors"
-        aria-label="Clear selection"
+        onClick={onToggleSelectionMode}
+        className="px-3 py-1.5 bg-slate-700 hover:bg-slate-600 rounded text-sm transition-colors"
+        title="Exit selection mode (Esc)"
       >
-        <X size={18} />
+        Done
       </button>
     </div>
   );

--- a/src/components/viewer/TranscriptView.tsx
+++ b/src/components/viewer/TranscriptView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { Conversation } from '@/config/types';
 import { TranscriptSegment } from './TranscriptSegment';
 import { TopicMarker } from './TopicMarker';
@@ -12,6 +12,9 @@ interface TranscriptViewProps {
   personOccurrences: Record<string, { start: number; end: number; personId: string }[]>;
   highlightedSegmentId?: string | null;
   recentReassignSegmentIds?: string[];
+  isSelectionMode?: boolean;
+  onToggleSelectionMode?: () => void;
+  selectionClearSignal?: number;
   onSeek: (ms: number) => void;
   onTermClick: (termId: string) => void;
   onRenameSpeaker: (speakerId: string) => void;
@@ -36,6 +39,9 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({
   personOccurrences,
   highlightedSegmentId,
   recentReassignSegmentIds = [],
+  isSelectionMode = false,
+  onToggleSelectionMode,
+  selectionClearSignal = 0,
   onSeek,
   onTermClick,
   onRenameSpeaker,
@@ -48,6 +54,14 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({
   // Multi-select state for bulk operations
   const [selectedSegmentIds, setSelectedSegmentIds] = useState<Set<string>>(new Set());
   const [lastSelectedIndex, setLastSelectedIndex] = useState<number | null>(null);
+
+  // Parent says "nuke the selection" by bumping this counter
+  useEffect(() => {
+    if (selectionClearSignal > 0) {
+      setSelectedSegmentIds(new Set());
+      setLastSelectedIndex(null);
+    }
+  }, [selectionClearSignal]);
 
   /**
    * Handle segment click with Shift modifier for multi-select
@@ -153,18 +167,20 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({
                 onTermClick={onTermClick}
                 onRenameSpeaker={onRenameSpeaker}
                 onReassignSpeaker={onReassignSpeaker}
-                onSegmentClick={(shiftKey) => handleSegmentClick(seg.segmentId, idx, shiftKey)}
+                onSegmentClick={isSelectionMode ? (shiftKey) => handleSegmentClick(seg.segmentId, idx, shiftKey) : undefined}
               />
             </div>
           );
         })}
       </div>
 
-      {/* Selection bar for bulk operations */}
+      {/* Selection bar for bulk operations — always rendered so the toggle button shows */}
       {onReassignSegments && (
         <TranscriptSelectionBar
           selectedSegmentIds={selectedSegmentIds}
           allSpeakers={allSpeakers}
+          isSelectionMode={isSelectionMode}
+          onToggleSelectionMode={onToggleSelectionMode}
           onReassign={handleBulkReassign}
           onClear={handleClearSelection}
         />

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -5,6 +5,8 @@ interface KeyboardShortcutsCallbacks {
   seekBack?: () => void;
   seekForward?: () => void;
   openHelp?: () => void;
+  toggleSelectionMode?: () => void;
+  exitSelectionMode?: () => void;
 }
 
 /**
@@ -14,8 +16,9 @@ interface KeyboardShortcutsCallbacks {
  * - Space: Play/Pause
  * - ← or J: Seek back 5s
  * - → or K: Seek forward 5s
+ * - S: Toggle selection mode (for multi-segment speaker reassignment)
  * - ?: Open keyboard shortcuts help modal
- * - Escape: Close modal (handled by modal components)
+ * - Escape: Exit selection mode + clear, or close modal
  *
  * Ignores events when user is typing in form fields.
  * Shows a first-time tooltip to introduce keyboard shortcuts.
@@ -84,6 +87,12 @@ export const useKeyboardShortcuts = (callbacks: KeyboardShortcutsCallbacks) => {
           }
           break;
 
+        case 's':
+        case 'S':
+          e.preventDefault();
+          callbacks.toggleSelectionMode?.();
+          break;
+
         case '?':
           e.preventDefault();
           callbacks.openHelp?.();
@@ -94,9 +103,11 @@ export const useKeyboardShortcuts = (callbacks: KeyboardShortcutsCallbacks) => {
           break;
 
         case 'Escape':
-          // Close help modal if open
+          // Help modal gets first dibs — close it before anything else
           if (helpModalOpen) {
             setHelpModalOpen(false);
+          } else {
+            callbacks.exitSelectionMode?.();
           }
           break;
       }

--- a/src/pages/Viewer.tsx
+++ b/src/pages/Viewer.tsx
@@ -59,6 +59,19 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
   const [mobileChatOpen, setMobileChatOpen] = useState(false);
   const [warningBannerDismissed, setWarningBannerDismissed] = useState(false);
 
+  // Selection mode: opt-in toggle so default clicks always navigate audio
+  const [isSelectionMode, setIsSelectionMode] = useState(false);
+  const [selectionClearSignal, setSelectionClearSignal] = useState(0);
+
+  const toggleSelectionMode = useCallback(() => {
+    setIsSelectionMode(prev => !prev);
+  }, []);
+
+  const exitSelectionModeAndClear = useCallback(() => {
+    setIsSelectionMode(false);
+    setSelectionClearSignal(prev => prev + 1);
+  }, []);
+
   // Fetch audio URL from Firebase Storage on mount
   // The URL is generated on-demand because Storage download URLs expire
   useEffect(() => {
@@ -154,7 +167,9 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
     togglePlay,
     seekBack: () => seek(currentTime - 5000),
     seekForward: () => seek(currentTime + 5000),
-    openHelp: () => {} // Modal state handled by hook
+    openHelp: () => {}, // Modal state handled by hook
+    toggleSelectionMode,
+    exitSelectionMode: exitSelectionModeAndClear
   });
 
   // Chat history persistence
@@ -502,6 +517,9 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
           personOccurrences={personOccurrences}
           highlightedSegmentId={highlightedSegmentId}
           recentReassignSegmentIds={recentReassignSegmentIds}
+          isSelectionMode={isSelectionMode}
+          onToggleSelectionMode={toggleSelectionMode}
+          selectionClearSignal={selectionClearSignal}
           onSeek={seek}
           onTermClick={handleTermClickInTranscript}
           onRenameSpeaker={handleRenameSpeaker}


### PR DESCRIPTION
## Release v2.9.2

### Added
- **Transcript Selection Mode Toggle** — Explicit opt-in selection mode resolves click ambiguity between audio navigation and multi-segment speaker reassignment
  - Default clicks always seek audio playback — no accidental segment selection
  - Press `S` or click the "Select" button to enter selection mode for multi-segment operations
  - Click or Shift+Click segments to build selection, then reassign via the floating bar
  - `Escape` exits selection mode and clears selections; "Done" button exits but preserves selections
  - Selection count badge and mode indicator visible while selection mode is active
  - Keyboard shortcuts (`S` toggle, `Esc` exit) added to the help modal (`?` key)

## Test Plan
- [x] Scoped ESLint: 0 errors, 0 warnings (9 files)
- [x] Scoped Vitest: 22/22 tests pass (TranscriptView + useKeyboardShortcuts)
- [x] Full test suite: 136/136 tests pass
- [x] TypeScript compilation: clean
- [ ] Manual: click segment in default mode → audio seeks, no selection
- [ ] Manual: press S → mode toggle visible, click segment → purple highlight
- [ ] Manual: Shift+Click → range select works
- [ ] Manual: timestamp button → seeks in both modes
- [ ] Manual: Escape → exits mode, clears selections
- [ ] Manual: reassign selected segments → workflow works

---
Scope: `speaker_reconciliation_manual_speaker_merge_08_04`
Iteration: `iteration_01`
Tag: `v2.9.2`
Build: `31`