### PR TITLE
fix(pipeline): remove double-offset on WhisperX chunk word timestamps

### DIFF
--- a/cloud-run-orchestrator/src/pipeline.ts
+++ b/cloud-run-orchestrator/src/pipeline.ts
@@ -472,14 +472,9 @@ export async function runPipeline(
         );
       }
 
-      // Offset words to chunk-local time (Word.start/end are in seconds)
-      const localWords = rawWords.map(w => ({
-        ...w,
-        start: w.start - chunkStartMs / 1000,
-        end: w.end - chunkStartMs / 1000,
-      }));
-
-      const chunkSegments = assignSpeakersToWords(localWords, localGeminiSegs);
+      // WhisperX words are already chunk-local (each chunk is a separate audio
+      // file starting at 0s), so no offset needed here.
+      const chunkSegments = assignSpeakersToWords(rawWords, localGeminiSegs);
 
       console.log(`[Pipeline] ${chunkLabel}: ${chunkSegments.length} segments from ${rawWords.length} words`);
 

--- a/functions/src/newPipeline.ts
+++ b/functions/src/newPipeline.ts
@@ -354,14 +354,9 @@ export async function processWithNewPipeline(
         );
       }
 
-      // Offset words to chunk-local time (Word.start/end are in seconds)
-      const localWords = rawWords.map(w => ({
-        ...w,
-        start: w.start - chunkStartMs / 1000,
-        end: w.end - chunkStartMs / 1000,
-      }));
-
-      const chunkSegments = assignSpeakersToWords(localWords, localGeminiSegs);
+      // WhisperX words are already chunk-local (each chunk is a separate audio
+      // file starting at 0s), so no offset needed here.
+      const chunkSegments = assignSpeakersToWords(rawWords, localGeminiSegs);
 
       log.info(`${chunkLabel}: ${chunkSegments.length} segments from ${rawWords.length} words`, ctx);
 


### PR DESCRIPTION
## Summary
- WhisperX processes each audio chunk as an independent file (timestamps start at 0s)
- Code was subtracting `chunkStartMs` from these already-chunk-local timestamps
- Chunk 2+ words pushed to negative timestamps → zero overlap with Gemini segments → all words nearest-neighbor to one segment → 1 giant segment per chunk
- Chunk 1 unaffected because `chunkStartMs=0`

**Production failure:** 103 aligned segments vs 1195 Gemini segments (91% drop), tripping the 50% quality gate.

## Test plan
- [x] TypeScript compilation passes
- [x] Existing tests pass (chunk 0 only — this bug only manifests on chunk 1+)
- [ ] Upload test on 45-min conversation with multiple chunks