### PR TITLE
chore(infra): remove stale Cloud Tasks references from GCP setup and deploy docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Reconciliation alert handler** — `handleReconciliationAlert.ts` superseded by the new pipeline's built-in handling
 - **Legacy tests** — `chunkMerge.test.ts`, `leaderChunk.test.ts`, `speakerNameResolution.test.ts`, `speakerQuality.test.ts`, `speakerQualityIntegration.test.ts`, `speakerReconciliation.test.ts`
 - **Obsolete documentation** — `chunk-merge.md`, `speaker-reconciliation-rollout.md`, `reconciliation-queries.md`
+- **Stale Cloud Tasks references** — Removed retired `cloudtasks.googleapis.com` API comment and legacy `transcription-queue` / `processTranscription` comment block from `gcp-setup.sh`; removed retired "Cloud Tasks Queue" section from deployment docs
 
 ## [2.14.0] - 2026-03-06
 

--- a/docs/how-to/deploy.md
+++ b/docs/how-to/deploy.md
@@ -194,13 +194,6 @@ gcloud projects add-iam-policy-binding $BILLING_PROJECT \
 
 The `gcp-setup.sh` script handles this automatically when run with the billing project configured.
 
-## Cloud Tasks Queue (Retired)
-
-> The `transcription-queue` was part of the legacy chunked pipeline and is no longer used.
-> The current hybrid pipeline (Gemini 3 Flash + WhisperX timestamps) processes everything
-> directly within `transcribeAudio` without Cloud Tasks. The queue may still exist in your
-> GCP project but can be safely paused or deleted.
-
 ## Whisper GPU Service (Cloud Run)
 
 The WhisperX service runs on Cloud Run with an NVIDIA L4 GPU. It provides **word-level timestamps only** — speaker diarization is handled by Gemini 3 Flash.

--- a/scripts/gcp-setup.sh
+++ b/scripts/gcp-setup.sh
@@ -393,9 +393,6 @@ APIS=(
     "generativelanguage.googleapis.com"
     "aiplatform.googleapis.com"  # Required for Vertex AI SDK (Gemini with billing labels)
     "apikeys.googleapis.com"
-    # Cloud Tasks API — no longer used (processTranscription retired),
-    # but kept enabled in case existing projects have queue resources.
-    # "cloudtasks.googleapis.com"
     # Speech-to-Text v2 (Chirp-3 diarization benchmark)
     "speech.googleapis.com"
 )
@@ -555,15 +552,7 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# Step 10: Cloud Tasks Queue — RETIRED
-# -----------------------------------------------------------------------------
-# The transcription-queue was used by the legacy processTranscription function
-# (Replicate-era pipeline). That function has been deleted and the current
-# hybrid pipeline (Gemini 3 Flash + WhisperX timestamps) processes inline.
-# Existing queues can be paused/deleted manually; new projects don't need one.
-
-# -----------------------------------------------------------------------------
-# Step 10b: Grant BigQuery Access for Billing Sync (Cross-Project)
+# Step 10: Grant BigQuery Access for Billing Sync (Cross-Project)
 # -----------------------------------------------------------------------------
 
 log_step "BigQuery billing sync access (cross-project)..."


### PR DESCRIPTION
## Summary

- Removed retired `cloudtasks.googleapis.com` API comment and legacy `transcription-queue` / `processTranscription` comment block from `scripts/gcp-setup.sh`
- Removed stale "Cloud Tasks Queue (Retired)" section from `docs/how-to/deploy.md`
- Updated changelog with removal entry

All active infrastructure (Pub/Sub, Cloud Run, Artifact Registry, WIF, secrets) remains untouched — this is purely subtractive cleanup preparing for scope `_09-03` (Cloud Run orchestrator provisioning).

## Test plan

- [x] Scoped validation: bash syntax check + forbidden-pattern grep (6 terms) — PASS
- [x] `npm run lint` — PASS (0 errors)
- [x] `npm run type-check` — PASS
- [x] `npm test -- --run` — PASS (136 tests)
- [x] Adversarial review: 3/3 PASS
- [x] Active Pub/Sub IAM bindings confirmed intact

**Scope:** gemini_hybrid_09_cloud_run_orchestrator_02_gcp_setup_cleanup
**Build:** 40