### PR TITLE
fix(infra): add CLOUD_LOGGING_ONLY to Cloud Build config

### DIFF
--- a/cloud-run-orchestrator/cloudbuild.yaml
+++ b/cloud-run-orchestrator/cloudbuild.yaml
@@ -14,6 +14,8 @@ images:
   - '${_IMAGE_NAME}:${_TAG}'
   - '${_IMAGE_NAME}:latest'
 timeout: 600s
+options:
+  logging: CLOUD_LOGGING_ONLY
 
 # Substitution defaults — workflow overrides these with real values.
 # _IMAGE_NAME: full AR path without tag (region-docker.pkg.dev/PROJECT/REPO/IMAGE)


### PR DESCRIPTION
## Summary
- Fixes orchestrator deploy failures that have been occurring since PR #141
- Custom `--service-account` in `gcloud builds submit` requires an explicit log destination — the default bucket is owned by the default Cloud Build SA and isn't accessible
- Adds `options.logging: CLOUD_LOGGING_ONLY` to `cloudbuild.yaml`, routing build logs to Cloud Logging instead of GCS

## Error
```
ERROR: (gcloud.builds.submit) INVALID_ARGUMENT: if 'build.service_account' is specified,
the build must either (a) specify 'build.logs_bucket',
(b) use the REGIONAL_USER_OWNED_BUCKET build.options.default_logs_bucket_behavior option,
or (c) use either CLOUD_LOGGING_ONLY / NONE logging options
```

## Test plan
- [ ] Merge and verify the Deploy Orchestrator workflow passes on main
- [ ] Confirm build logs appear in Cloud Logging console