### PR TITLE
fix(infra): WIF identity token + serviceAccountTokenCreator for health check

### DIFF
--- a/.github/workflows/deploy-whisper.yml
+++ b/.github/workflows/deploy-whisper.yml
@@ -183,12 +183,21 @@ jobs:
       - name: Health check
         env:
           SERVICE_URL: ${{ steps.deploy.outputs.url }}
+          SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
         run: |
           echo "Waiting for service to become ready (GPU cold start can take 2-3 min)..."
-          TOKEN=$(gcloud auth print-identity-token \
-            --audiences="$SERVICE_URL" 2>/dev/null || gcloud auth print-identity-token)
 
           for i in {1..12}; do
+            # WIF credentials can't mint identity tokens directly —
+            # impersonate the SA to get one for each attempt (tokens expire)
+            TOKEN=$(gcloud auth print-identity-token \
+              --impersonate-service-account="$SERVICE_ACCOUNT" \
+              --audiences="$SERVICE_URL" 2>/dev/null) || {
+              echo "Attempt $i/12: Failed to mint identity token, retrying in 15s..."
+              sleep 15
+              continue
+            }
+
             STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
               -H "Authorization: Bearer $TOKEN" \
               "$SERVICE_URL/health" 2>/dev/null || echo "000")

--- a/scripts/gcp-setup.sh
+++ b/scripts/gcp-setup.sh
@@ -908,6 +908,7 @@ else
         "roles/storage.admin"
         "roles/iam.serviceAccountUser"
         "roles/secretmanager.secretVersionManager"  # Deploy workflow updates WHISPER_SERVICE_URL after Cloud Run deploy
+        "roles/iam.serviceAccountTokenCreator"      # Health check mints ID tokens via --impersonate-service-account
     )
 
     for role in "${GITHUB_SA_ROLES[@]}"; do


### PR DESCRIPTION
## Summary
Follow-up to #136. The health check step in the deploy-whisper workflow fails because Workload Identity Federation credentials can't call `gcloud auth print-identity-token` directly.

- Uses `--impersonate-service-account` to mint ID tokens via the SA
- Adds `roles/iam.serviceAccountTokenCreator` to the GitHub Actions SA
- Moves token minting inside the retry loop (fresh token each attempt)

## To apply now
```bash
PROJECT_ID="your-project-id" && gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:github-actions@${PROJECT_ID}.iam.gserviceaccount.com" --role="roles/iam.serviceAccountTokenCreator"
```

## Test Plan
- [ ] Run `./scripts/gcp-setup.sh` to apply the new IAM binding
- [ ] Re-run deploy-whisper workflow — health check should now get a valid identity token