### PR TITLE
fix(pipeline): preserve WhisperX segment boundaries for readable transcript chunks

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -45,6 +45,14 @@
       "collectionGroup": "_metrics",
       "queryScope": "COLLECTION",
       "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "_metrics",
+      "queryScope": "COLLECTION",
+      "fields": [
         { "fieldPath": "type", "order": "ASCENDING" },
         { "fieldPath": "timestamp", "order": "DESCENDING" }
       ]

--- a/functions/src/__tests__/speakerAssignment.test.ts
+++ b/functions/src/__tests__/speakerAssignment.test.ts
@@ -14,8 +14,8 @@ import { GeminiSegment } from '../gemini3Pipeline';
 // =============================================================================
 
 /** Build a Word. start/end are in SECONDS, as WhisperX produces them. */
-function word(text: string, startSec: number, endSec: number, idx: number): Word {
-  return { word: text, start: startSec, end: endSec, index: idx };
+function word(text: string, startSec: number, endSec: number, idx: number, segBreak?: boolean): Word {
+  return { word: text, start: startSec, end: endSec, index: idx, segmentBreak: segBreak };
 }
 
 /**
@@ -233,7 +233,7 @@ describe('assignSpeakersToWords', () => {
   // All words in one segment → single output segment
   // ---------------------------------------------------------------------------
 
-  it('produces one output segment when all words fall within a single diarization window', () => {
+  it('produces one output segment when all words fall within a single diarization window (no segment breaks)', () => {
     const words = [
       word('one',   0.5, 0.8, 0),
       word('two',   0.9, 1.2, 1),
@@ -251,5 +251,54 @@ describe('assignSpeakersToWords', () => {
     expect(result[0].text).toBe('one two three');
     expect(result[0].startMs).toBe(500);
     expect(result[0].endMs).toBe(1600);
+  });
+
+  // ---------------------------------------------------------------------------
+  // WhisperX segment boundary breaks
+  // ---------------------------------------------------------------------------
+
+  it('breaks same-speaker words at WhisperX segment boundaries', () => {
+    // Same speaker for all words, but a natural pause (segmentBreak) at word 3.
+    // Should produce two segments for readability, both attributed to Alice.
+    const words = [
+      word('first',    0.0, 0.3, 0, true),   // start of WhisperX segment 1
+      word('sentence', 0.3, 0.7, 1),
+      word('here',     0.7, 1.0, 2),
+      word('second',   2.0, 2.3, 3, true),   // start of WhisperX segment 2
+      word('sentence', 2.3, 2.6, 4),
+      word('there',    2.6, 3.0, 5),
+    ];
+    const segments = [seg('Alice', 0, 10000)];
+
+    const result = assignSpeakersToWords(words, segments);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].speakerId).toBe('Alice');
+    expect(result[0].text).toBe('first sentence here');
+    expect(result[1].speakerId).toBe('Alice');
+    expect(result[1].text).toBe('second sentence there');
+  });
+
+  it('breaks on both speaker change and segment boundary', () => {
+    // Alice speaks two WhisperX segments, then Bob speaks one.
+    const words = [
+      word('alice1', 0.0, 0.5, 0, true),
+      word('alice2', 0.5, 1.0, 1),
+      word('alice3', 2.0, 2.5, 2, true),   // segment break, same speaker
+      word('alice4', 2.5, 3.0, 3),
+      word('bob1',   5.0, 5.5, 4, true),   // segment break + speaker change
+      word('bob2',   5.5, 6.0, 5),
+    ];
+    const segments = [
+      seg('Alice', 0, 4000),
+      seg('Bob', 4000, 8000),
+    ];
+
+    const result = assignSpeakersToWords(words, segments);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({ speakerId: 'Alice', text: 'alice1 alice2' });
+    expect(result[1]).toMatchObject({ speakerId: 'Alice', text: 'alice3 alice4' });
+    expect(result[2]).toMatchObject({ speakerId: 'Bob', text: 'bob1 bob2' });
   });
 });

--- a/functions/src/alignment.ts
+++ b/functions/src/alignment.ts
@@ -85,6 +85,8 @@ export interface Word {
   end: number;    // seconds
   index: number;
   score?: number; // WhisperX confidence score [0-1], if available
+  /** True when this word starts a new WhisperX segment (natural pause boundary) */
+  segmentBreak?: boolean;
 }
 
 export interface Segment {
@@ -1458,6 +1460,7 @@ async function getWhisperxTimestamps(
             const segObj = segment as Record<string, unknown>;
             if (Array.isArray(segObj.words)) {
               segmentsWithWords++;
+              let isFirstWordInSegment = true;
               for (const w of segObj.words) {
                 if (typeof w === 'object' && w !== null) {
                   const wordObj = w as Record<string, unknown>;
@@ -1465,8 +1468,12 @@ async function getWhisperxTimestamps(
                     word: typeof wordObj.word === 'string' ? wordObj.word : '',
                     start: typeof wordObj.start === 'number' ? wordObj.start : 0.0,
                     end: typeof wordObj.end === 'number' ? wordObj.end : 0.0,
-                    index: wordIdx
+                    index: wordIdx,
+                    // Mark the first word in each WhisperX segment so downstream
+                    // grouping can break here (preserves natural pause boundaries)
+                    segmentBreak: isFirstWordInSegment,
                   });
+                  isFirstWordInSegment = false;
                   wordIdx++;
                 }
               }

--- a/functions/src/speakerAssignment.ts
+++ b/functions/src/speakerAssignment.ts
@@ -86,16 +86,20 @@ export function assignSpeakersToWords(words: Word[], segments: GeminiSegment[]):
     return nearestSeg.speaker;
   });
 
-  // Phase 2: group consecutive same-speaker words into segments.
-  // Walk the array, flush a segment whenever the speaker changes.
+  // Phase 2: group words into segments, breaking on:
+  //   - Speaker change (different Gemini diarization window)
+  //   - WhisperX segment boundary (natural pause in speech)
+  // This preserves the readable sentence-level chunking that WhisperX
+  // detects from pauses, while still assigning the correct speaker.
   const result: AlignedSegment[] = [];
   let groupStart = 0;
 
   for (let i = 1; i <= words.length; i++) {
-    // Flush on speaker change or at the end of the array.
-    const speakerChanged = i === words.length || wordSpeakers[i] !== wordSpeakers[groupStart];
+    const isEnd = i === words.length;
+    const speakerChanged = !isEnd && wordSpeakers[i] !== wordSpeakers[groupStart];
+    const segmentBoundary = !isEnd && words[i].segmentBreak === true;
 
-    if (speakerChanged) {
+    if (isEnd || speakerChanged || segmentBoundary) {
       const groupWords = words.slice(groupStart, i);
       result.push({
         speakerId: wordSpeakers[groupStart],


### PR DESCRIPTION
## Summary
- Speaker assignment only broke on speaker change, producing monolithic text blocks
- Now also breaks at WhisperX segment boundaries (natural pauses in speech)
- Same speaker can have consecutive segments again (matching old pipeline behavior)
- Adds missing Firestore composite index for `_metrics` (userId ASC, timestamp ASC)

## Root cause
The old HARDY pipeline preserved WhisperX's segment structure. The new no-text pipeline flattened all words into a single array and only broke on speaker change, losing natural sentence/pause boundaries. A 30-second speaker turn became one wall of text instead of 3-4 readable sentences.

## Test plan
- [x] 14 unit tests pass (2 new tests for segmentBreak behavior)
- [x] TypeScript compilation passes
- [x] Backward compatible (words without segmentBreak still merge normally)
- [ ] Upload test to verify natural chunking restored