### PR TITLE
feat(gemini): enable thinking budget for better speaker diarization

### DIFF
--- a/functions/src/gemini3Pipeline.ts
+++ b/functions/src/gemini3Pipeline.ts
@@ -824,7 +824,10 @@ export async function processWithGemini3Flash(
         config: {
           temperature: 0.1,
           maxOutputTokens: 65536,
-          thinkingConfig: { thinkingBudget: 0 },
+          // Let the model reason about speaker identity before committing.
+          // 4096 tokens is enough for "Speaker 2 sounds like the person
+          // addressed as Sam at 3:42" type reasoning without blowing the budget.
+          thinkingConfig: { thinkingBudget: 4096 },
           responseMimeType: 'application/json',
           responseSchema: RESPONSE_SCHEMA,
         },


### PR DESCRIPTION
## Summary
- Enable `thinkingBudget: 4096` (was `0` — completely disabled)
- Lets Gemini reason about speaker identity, name-to-voice mapping, and turn boundaries before producing structured output
- Single parameter change, no architecture changes

## Context
Current diarization quality is poor: wrong speaker names (Sam ↔ Adam swap), missed speaker changes, inconsistent segment counts (144-1453 across runs). With thinking disabled, the model was forced to produce complex multi-speaker diarization without any internal reasoning.

## Test plan
- [ ] Upload same test conversation, compare speaker accuracy vs previous runs
- [ ] Check if terms/topics come back populated
- [ ] Monitor token usage (thinking tokens are separate from output tokens)