### PR TITLE
fix(pipeline): re-encode audio chunks to CBR for accurate seek timestamps

### DIFF
--- a/cloud-run-orchestrator/src/pipeline.ts
+++ b/cloud-run-orchestrator/src/pipeline.ts
@@ -295,11 +295,19 @@ async function splitIntoChunks(
     const chunkEndSec = Math.min((i + 1) * CHUNK_SEC, durationSec);
     const chunkPath = path.join(os.tmpdir(), `orchestrator-chunk-${i}-${Date.now()}.mp3`);
 
+    // Re-encode instead of stream copy. -c copy preserves VBR encoding
+    // and can't seek to exact positions (nearest packet boundary only).
+    // Re-encoding guarantees the chunk starts at exactly chunkStartSec,
+    // and produces CBR output that WhisperX timestamps align to.
+    // Matches the old chunked pipeline's proven ffmpeg args.
     await execFileAsync(ffmpegPath, [
       '-y', '-i', mp3Path,
       '-ss', String(chunkStartSec),
       '-t', String(chunkEndSec - chunkStartSec),
-      '-c', 'copy',
+      '-acodec', 'libmp3lame',
+      '-ar', '16000',    // 16kHz — optimal for speech/WhisperX
+      '-ac', '1',         // mono — fine for speech, halves size
+      '-ab', '64k',       // CBR 64kbps — browser seek is accurate
       chunkPath,
     ], { timeout: 300_000 });
 

--- a/functions/src/newPipeline.ts
+++ b/functions/src/newPipeline.ts
@@ -167,13 +167,17 @@ async function splitIntoChunks(
     const chunkEndSec = Math.min((i + 1) * CHUNK_SEC, durationSec);
     const chunkPath = path.join(os.tmpdir(), `newpipeline-chunk-${i}-${Date.now()}.mp3`);
 
-    // Stream copy is fine here — WhisperX is fine with VBR seeking artifacts
-    // and we want speed over perfect boundaries
+    // Re-encode instead of stream copy — -c copy can't seek to exact
+    // positions on VBR MP3, causing timestamp drift in downstream output.
+    // CBR 16kHz mono matches the old pipeline's proven ffmpeg args.
     await execFileAsync(ffmpegPath, [
       '-y', '-i', mp3Path,
       '-ss', String(chunkStartSec),
       '-t', String(chunkEndSec - chunkStartSec),
-      '-c', 'copy',
+      '-acodec', 'libmp3lame',
+      '-ar', '16000',
+      '-ac', '1',
+      '-ab', '64k',
       chunkPath,
     ], { timeout: 300_000 });
 


### PR DESCRIPTION
## Summary
- Changed ffmpeg chunk extraction from `-c copy` (stream copy) to `-acodec libmp3lame -ar 16000 -ac 1 -ab 64k` (re-encode to CBR)
- Stream copy can't seek to exact positions on VBR MP3 — chunks start at nearest packet boundary, not requested timestamp
- Caused 6-10s seek offset in browser when clicking segments
- Matches the old pipeline's proven ffmpeg args that had perfect seek accuracy

## Root cause
Found by comparing git history: old pipeline (`chunking.ts` at v2.14.0) used `-acodec libmp3lame` for chunks. New pipeline used `-c copy` for speed but sacrificed timestamp precision.

## Test plan
- [x] TypeScript compilation passes
- [x] Tests pass
- [ ] Upload test conversation, verify click-to-seek accuracy across all chunks