### PR TITLE
chore(release): v2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.0] - 2026-03-06
+
+### Fixed
+- **Over-Aggressive Segment Merging** - Speaker reassignment no longer collapses all adjacent same-speaker segments into giant monologue blocks
+  - Phase 3 of `applySpeakerReassignments()` now only merges segments directly involved in reassignments or splits, preserving WhisperX's natural sentence boundaries
+  - Previously, 104 well-segmented sentences could collapse into 14 massive blocks, trapping multiple speakers' text in single segments
+  - Tracks modified indices through the reassign → split → merge pipeline, including correct index shifting for splice operations
+
 ## [2.11.0] - 2026-02-27
 
 ### Added

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -1,5 +1,16 @@
 # What's New
 
+## Version 2.13.0 - March 6, 2026
+
+### 🐛 Better Transcript Segmentation
+
+**Conversations Stay Properly Broken Down**
+- Fixed an issue where transcripts could collapse dozens of natural sentences into a handful of giant text blocks
+- Each speaker turn now preserves WhisperX's original sentence-level breaks, so you see granular, navigable segments instead of walls of text
+- This particularly improves results for multi-speaker conversations where different people's words were being mashed together in the same block
+
+---
+
 ## Version 2.11.0 - February 27, 2026
 
 ### ✨ Resizable Sidebar

--- a/functions/src/transcribe.ts
+++ b/functions/src/transcribe.ts
@@ -3133,6 +3133,8 @@ export function applySpeakerReassignments(
   // ---- Phase 1: Reassignments ----
   const reassignments = corrections.filter(c => c.action === 'reassign' && c.newSpeaker);
   let result = [...segments];
+  // Track which indices were modified so Phase 3 only merges around them
+  const touchedIndices = new Set<number>();
 
   for (const correction of reassignments) {
     const { segmentIndex, newSpeaker } = correction;
@@ -3151,6 +3153,7 @@ export function applySpeakerReassignments(
     if (oldSpeaker !== newSpeaker) {
       console.debug(`[Speaker Reassignment] Seg ${segmentIndex}: ${oldSpeaker} -> ${newSpeaker}`);
       result[segmentIndex] = { ...result[segmentIndex], speakerId: newSpeaker! };
+      touchedIndices.add(segmentIndex);
     }
   }
 
@@ -3257,15 +3260,32 @@ export function applySpeakerReassignments(
     };
 
     result.splice(segmentIndex, 1, segBefore, segAfter);
+    // Both halves of the split are new — mark them for Phase 3
+    touchedIndices.add(segmentIndex);
+    touchedIndices.add(segmentIndex + 1);
+    // Splits insert an element, so bump any previously-tracked indices above this point
+    const shifted = new Set<number>();
+    for (const idx of touchedIndices) {
+      shifted.add(idx > segmentIndex + 1 ? idx + 1 : idx);
+    }
+    touchedIndices.clear();
+    for (const idx of shifted) touchedIndices.add(idx);
   }
 
-  // ---- Phase 3: Merge adjacent same-speaker segments ----
-  // Splits can expose or create same-speaker neighbours — clean them up.
+  // ---- Phase 3: Merge adjacent same-speaker segments (ONLY around modified indices) ----
+  // Only merge neighbours when at least one was touched by Phase 1/2.
+  // Unconditionally merging all same-speaker neighbours destroys WhisperX's
+  // natural sentence boundaries and creates giant multi-sentence blocks.
   const merged: typeof result = [];
-  for (const seg of result) {
+  for (let i = 0; i < result.length; i++) {
+    const seg = result[i];
     const last = merged[merged.length - 1];
-    if (last && last.speakerId === seg.speakerId) {
-      // Extend the previous segment
+    if (
+      last &&
+      last.speakerId === seg.speakerId &&
+      (touchedIndices.has(i) || touchedIndices.has(i - 1))
+    ) {
+      // Only merge if one of the pair was modified by reassignment/split
       merged[merged.length - 1] = {
         ...last,
         text: last.text.trimEnd() + ' ' + seg.text.trimStart(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audio-transcript-analysis-app",
-  "version": "2.8.0",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audio-transcript-analysis-app",
-      "version": "2.8.0",
+      "version": "2.11.0",
       "dependencies": {
         "@google/genai": "^1.33.0",
         "dotenv": "^17.2.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-transcript-analysis-app",
   "private": true,
-  "version": "2.11.0",
+  "version": "2.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Release v2.13.0

### Fixed
- **Over-Aggressive Segment Merging** — `applySpeakerReassignments()` Phase 3 was unconditionally merging ALL adjacent same-speaker segments, not just those created by splits/reassignments. This collapsed WhisperX's natural sentence boundaries into giant monologue blocks (e.g., 104 segments → 14).

Phase 3 now tracks which indices were modified and only merges neighbors of touched segments, preserving the granular transcript structure users expect.

## Changelog Entry
```
### Fixed
- Over-aggressive segment merging — Phase 3 now only merges segments directly
  involved in reassignments or splits, preserving natural sentence boundaries
```

## Test Plan
- [x] All 28 `segmentBoundaries` tests pass (including split-merge, mixed reassign+split)
- [x] All 35 `speakerReconciliation` tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Upload a multi-speaker conversation and verify segments are granular, not collapsed

---
Tag: `v2.13.0`
Build: `35`