### PR TITLE
fix(deploy): add speakerAssignment.ts to Dockerfile, remove dead feature flags step

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -213,17 +213,6 @@ jobs:
         run: |
           firebase deploy --only functions --force
 
-      # Initialize feature flags in Firestore (idempotent - preserves existing values)
-      - name: Install Root Dependencies
-        if: github.event_name == 'push' || github.event.inputs.deploy_target != 'rules-only'
-        run: npm ci
-
-      - name: Initialize Feature Flags
-        if: github.event_name == 'push' || github.event.inputs.deploy_target != 'rules-only'
-        run: |
-          echo "Initializing feature flags..."
-          node scripts/init-feature-flags.js ${{ env.FIREBASE_PROJECT_ID }}
-
       - name: Deployment Summary
         if: success()
         run: |

--- a/cloud-run-orchestrator/Dockerfile
+++ b/cloud-run-orchestrator/Dockerfile
@@ -32,8 +32,9 @@ COPY cloud-run-orchestrator/tsconfig.json ./
 RUN node scripts/generate-version.js \
     && mkdir -p src/_functions \
     && cp functions-src/gemini3Pipeline.ts functions-src/alignment.ts \
-       functions-src/audioUtils.ts functions-src/logger.ts \
-       functions-src/types.ts functions-src/firestoreUtils.ts \
+       functions-src/audioUtils.ts functions-src/speakerAssignment.ts \
+       functions-src/logger.ts functions-src/types.ts \
+       functions-src/firestoreUtils.ts \
        src/_functions/ \
     && npx tsc && npx tsc-alias
 


### PR DESCRIPTION
## Summary
- Orchestrator Docker build failed: `speakerAssignment.ts` was added to `copy-functions-modules.sh` but not to the Dockerfile's hardcoded `cp` command
- Firebase deploy failed: `scripts/init-feature-flags.js` was removed with the feature flag system but the workflow still referenced it

## Test plan
- [x] Dockerfile now copies all 7 required modules including speakerAssignment.ts
- [x] Firebase deploy workflow no longer references deleted init-feature-flags.js
- [ ] CI checks pass
- [ ] Both deploy workflows succeed on merge