### PR TITLE
fix(infra): grant GitHub Actions SA secret version manager role

### DIFF
--- a/scripts/gcp-setup.sh
+++ b/scripts/gcp-setup.sh
@@ -907,6 +907,7 @@ else
         "roles/cloudbuild.builds.builder"
         "roles/storage.admin"
         "roles/iam.serviceAccountUser"
+        "roles/secretmanager.secretVersionManager"  # Deploy workflow updates WHISPER_SERVICE_URL after Cloud Run deploy
     )
 
     for role in "${GITHUB_SA_ROLES[@]}"; do


### PR DESCRIPTION
## Summary
- Adds `roles/secretmanager.secretVersionManager` to the GitHub Actions service account in `gcp-setup.sh`
- The deploy-whisper workflow needs this to update `WHISPER_SERVICE_URL` in Secret Manager after Cloud Run deploys

## Why it broke
The workflow (line 174) calls `gcloud secrets versions add` to write the new Cloud Run URL, but the GitHub Actions SA only had Cloud Run + Cloud Build + Storage permissions — no Secret Manager access.

## Idempotency
The workflow already checks the current secret value before writing (lines 167-178), so re-deploys to the same URL won't create extra versions. The new role also covers the `versions.access` call needed for that read-check.

## Test Plan
- [ ] Run `./scripts/gcp-setup.sh` to apply the new IAM binding
- [ ] Re-run the deploy-whisper workflow — the "Update service URL secret" step should pass

## To apply now (before merge)
```bash
gcloud projects add-iam-policy-binding $PROJECT_ID \
  --member="serviceAccount:github-actions@${PROJECT_ID}.iam.gserviceaccount.com" \
  --role="roles/secretmanager.secretVersionManager"
```