### PR TITLE
chore(release): v2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.0] - 2026-02-27
+
+### Added
+- **Draggable Sidebar Resize** - Viewer sidebar width can now be adjusted by dragging its left edge
+  - Width persists to localStorage across sessions (default 320px, min 280px, max 50% viewport)
+  - Visual drag handle highlights blue on hover and during drag
+
 ## [2.10.0] - 2026-02-26
 
 ### Added

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -1,5 +1,16 @@
 # What's New
 
+## Version 2.11.0 - February 27, 2026
+
+### ✨ Resizable Sidebar
+
+**Drag to Fit Your Screen**
+- You can now **drag the left edge of the sidebar** to make it wider or narrower
+- Your preferred width is remembered across sessions — set it once and forget it
+- Works with any width from 280px up to half your screen
+
+---
+
 ## Version 2.10.0 - February 26, 2026
 
 ### 🚀 Faster Multi-Chunk Processing

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-transcript-analysis-app",
   "private": true,
-  "version": "2.10.0",
+  "version": "2.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,3 +7,4 @@ export { useAudioPlayer } from './useAudioPlayer';
 export { usePersonMentions } from './usePersonMentions';
 export { useTranscriptSelection } from './useTranscriptSelection';
 export { useAutoScroll } from './useAutoScroll';
+export { usePanelResize } from './usePanelResize';

--- a/src/hooks/usePanelResize.ts
+++ b/src/hooks/usePanelResize.ts
@@ -1,0 +1,100 @@
+import React, { useState, useCallback, useEffect, useRef } from 'react';
+
+const STORAGE_KEY = 'sidebar-panel-width';
+const DEFAULT_WIDTH = 320;
+const MIN_WIDTH = 280;
+// Max is 50% of viewport — computed dynamically during drag
+
+function loadWidth(): number {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = Number(stored);
+      if (Number.isFinite(parsed) && parsed >= MIN_WIDTH) return parsed;
+    }
+  } catch {
+    // localStorage unavailable (private browsing, etc.) — not the end of the world
+  }
+  return DEFAULT_WIDTH;
+}
+
+function saveWidth(width: number) {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(Math.round(width)));
+  } catch {
+    // Same as above — we tried
+  }
+}
+
+/**
+ * Drag-to-resize for a sidebar panel.
+ *
+ * Returns the current width, whether a drag is in progress, and a
+ * `handleProps` object to spread onto the drag-handle element.
+ *
+ * Width is clamped between MIN_WIDTH and 50vw and persisted to localStorage.
+ */
+export function usePanelResize() {
+  const [width, setWidth] = useState(loadWidth);
+  const [isDragging, setIsDragging] = useState(false);
+
+  // Refs let the pointermove handler read fresh values without re-subscribing
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(width);
+
+  // Persist width whenever it settles (not on every pixel of drag)
+  useEffect(() => {
+    if (!isDragging) saveWidth(width);
+  }, [isDragging, width]);
+
+  // Kill text selection while dragging — nobody wants to highlight half the page mid-resize
+  useEffect(() => {
+    if (isDragging) {
+      document.body.style.userSelect = 'none';
+      return () => { document.body.style.userSelect = ''; };
+    }
+  }, [isDragging]);
+
+  const onPointerMove = useCallback((e: PointerEvent) => {
+    // Handle moves left = sidebar grows (handle is on the left edge)
+    const dx = startXRef.current - e.clientX;
+    const maxWidth = window.innerWidth * 0.5;
+    const next = Math.min(maxWidth, Math.max(MIN_WIDTH, startWidthRef.current + dx));
+    setWidth(next);
+  }, []);
+
+  const onPointerUp = useCallback(() => {
+    setIsDragging(false);
+    document.removeEventListener('pointermove', onPointerMove);
+    document.removeEventListener('pointerup', onPointerUp);
+  }, [onPointerMove]);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      startXRef.current = e.clientX;
+      startWidthRef.current = width;
+      setIsDragging(true);
+      document.addEventListener('pointermove', onPointerMove);
+      document.addEventListener('pointerup', onPointerUp);
+    },
+    [width, onPointerMove, onPointerUp],
+  );
+
+  // Safety net: clean up listeners if the component unmounts mid-drag
+  useEffect(() => {
+    return () => {
+      document.removeEventListener('pointermove', onPointerMove);
+      document.removeEventListener('pointerup', onPointerUp);
+    };
+  }, [onPointerMove, onPointerUp]);
+
+  return {
+    width,
+    isDragging,
+    handleProps: {
+      onPointerDown,
+      style: { cursor: 'col-resize' } as React.CSSProperties,
+    },
+  };
+}

--- a/src/pages/Viewer.tsx
+++ b/src/pages/Viewer.tsx
@@ -9,6 +9,7 @@ import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import { useChat } from '../hooks/useChat';
 import { useChatHistory } from '../hooks/useChatHistory';
 import { useSpeakerCorrections } from '../hooks/useSpeakerCorrections';
+import { usePanelResize } from '../hooks/usePanelResize';
 import { ViewerHeader } from '../components/viewer/ViewerHeader';
 import { TranscriptView } from '../components/viewer/TranscriptView';
 import { Sidebar } from '../components/viewer/Sidebar';
@@ -156,6 +157,9 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
       return () => clearTimeout(timer);
     }
   }, [targetSegmentId]);
+
+  // Draggable sidebar resize
+  const { width: sidebarWidth, isDragging: isSidebarDragging, handleProps: sidebarHandleProps } = usePanelResize();
 
   // Keyboard shortcuts (Space, ←/→, J/K, ?, Escape)
   const {
@@ -528,7 +532,20 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
         />
 
         {/* Sidebar (Desktop) - use corrected speakers */}
-        <div className="hidden lg:block w-80 shrink-0 z-10 shadow-xl shadow-slate-200/50">
+        <div
+          className="hidden lg:flex shrink-0 z-10 shadow-xl shadow-slate-200/50"
+          style={{ width: sidebarWidth }}
+        >
+          {/* Drag handle — thin strip on the left edge of the sidebar */}
+          <div
+            {...sidebarHandleProps}
+            className={`w-1 shrink-0 transition-colors duration-150 ${
+              isSidebarDragging
+                ? 'bg-blue-400'
+                : 'bg-transparent hover:bg-blue-300'
+            }`}
+          />
+          <div className="flex-1 min-w-0 h-full">
           <Sidebar
             terms={Object.values(conversation.terms)}
             people={conversation.people || []}
@@ -573,6 +590,7 @@ export const Viewer: React.FC<ViewerProps> = ({ onBack, onStatsClick, targetSegm
             recentMerge={recentMerge}
             speakerSegmentCounts={speakerSegmentCounts}
           />
+          </div>
         </div>
 
         {/* Mobile Sidebar Panel - full sidebar with Context/People/Chat tabs */}


### PR DESCRIPTION
## Release v2.11.0

### Added
- **Draggable Sidebar Resize** — Viewer sidebar width can now be adjusted by dragging its left edge
  - Width persists to localStorage across sessions (default 320px, min 280px, max 50% viewport)
  - Visual drag handle highlights blue on hover and during drag

Also includes all changes from v2.10.0 (leader-chunk speaker hint propagation, name-match floor semantics, monotonic clustering threshold, broader over-fragmentation trigger).

## Upgrade Notes
No breaking changes. New feature is additive and purely client-side.

---
Scope: `speaker_recon_cross_chunk_merge_fixes-02`
Tag: `v2.11.0`
Build: `33`