### PR TITLE
fix(infra): add resource-level actAs binding for orchestrator deploys

### DIFF
--- a/scripts/gcp-setup.sh
+++ b/scripts/gcp-setup.sh
@@ -809,7 +809,17 @@ if gcloud iam service-accounts describe "$GH_SA_ORCHESTRATOR" --project="$PROJEC
     add_iam_binding "serviceAccount:$GH_SA_ORCHESTRATOR" "roles/run.admin" \
         "GitHub Actions SA → Cloud Run Admin (orchestrator deploy)"
     add_iam_binding "serviceAccount:$GH_SA_ORCHESTRATOR" "roles/iam.serviceAccountUser" \
-        "GitHub Actions SA → Service Account User (orchestrator runtime SA)"
+        "GitHub Actions SA → Service Account User (project-level)"
+
+    # Cloud Run's actAs check needs a resource-level binding on the target SA,
+    # not just a project-level serviceAccountUser grant. Without this the deploy
+    # step fails with PERMISSION_DENIED on iam.serviceAccounts.actAs.
+    gcloud iam service-accounts add-iam-policy-binding "$ORCHESTRATOR_RUNTIME_SA" \
+        --project="$PROJECT_ID" \
+        --member="serviceAccount:$GH_SA_ORCHESTRATOR" \
+        --role="roles/iam.serviceAccountUser" \
+        --quiet > /dev/null 2>&1 || true
+    log_success "GitHub Actions SA → actAs orchestrator-runtime SA (resource-level)"
 
     # Allow the deploy workflow to update ORCHESTRATOR_URL secret version.
     # secretVersionManager covers both add and destroy; secretVersionAdder is read-only add.


### PR DESCRIPTION
## Summary
- Fixes the second orchestrator deploy failure: `PERMISSION_DENIED: iam.serviceAccounts.actAs denied on orchestrator-runtime@...`
- The project-level `roles/iam.serviceAccountUser` grant isn't sufficient for Cloud Run's `actAs` check — it needs a **resource-level** binding directly on the target SA
- Adds `gcloud iam service-accounts add-iam-policy-binding` for the GitHub Actions SA on `orchestrator-runtime`

## Required After Merge
```bash
./scripts/gcp-setup.sh
```
The script change alone won't fix CI — the IAM binding must be applied in GCP before the next deploy will succeed.

## Context
This is the second of two deploy fixes:
1. PR #143 — `CLOUD_LOGGING_ONLY` for Cloud Build log destination (merged)
2. **This PR** — resource-level `actAs` for Cloud Run deploy

## Test plan
- [ ] Run `./scripts/gcp-setup.sh` after merge
- [ ] Re-trigger Deploy Orchestrator workflow (manual dispatch or push to main)
- [ ] Verify deploy completes through build → deploy → health check