### PR TITLE
fix(pipeline): set alignmentStatus='aligned' to prevent client drift correction

### DIFF
--- a/cloud-run-orchestrator/src/pipeline.ts
+++ b/cloud-run-orchestrator/src/pipeline.ts
@@ -524,6 +524,9 @@ export async function runPipeline(
       topics: assembled.topics,
       people: assembled.people,
       durationMs: assembled.durationMs,
+      // Tells the client that timestamps are WhisperX-accurate and
+      // drift correction should NOT be applied on top of them.
+      alignmentStatus: 'aligned',
       processingPipeline: 'gemini_hybrid',
       pipelineVersion: 'gemini_hybrid',
       updatedAt: FieldValue.serverTimestamp(),

--- a/functions/src/newPipeline.ts
+++ b/functions/src/newPipeline.ts
@@ -416,6 +416,9 @@ export async function processWithNewPipeline(
       topics: assembled.topics,
       people: assembled.people,
       durationMs: assembled.durationMs,
+      // Tells the client that timestamps are WhisperX-accurate and
+      // drift correction should NOT be applied on top of them.
+      alignmentStatus: 'aligned',
       processingPipeline: 'gemini_hybrid',
       pipelineVersion: 'gemini_hybrid',
       updatedAt: FieldValue.serverTimestamp(),


### PR DESCRIPTION
## Summary
- Orchestrator and Cloud Functions pipelines produce WhisperX-accurate timestamps but never wrote `alignmentStatus` to Firestore
- Without it, client drift correction applies scaling on top of accurate timestamps, causing click-to-play to seek ~6s off
- Fixes the issue where clicking a segment at 0:30 would play audio from 0:36

## Test plan
- [x] TypeScript compilation passes
- [x] Tests pass
- [ ] Reprocess a conversation and verify click-to-play seeks to correct position