### PR TITLE
chore(release): v2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.0] - 2026-03-06
+
+### Changed
+- **Fuzzy Speaker Name Matching** - Cross-chunk speaker reconciliation now uses Levenshtein distance for name comparison instead of exact string equality
+  - Catches ASR transcription variants like "Arya"/"Araya" and "Dennis"/"Denis" that were previously treated as different speakers
+  - Names 4+ characters use a ≥80% similarity threshold (~1 typo per 5 characters); names ≤3 characters require exact match to avoid false merges (e.g., "Jay" ≠ "Ray")
+  - Fuzzy matches logged with `editDistance` and `fuzzyMatchedWith` fields for observability
+
 ## [2.13.0] - 2026-03-06
 
 ### Fixed

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -1,5 +1,16 @@
 # What's New
 
+## Version 2.14.0 - March 6, 2026
+
+### 🎯 Smarter Speaker Name Matching
+
+**Fewer "Ghost" Speakers from Spelling Variants**
+- The system now recognizes that names like "Arya" and "Araya" (or "Dennis" and "Denis") are the same person, even when different audio chunks transcribe the name slightly differently
+- Previously, a single misspelled letter would create a duplicate speaker — you'd see both "Arya" and "Araya" in your transcript as separate people
+- Short names (3 characters or fewer) still require exact matches to avoid false merges — "Jay" won't accidentally merge with "Ray"
+
+---
+
 ## Version 2.13.0 - March 6, 2026
 
 ### 🐛 Better Transcript Segmentation

--- a/docs/explanation/chunk-merge.md
+++ b/docs/explanation/chunk-merge.md
@@ -7,12 +7,77 @@ This document explains the chunk merge system - the final step in processing lar
 The chunk merge system is part of the large file upload flow:
 
 ```
-Audio Upload → Chunking → Chunk Processing → Chunk Merge → Complete
-                ↓              ↓                  ↓
-           (30s overlap)  (WhisperX + Gemini)  (Deduplicate)
+Audio Upload → Chunking → Leader Dispatch → Leader Processes → Followers Dispatch → Chunk Merge → Complete
+                 ↓             ↓                  ↓                    ↓                  ↓
+            (30s overlap)  (chunk 0 only)  (extract hints)    (hints skip pre-analysis) (Deduplicate)
 ```
 
 **Purpose**: Transform multiple chunk artifacts into a single merged conversation document with no duplicates or gaps.
+
+## Leader-Chunk-First Dispatch
+
+Before chunks are merged, they must be processed. In parallel mode, processing uses a **leader-chunk-first** pattern that balances speed with speaker consistency.
+
+### Why Not Dispatch All Chunks at Once?
+
+The naive approach — dispatch all chunks simultaneously — means every chunk runs Gemini pre-analysis independently, producing potentially inconsistent speaker identities. Chunk 0 might call a speaker "Alice" while chunk 3 calls the same voice "Speaker 1". Speaker reconciliation at merge time can fix this, but the quality improves dramatically when chunks already agree on who's speaking.
+
+### How It Works
+
+```
+transcribeAudio (Storage trigger):
+    │
+    ├─ Chunk audio into N pieces
+    ├─ Upload all chunks to Storage
+    ├─ Dispatch ONLY chunk 0 (the "leader") as a Cloud Task
+    └─ Store chunks 1..N as pendingFollowerChunks in Firestore
+         │
+         ▼
+processTranscription (chunk 0):
+    │
+    ├─ Full pipeline: Gemini pre-analysis → WhisperX → store results
+    ├─ extractSpeakerHints() → { numSpeakers, speakerNames, speakerNotes }
+    └─ dispatchFollowersWithHints() (transactional):
+         ├─ Read pendingFollowerChunks from Firestore
+         ├─ Check followersDispatched guard (idempotency)
+         ├─ Enqueue Cloud Task for each follower with speakerHints in payload
+         ├─ Set followersDispatched = true (atomically)
+         └─ Delete pendingFollowerChunks (cleanup)
+              │
+              ▼
+processTranscription (chunks 1..N, staggered):
+    │
+    ├─ Receive speakerHints from task payload
+    ├─ SKIP Gemini pre-analysis (hints already provide speaker identities)
+    ├─ WhisperX diarization seeded with hint data (numSpeakers + speakerNames)
+    └─ Speaker notes seeded from leader's speakerNotes
+```
+
+### What Speaker Hints Contain
+
+The `SpeakerHints` structure is extracted from the leader's pipeline results:
+
+- **`numSpeakers`**: How many speakers the leader identified
+- **`speakerNames`**: Deduplicated names from `speakerMappings` (canonical IDs with display names) and `chunkSpeakerSignatures` (richer metadata with inferred names)
+- **`speakerNotes`**: Per-speaker metadata (ID, inferred name, role) used to seed Gemini content analysis
+
+### Idempotency
+
+The follower dispatch uses a Firestore transaction with a `followersDispatched` boolean guard. Cloud Tasks has at-least-once delivery semantics, meaning the leader's `processTranscription` could theoretically run twice. The guard ensures followers are only dispatched once regardless of retries.
+
+### Trade-offs
+
+| Aspect | Leader-First | Naive Parallel | Sequential |
+|--------|-------------|----------------|------------|
+| Latency | Leader delay + parallel followers | All chunks at once | Each waits for predecessor |
+| Gemini calls | 1 full + (N-1) skipped | N full | N full (with context) |
+| Name consistency | High (shared hints) | Low (independent guesses) | High (context propagation) |
+| Token cost | Lower (pre-analysis skipped) | Highest | Moderate |
+| Reconciliation needed | Yes (at merge) | Yes (at merge) | No |
+
+### Retry Behavior
+
+The retry flow (`retry.ts`) dispatches follower chunks directly without leader hints. This means retried followers won't benefit from the hint optimization — they run the full pipeline including Gemini pre-analysis. This is acceptable because retry is a degraded path where correctness matters more than cost savings.
 
 ## System Architecture
 
@@ -469,19 +534,11 @@ The reconciliation system provides several quality indicators:
 
 ## Future Improvements
 
-### 1. Voice Embeddings
+### 1. Retry Hint Propagation
 
-Add voice biometric signatures to speaker reconciliation for more robust matching. Would complement name/content signals with acoustic fingerprints.
+The retry flow currently dispatches followers without leader hints (degraded path). A future improvement could read `leaderSpeakerHints` from `chunkingMetadata` during retry dispatch to provide the same optimization.
 
-### 2. Manual Override UI
-
-Allow users to manually merge or split speakers if reconciliation makes mistakes. Store overrides in Firestore for future reference.
-
-### 3. Adaptive Thresholds
-
-Adjust confidence thresholds based on chunk count, audio quality, and historical accuracy. Learn from user feedback.
-
-### 4. Progressive Merge
+### 2. Progressive Merge
 
 Start merging early chunks while later chunks still processing (reduces time to first view).
 
@@ -496,14 +553,16 @@ Start merging early chunks while later chunks still processing (reduces time to 
 
 ## Key Takeaways
 
-1. **Chunk artifacts** store intermediate results in `conversations/{id}/chunks/*`
-2. **Speaker reconciliation** (parallel mode) matches speakers across chunks using name/topic/term signals
-3. **Confidence threshold** (default 0.75) triggers fallback if reconciliation is uncertain
-4. **Fallback flow**: Low confidence → archive parallel chunks → reprocess sequentially
-5. **Merge trigger** fires atomically when all chunks complete
-6. **Deduplication** uses "preferred chunk" logic (later chunk wins in overlaps)
-7. **Idempotency** ensures safe retries and prevents double-fallback
-8. **Status flow**: `chunking → merging → [reprocessing?] → complete`
-9. **Observability**: Structured logs + `reconciliationMetadata` + `fallbackMetadata` for monitoring
+1. **Leader-first dispatch**: Only chunk 0 processes initially; it extracts speaker hints and dispatches followers
+2. **Speaker hints**: Followers skip Gemini pre-analysis, using leader's speaker identities for WhisperX and content analysis
+3. **Chunk artifacts** store intermediate results in `conversations/{id}/chunks/*`
+4. **Speaker reconciliation** (parallel mode) matches speakers across chunks using voice embeddings + name signals
+5. **Confidence threshold** (default 0.75) triggers fallback if reconciliation is uncertain
+6. **Fallback flow**: Low confidence → archive parallel chunks → reprocess sequentially
+7. **Merge trigger** fires atomically when all chunks complete
+8. **Deduplication** uses "preferred chunk" logic (later chunk wins in overlaps)
+9. **Idempotency** ensures safe retries and prevents duplicate dispatch/merge/fallback
+10. **Status flow**: `chunking → merging → [reprocessing?] → complete`
+11. **Observability**: Structured logs + `reconciliationMetadata` + `fallbackMetadata` for monitoring
 
-The merge layer is the final step that transforms chunked processing back into a seamless user experience. Speaker reconciliation ensures consistent identities across chunk boundaries, and automatic fallback to sequential processing protects users from mislabeled transcripts when confidence is low.
+The merge layer is the final step that transforms chunked processing back into a seamless user experience. The leader-first dispatch pattern ensures followers start with good speaker identities, speaker reconciliation assigns canonical IDs across chunk boundaries, and automatic fallback to sequential processing protects users from mislabeled transcripts when confidence is low.

--- a/docs/reference/cloud-functions-flow.md
+++ b/docs/reference/cloud-functions-flow.md
@@ -76,8 +76,9 @@ The application uses **18 Cloud Functions** across 8 source modules to handle au
 │ │ 1. Detect audio duration                                              │ │  │
 │ │ 2. If >30 min → Chunk audio into overlapping segments                 │ │  │
 │ │ 3. Upload chunks to Storage                                           │ │  │
-│ │ 4. Create Cloud Tasks for each chunk                                  │ │  │
-│ │ 5. If <30 min → Process directly via executeTranscriptionPipeline     │ │  │
+│ │ 4. Create Cloud Task for chunk 0 ONLY (the "leader")                  │ │  │
+│ │    Store remaining chunks as pendingFollowerChunks in Firestore       │ │  │
+│ │ 5. If <30 min → Process directly via executeTranscriptionPipeline    │ │  │
 │ └───────────────────────────────────────────────────────────────────────┘ │  │
 └─────────┬─────────────────────────────────────┬───────────────────────────┘  │
           │                                     │                              │
@@ -85,37 +86,44 @@ The application uses **18 Cloud Functions** across 8 source modules to handle au
           ▼                                     ▼                              │
 ┌───────────────────────┐             ┌───────────────────────┐                │
 │ Direct Processing     │             │ Cloud Tasks Queue     │◄───────────────┘
-│ (same function)       │             │ (N chunk tasks)       │  retryTranscription
+│ (same function)       │             │ (leader chunk only)   │  retryTranscription
 │                       │             │                       │  enqueues here
 │ → Gemini API          │             │ mode: parallel or     │
 │ → WhisperX align      │             │       sequential      │
 │ → Firestore update    │             │                       │
 │ → status: complete    │             └───────────┬───────────┘
 └───────────────────────┘                         │
-                                                  │ For each chunk
+                                                  │ Chunk 0 (leader)
                                                   ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │ processTranscription (Cloud Tasks HTTP)                                     │
 │ Memory: 2GiB | Timeout: 60 min                                              │
 │ ┌─────────────────────────────────────────────────────────────────────────┐ │
-│ │ PARALLEL MODE:                      SEQUENTIAL MODE:                    │ │
+│ │ LEADER CHUNK (chunk 0):              FOLLOWER CHUNKS (1..N):            │ │
 │ │ ┌──────────────────────┐            ┌──────────────────────┐            │ │
-│ │ │ Fresh context        │            │ Load predecessor     │            │ │
-│ │ │ (no dependencies)    │            │ context (speaker     │            │ │
-│ │ │                      │            │ IDs, signatures)     │            │ │
+│ │ │ Full pipeline:       │            │ Hints-assisted:      │            │ │
+│ │ │ • Gemini pre-analysis│            │ • Skip Gemini        │            │ │
+│ │ │ • WhisperX diarize   │            │   pre-analysis       │            │ │
+│ │ │ • Store results      │            │ • WhisperX with      │            │ │
+│ │ │                      │            │   speaker hints      │            │ │
 │ │ └──────────┬───────────┘            └──────────┬───────────┘            │ │
+│ │            │                                   │                        │ │
+│ │            ▼                                   │                        │ │
+│ │ ┌──────────────────────┐                       │                        │ │
+│ │ │ Extract speaker hints│                       │                        │ │
+│ │ │ from leader results  │                       │                        │ │
+│ │ │ (names, count, roles)│                       │                        │ │
+│ │ └──────────┬───────────┘                       │                        │ │
+│ │            │                                   │                        │ │
+│ │            ▼                                   │                        │ │
+│ │ ┌──────────────────────┐                       │                        │ │
+│ │ │ Dispatch followers   │──── Cloud Tasks ─────►│                        │ │
+│ │ │ with speaker hints   │  (speakerHints in     │                        │ │
+│ │ │ (transactional guard)│   each task payload)  │                        │ │
+│ │ └──────────┬───────────┘                       │                        │ │
 │ │            │                                   │                        │ │
 │ │            └─────────────┬─────────────────────┘                        │ │
 │ │                          ▼                                              │ │
-│ │                ┌───────────────────────┐                                │ │
-│ │                │ executeTranscription  │                                │ │
-│ │                │ Pipeline:             │                                │ │
-│ │                │ • Gemini API call     │                                │ │
-│ │                │ • WhisperX alignment  │                                │ │
-│ │                │ • Store chunk result  │                                │ │
-│ │                └──────────┬────────────┘                                │ │
-│ │                           │                                             │ │
-│ │                           ▼                                             │ │
 │ │                ┌───────────────────────┐                                │ │
 │ │                │ Mark chunk complete   │                                │ │
 │ │                │ Emit next context     │                                │ │
@@ -291,9 +299,15 @@ Entry point for all audio uploads. Triggered when a file is uploaded to Firebase
 
 **Responsibilities:**
 - Detect audio duration using ffprobe
-- For files >30 min: split into overlapping chunks, upload chunks, create Cloud Tasks
+- For files >30 min: split into overlapping chunks, upload chunks, dispatch leader chunk
 - For files ≤30 min: process directly via `executeTranscriptionPipeline`
 - Update Firestore with processing status
+
+**Leader-First Dispatch (parallel mode):**
+- Only chunk 0 (the "leader") is dispatched as a Cloud Task immediately
+- All remaining chunks are serialized as `pendingFollowerChunks` in Firestore's `chunkingMetadata`
+- Followers are NOT enqueued until the leader completes and extracts speaker hints
+- This ensures followers can skip Gemini pre-analysis and use the leader's speaker identities
 
 **Key Decisions:**
 - 9-minute timeout is a hard limit for Storage triggers
@@ -308,12 +322,22 @@ Handles the actual transcription work for each chunk or whole file.
 
 **Processing Pipeline:**
 1. Download audio from Storage
-2. Call Gemini API for transcription + speaker diarization
-3. Call WhisperX (via Replicate) for word-level timestamp alignment
+2. Call Gemini API for transcription + speaker diarization (skipped for followers with hints)
+3. Call WhisperX (via Cloud Run GPU) for word-level timestamp alignment
 4. Store results in Firestore (chunk subcollection or main document)
+5. **Leader chunk only**: Extract speaker hints → dispatch all follower chunks
+
+**Leader-Chunk-First Dispatch (parallel mode):**
+
+When chunk 0 (the leader) completes, `processTranscription` runs two additional steps:
+
+1. **Extract speaker hints** via `extractSpeakerHints()` — collects speaker count, names, and role metadata from the leader's pipeline results (`speakerMappings` + `chunkSpeakerSignatures`)
+2. **Dispatch followers** via `dispatchFollowersWithHints()` — reads `pendingFollowerChunks` from Firestore inside a transaction, enqueues a Cloud Task for each follower with `speakerHints` embedded in the task payload, and atomically sets `followersDispatched: true` to prevent duplicate dispatch
+
+Follower chunks receive these hints and skip Gemini pre-analysis entirely, using the leader's speaker identities to seed WhisperX diarization and speaker notes. This saves both latency and Gemini token costs while improving cross-chunk name consistency.
 
 **Two Processing Modes:**
-- **Parallel**: All chunks process independently, speaker reconciliation at merge
+- **Parallel**: Leader chunk processes first, followers use leader hints, speaker reconciliation at merge
 - **Sequential**: Each chunk waits for predecessor, consistent speaker IDs throughout
 
 ### 3. processMerge (Cloud Tasks HTTP)
@@ -477,11 +501,12 @@ Storage triggers have a **9-minute hard timeout limit**. Large audio files can t
 
 ### Why Two Processing Modes?
 
-**Parallel Mode** (default):
-- Faster: all chunks process simultaneously
-- ~60% faster for 6-chunk files
-- Speaker IDs may differ across chunks
-- Requires speaker reconciliation at merge
+**Parallel Mode** (default, with leader-first dispatch):
+- Leader chunk (chunk 0) processes first, extracts speaker hints
+- Follower chunks process concurrently using leader's hints (skip Gemini pre-analysis)
+- Faster than fully sequential, with better name consistency than naive parallel
+- Speaker reconciliation still runs at merge to assign canonical IDs
+- Adds leader processing latency (~2-5 min) before followers start
 
 **Sequential Mode** (fallback):
 - Slower: each chunk waits for predecessor

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -40,6 +40,9 @@ interface ConversationDoc {
   // Processing Mode (Chunked Uploads)
   processingMode?: 'parallel' | 'sequential';  // Controls chunk execution strategy
 
+  // Chunking Metadata (Large File Processing)
+  chunkingMetadata?: ChunkingMetadata;          // Present when file is chunked (>30 min)
+
   // Speaker Reconciliation (Parallel Mode Only)
   reconciliationConfidence?: number;           // Overall confidence (0-1) of speaker matching
   reconciliationDetails?: ReconciliationDetails; // Detailed match evidence per cluster
@@ -879,6 +882,68 @@ interface FallbackMetadata {
 - Tracking threshold configuration at time of trigger
 
 **When present**: Only on conversations where fallback to sequential was triggered. Can query `fallbackMetadata.triggeredAt IS NOT NULL` to find all fallback occurrences.
+
+### ChunkingMetadata
+
+Metadata tracking chunk processing state for large files. Stored as an embedded object on the conversation document.
+
+```typescript
+interface ChunkingMetadata {
+  totalChunks: number;                          // Total number of audio chunks
+  chunkStatuses: Record<string, ChunkStatus>;   // Per-chunk processing status
+  mergeTaskEnqueued?: boolean;                  // Guard flag: merge task already dispatched
+  mergedAt?: string;                            // ISO timestamp when merge completed
+
+  // Leader-chunk-first dispatch (parallel mode)
+  leaderSpeakerHints?: SpeakerHints;            // Speaker hints extracted from chunk 0
+  pendingFollowerChunks?: PendingFollowerChunk[];  // Followers waiting for leader to complete
+  followersDispatched?: boolean;                // Guard flag: followers already enqueued
+}
+```
+
+**Leader-first fields** (all optional for backward compatibility):
+- `leaderSpeakerHints`: Set after chunk 0 completes, contains speaker count/names/roles extracted from the leader's pipeline results
+- `pendingFollowerChunks`: Set by `transcribeAudio` when dispatching chunk 0, stores serialized follower chunk descriptors (storage paths, overlap info, timestamps)
+- `followersDispatched`: Transactional guard flag set atomically by `dispatchFollowersWithHints()` to prevent duplicate follower dispatch from Cloud Tasks at-least-once delivery
+
+### SpeakerHints
+
+Speaker identity hints extracted from the leader chunk and forwarded to all follower chunks via Cloud Task payloads.
+
+```typescript
+interface SpeakerHints {
+  numSpeakers: number;                // Number of speakers identified by leader
+  speakerNames: string[];             // Deduplicated speaker names from leader
+  speakerNotes?: Array<{              // Per-speaker metadata for Gemini prompting
+    speakerId: string;
+    inferredName?: string;
+    role?: string;
+  }>;
+}
+```
+
+**How hints are used by followers:**
+- `numSpeakers` + `speakerNames` seed WhisperX diarization (skip Gemini pre-analysis)
+- `speakerNotes` seed the Gemini content analysis speaker notes
+- Followers with valid hints bypass the entire Gemini pre-analysis step
+
+### PendingFollowerChunk
+
+Serialized descriptor for a follower chunk waiting to be dispatched after the leader completes.
+
+```typescript
+interface PendingFollowerChunk {
+  chunkIndex: number;           // Chunk position (1..N)
+  totalChunks: number;          // Total chunk count
+  chunkStoragePath: string;     // Firebase Storage path to the chunk audio
+  startMs: number;              // Chunk start time in original audio
+  endMs: number;                // Chunk end time in original audio
+  overlapBeforeMs: number;      // Overlap with previous chunk (ms)
+  overlapAfterMs: number;       // Overlap with next chunk (ms)
+}
+```
+
+**Lifecycle:** Created by `transcribeAudio`, stored in `chunkingMetadata.pendingFollowerChunks`, consumed and deleted by `dispatchFollowersWithHints()` after leader completion.
 
 ## Firebase Storage Structure
 

--- a/functions/src/__tests__/speakerReconciliation.test.ts
+++ b/functions/src/__tests__/speakerReconciliation.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { reconcileSpeakers, ReconciliationLowConfidenceError } from '../speakerReconciliation';
-import { reconcileSpeakersWithEmbeddings } from '../speakerReconciliationEmbeddings';
+import { reconcileSpeakersWithEmbeddings, levenshteinDistance, namesAreSimilar } from '../speakerReconciliationEmbeddings';
 import { SpeakerSignature, ChunkArtifact } from '../types';
 import { computeAdaptiveEdgeThreshold } from '../adaptiveThresholds';
 
@@ -1006,6 +1006,147 @@ describe('speakerReconciliation', () => {
         const result = reconcileSpeakersWithEmbeddings(chunkArtifacts);
 
         // Different names → no boost → stay separate
+        expect(result.nameBoostCount).toBe(0);
+        expect(result.clusterDetails.length).toBe(2);
+      });
+    });
+
+    describe('fuzzy name matching utilities', () => {
+      describe('levenshteinDistance', () => {
+        it('should return 0 for identical strings', () => {
+          expect(levenshteinDistance('arya', 'arya')).toBe(0);
+        });
+
+        it('should handle empty strings', () => {
+          expect(levenshteinDistance('', 'abc')).toBe(3);
+          expect(levenshteinDistance('abc', '')).toBe(3);
+          expect(levenshteinDistance('', '')).toBe(0);
+        });
+
+        it('should compute single insertion', () => {
+          // "arya" → "araya" requires one insertion
+          expect(levenshteinDistance('arya', 'araya')).toBe(1);
+        });
+
+        it('should compute single substitution', () => {
+          expect(levenshteinDistance('jay', 'ray')).toBe(1);
+        });
+
+        it('should compute multiple edits', () => {
+          expect(levenshteinDistance('alice', 'bob')).toBe(5);
+        });
+
+        it('should be symmetric', () => {
+          expect(levenshteinDistance('araya', 'arya')).toBe(levenshteinDistance('arya', 'araya'));
+        });
+      });
+
+      describe('namesAreSimilar', () => {
+        it('should match identical names', () => {
+          expect(namesAreSimilar('sam', 'sam')).toBe(true);
+          expect(namesAreSimilar('dennis', 'dennis')).toBe(true);
+        });
+
+        it('should match ASR transcription variants (the Arya/Araya case)', () => {
+          // dist=1, maxLen=5, sim=0.80 — just clears the 0.80 threshold
+          expect(namesAreSimilar('arya', 'araya')).toBe(true);
+        });
+
+        it('should match common transcription variants for longer names', () => {
+          // "dennis" vs "denis": dist=1, maxLen=6, sim=0.83
+          expect(namesAreSimilar('dennis', 'denis')).toBe(true);
+        });
+
+        it('should NOT fuzzy-match short names (≤3 chars)', () => {
+          // "jay" vs "ray": only 1 edit away but too short to trust
+          expect(namesAreSimilar('jay', 'ray')).toBe(false);
+          expect(namesAreSimilar('sam', 'sal')).toBe(false);
+        });
+
+        it('should still exact-match short names', () => {
+          expect(namesAreSimilar('jay', 'jay')).toBe(true);
+          expect(namesAreSimilar('sam', 'sam')).toBe(true);
+        });
+
+        it('should NOT match clearly different names', () => {
+          expect(namesAreSimilar('alice', 'bob')).toBe(false);
+          expect(namesAreSimilar('nick', 'dennis')).toBe(false);
+          expect(namesAreSimilar('alice', 'alex')).toBe(false); // dist=2, sim=0.60
+        });
+
+        it('should require one short + one long to both be >3 chars', () => {
+          // If either name is ≤3 chars and they're not identical, reject
+          expect(namesAreSimilar('sam', 'samm')).toBe(false); // "sam" is ≤3
+        });
+      });
+    });
+
+    describe('REQ-3b: fuzzy name merge floor', () => {
+      it('should merge cross-chunk speakers with fuzzy-matching names (Arya/Araya)', () => {
+        // The real-world case: Gemini transcribes "Arya" in one chunk and "Araya"
+        // in another. Embeddings alone are too dissimilar (0.50) but the name
+        // floor should lift them to 0.75 and merge.
+        const embeddingA = generateEmbedding(12001);
+        const embeddingB = generateEmbedding(12002, { to: embeddingA, score: 0.50 });
+
+        const chunkArtifacts = [
+          createChunkArtifact(0, { SPEAKER_00: embeddingA }, { SPEAKER_00: 'Arya (Host / Product Presenter)' }),
+          createChunkArtifact(1, { SPEAKER_00: embeddingB }, { SPEAKER_00: 'Araya (Vendor Sales Representative)' }),
+        ];
+
+        const result = reconcileSpeakersWithEmbeddings(chunkArtifacts);
+
+        // Fuzzy match "arya" ≈ "araya" → floor applied → single cluster
+        expect(result.nameBoostCount).toBe(1);
+        expect(result.clusterDetails.length).toBe(1);
+        expect(result.speakerIdMap.get('SPEAKER_00_chunk0')).toBe(
+          result.speakerIdMap.get('SPEAKER_00_chunk1')
+        );
+      });
+
+      it('should merge cross-chunk speakers with fuzzy-matching names (Dennis/Denis)', () => {
+        const embeddingA = generateEmbedding(12011);
+        const embeddingB = generateEmbedding(12012, { to: embeddingA, score: 0.50 });
+
+        const chunkArtifacts = [
+          createChunkArtifact(0, { SPEAKER_00: embeddingA }, { SPEAKER_00: 'Dennis (Technical Lead)' }),
+          createChunkArtifact(1, { SPEAKER_00: embeddingB }, { SPEAKER_00: 'Denis (Technical Lead)' }),
+        ];
+
+        const result = reconcileSpeakersWithEmbeddings(chunkArtifacts);
+
+        expect(result.nameBoostCount).toBe(1);
+        expect(result.clusterDetails.length).toBe(1);
+      });
+
+      it('should NOT fuzzy-merge short names that are 1 edit apart (Jay/Ray)', () => {
+        const embeddingA = generateEmbedding(12021);
+        const embeddingB = generateEmbedding(12022, { to: embeddingA, score: 0.50 });
+
+        const chunkArtifacts = [
+          createChunkArtifact(0, { SPEAKER_00: embeddingA }, { SPEAKER_00: 'Jay' }),
+          createChunkArtifact(1, { SPEAKER_00: embeddingB }, { SPEAKER_00: 'Ray' }),
+        ];
+
+        const result = reconcileSpeakersWithEmbeddings(chunkArtifacts);
+
+        // Short names → exact match required → no boost → separate
+        expect(result.nameBoostCount).toBe(0);
+        expect(result.clusterDetails.length).toBe(2);
+      });
+
+      it('should NOT fuzzy-merge names that are too dissimilar (Alice/Alex)', () => {
+        const embeddingA = generateEmbedding(12031);
+        const embeddingB = generateEmbedding(12032, { to: embeddingA, score: 0.50 });
+
+        const chunkArtifacts = [
+          createChunkArtifact(0, { SPEAKER_00: embeddingA }, { SPEAKER_00: 'Alice' }),
+          createChunkArtifact(1, { SPEAKER_00: embeddingB }, { SPEAKER_00: 'Alex' }),
+        ];
+
+        const result = reconcileSpeakersWithEmbeddings(chunkArtifacts);
+
+        // "alice" vs "alex": dist=2, sim=0.60 — below 0.80 threshold
         expect(result.nameBoostCount).toBe(0);
         expect(result.clusterDetails.length).toBe(2);
       });

--- a/functions/src/speakerReconciliationEmbeddings.ts
+++ b/functions/src/speakerReconciliationEmbeddings.ts
@@ -177,10 +177,62 @@ function normalizeSpeakerName(displayName: string): string | null {
 }
 
 /**
+ * Levenshtein (edit) distance between two strings.
+ * Classic DP — O(m·n) time, O(min(m,n)) space.
+ * Exported for testing.
+ */
+export function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  // Use the shorter string as the "row" dimension for space efficiency
+  if (a.length > b.length) { const tmp = a; a = b; b = tmp; }
+
+  let prev = Array.from({ length: a.length + 1 }, (_, i) => i);
+
+  for (let j = 1; j <= b.length; j++) {
+    const curr = [j];
+    for (let i = 1; i <= a.length; i++) {
+      curr[i] = a[i - 1] === b[j - 1]
+        ? prev[i - 1]
+        : 1 + Math.min(prev[i - 1], prev[i], curr[i - 1]);
+    }
+    prev = curr;
+  }
+
+  return prev[a.length];
+}
+
+/**
+ * Check if two normalized speaker names are "close enough" to be the same
+ * person, accounting for ASR transcription variants (Arya/Araya, Denis/Dennis).
+ *
+ * Uses Levenshtein distance with length-aware thresholds:
+ *  - Names ≤ 3 chars: exact match only (too short for fuzzy — "Jay" ≠ "Ray")
+ *  - Names 4+ chars: normalized similarity ≥ 0.80 (~1 typo per 5 chars)
+ *
+ * Exported for testing.
+ */
+export function namesAreSimilar(nameA: string, nameB: string): boolean {
+  if (nameA === nameB) return true;
+
+  // Short names are too ambiguous for fuzzy matching
+  if (nameA.length <= 3 || nameB.length <= 3) return false;
+
+  const dist = levenshteinDistance(nameA, nameB);
+  const maxLen = Math.max(nameA.length, nameB.length);
+  const similarity = 1 - dist / maxLen;
+
+  return similarity >= 0.80;
+}
+
+/**
  * Apply name-based similarity boosts to cross-chunk speaker pairs.
  *
- * When two speakers from different chunks share the same normalized display name,
- * we nudge their similarity up by NAME_BOOST. This helps borderline pairs that
+ * When two speakers from different chunks share similar normalized display names
+ * (fuzzy match via Levenshtein distance — catches ASR variants like Arya/Araya),
+ * we lift their similarity to NAME_MERGE_FLOOR. This helps borderline pairs that
  * voice embeddings alone can't confidently merge — especially when audio quality
  * is uneven across chunks. Won't rescue truly different speakers (the embedding
  * signal is still dominant), but it's a useful tiebreaker.
@@ -217,9 +269,9 @@ function applyNameBoosts(
       const nameI = normalizeSpeakerName(speakerI.displayName);
       const nameJ = normalizeSpeakerName(speakerJ.displayName);
 
-      if (!nameI || !nameJ || nameI !== nameJ) continue;
+      if (!nameI || !nameJ || !namesAreSimilar(nameI, nameJ)) continue;
 
-      // Same normalized name in different chunks — lift to floor if below it.
+      // Same (or fuzzy-matched) name in different chunks — lift to floor if below it.
       // Max semantics: already above 0.75? Leave it alone. Below? Raise to floor.
       // Avoids piling score onto already-high pairs and makes the threshold crisp.
       const before = similarityMatrix[i][j];
@@ -227,10 +279,12 @@ function applyNameBoosts(
       similarityMatrix[i][j] = boosted;
       similarityMatrix[j][i] = boosted;
 
+      const fuzzyMatch = nameI !== nameJ;
       console.log('[EmbeddingReconciliation] Name floor applied:', {
         entryI: entries[i].originalId,
         entryJ: entries[j].originalId,
         name: nameI,
+        ...(fuzzyMatch ? { fuzzyMatchedWith: nameJ, editDistance: levenshteinDistance(nameI, nameJ) } : {}),
         before: before.toFixed(3),
         floor: EmbeddingReconciliationConfig.NAME_MERGE_FLOOR.toFixed(3),
         after: boosted.toFixed(3),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-transcript-analysis-app",
   "private": true,
-  "version": "2.13.0",
+  "version": "2.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Release v2.14.0

### Changed
- **Fuzzy Speaker Name Matching** — Cross-chunk speaker reconciliation now uses Levenshtein distance instead of exact string equality
  - Catches ASR transcription variants like "Arya"/"Araya" and "Dennis"/"Denis" that previously created duplicate speakers
  - Names 4+ characters use ≥80% similarity threshold; names ≤3 characters require exact match to prevent false merges
  - Enhanced logging with `editDistance` and `fuzzyMatchedWith` fields for observability

### Documentation
- Updated `docs/explanation/chunk-merge.md` with leader-chunk-first dispatch flow diagrams
- Updated `docs/reference/cloud-functions-flow.md` with leader/follower ASCII architecture diagrams
- Updated `docs/reference/data-model.md` with `ChunkingMetadata` and `SpeakerHints` type docs

## Test Plan
- [x] 52 speaker reconciliation tests passing (11 new fuzzy matching tests)
- [x] 28 segment boundary tests passing
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] Pre-commit hooks pass

## Notes
Rebased onto main (which now includes v2.13.0 segment merge fix from PR #133). Version bumped from v2.12.0 → v2.14.0 since v2.12.0 tag already existed on remote and v2.13.0 was taken by the segment fix.

---
Scope: `speaker_recon_cross_chunk_merge_fixes-02`
Tag: `v2.14.0`
Build: `36`