### PR TITLE
fix(gemini): backfill empty arrays on truncated JSON to prevent crash

### DIFF
--- a/functions/src/gemini3Pipeline.ts
+++ b/functions/src/gemini3Pipeline.ts
@@ -309,7 +309,14 @@ export function parseGeminiJson(text: string): GeminiPipelineResult {
 
     try {
       const result = JSON.parse(repaired) as GeminiPipelineResult;
-      const segCount = (result.segments || []).length;
+      // Truncation likely killed everything after segments — backfill with
+      // empty arrays so downstream code doesn't crash on .length
+      result.speakers = result.speakers || [];
+      result.segments = result.segments || [];
+      result.terms = result.terms || [];
+      result.topics = result.topics || [];
+      result.persons = result.persons || [];
+      const segCount = result.segments.length;
       // Log warning but don't throw — partial data is better than none
       log.warn(`JSON truncation repaired — recovered ${segCount} segments (some tail data lost)`, {
         stage: 'gemini3-parse',
@@ -325,7 +332,13 @@ export function parseGeminiJson(text: string): GeminiPipelineResult {
   if (lastBrace !== -1) {
     try {
       const truncated = cleaned.substring(0, lastBrace + 1);
-      return JSON.parse(truncated) as GeminiPipelineResult;
+      const result = JSON.parse(truncated) as GeminiPipelineResult;
+      result.speakers = result.speakers || [];
+      result.segments = result.segments || [];
+      result.terms = result.terms || [];
+      result.topics = result.topics || [];
+      result.persons = result.persons || [];
+      return result;
     } catch (_) {
       // Give up
     }


### PR DESCRIPTION
## Summary
- When Gemini hits the 65K token ceiling (1453 segments for one conversation), JSON gets truncated mid-segments array
- The repair logic recovers segments but `terms`, `topics`, `persons` are lost (undefined)
- Crash on `result.terms.length` — `Cannot read properties of undefined (reading 'length')`
- Fix: backfill all array fields with empty defaults after any truncation repair path

## Context
This is the 3rd upload test failure. The conversation produced 1453 diarization segments, consuming the entire 65K completion token budget. The no-text prompt's segment count is highly variable (144-1453 across runs).

## Test plan
- [x] TypeScript check passes
- [x] Existing tests pass
- [ ] Reprocess the failing conversation