### PR TITLE
fix(pipeline): create CBR playback audio for accurate browser seeking

### DIFF
--- a/cloud-run-orchestrator/src/pipeline.ts
+++ b/cloud-run-orchestrator/src/pipeline.ts
@@ -396,13 +396,40 @@ export async function runPipeline(
     checkTimeout('after Gemini analysis');
 
     // =======================================================================
-    // Step 2: Download MP3 for WhisperX chunking
+    // Step 2: Download MP3 for WhisperX chunking + create playback file
     // =======================================================================
     mp3Path = await downloadMp3(audioStoragePath, conversationId);
     const durationSec = await getAudioDuration(mp3Path);
     const audioDurationMs = Math.round(durationSec * 1000);
 
     console.log(`[Pipeline] Audio: ${(audioDurationMs / 1000 / 60).toFixed(1)} min`);
+
+    // Re-encode the full audio to CBR MP3 for browser playback.
+    // VBR MP3 files have wildly inaccurate seek-by-byte-offset in browsers,
+    // causing click-to-play to land 5-10s away from the target. CBR with
+    // a proper Xing header fixes this. ~2-3s encoding time is worth it.
+    const ffmpegPath = await getFfmpegPath();
+    const playbackPath = path.join(os.tmpdir(), `playback-${conversationId}-${Date.now()}.mp3`);
+    await execFileAsync(ffmpegPath, [
+      '-y', '-i', mp3Path,
+      '-acodec', 'libmp3lame',
+      '-ab', '128k',     // CBR 128kbps — good quality for playback
+      '-ar', '44100',    // Keep original sample rate for playback quality
+      '-ac', '2',        // Keep stereo for playback
+      playbackPath,
+    ], { timeout: 300_000 });
+
+    // Upload playback file alongside the original
+    const playbackStoragePath = audioStoragePath.replace(/\.[^.]+$/, '_playback.mp3');
+    const bucketName = process.env.FIREBASE_STORAGE_BUCKET!;
+    const bucket = getStorage().bucket(bucketName);
+    await bucket.upload(playbackPath, {
+      destination: playbackStoragePath,
+      metadata: { contentType: 'audio/mpeg' },
+    });
+    // Clean up temp file immediately
+    try { fs.unlinkSync(playbackPath); } catch { /* best-effort */ }
+    console.log(`[Pipeline] Playback CBR MP3 uploaded: ${playbackStoragePath}`);
 
     // =======================================================================
     // Step 3: WhisperX alignment — chunk by chunk
@@ -535,6 +562,8 @@ export async function runPipeline(
       // Tells the client that timestamps are WhisperX-accurate and
       // drift correction should NOT be applied on top of them.
       alignmentStatus: 'aligned',
+      // CBR playback file for accurate browser seeking
+      playbackAudioPath: playbackStoragePath,
       processingPipeline: 'gemini_hybrid',
       pipelineVersion: 'gemini_hybrid',
       updatedAt: FieldValue.serverTimestamp(),

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -129,7 +129,8 @@ export interface Conversation {
   updatedAt: string; // For sync conflict resolution and tracking
   durationMs: number;
   audioUrl?: string; // Ephemeral signed URL for audio playback (not stored in Firestore)
-  audioStoragePath?: string; // Firebase Storage path for audio file
+  audioStoragePath?: string; // Firebase Storage path for original uploaded audio
+  playbackAudioPath?: string; // CBR re-encoded MP3 for accurate browser seeking
   status: 'processing' | 'chunking' | 'merging' | 'reprocessing' | 'needs_review' | 'complete' | 'failed' | 'aborted';
   abortRequested?: boolean;  // Set to true to request abort, Cloud Function checks this
   speakers: Record<string, Speaker>;

--- a/src/contexts/ConversationContext.tsx
+++ b/src/contexts/ConversationContext.tsx
@@ -69,8 +69,8 @@ export const ConversationProvider: React.FC<{ children: ReactNode }> = ({ childr
       return conversation.audioUrl;
     }
 
-    // Get the URL from Storage
-    const storagePath = conversation.audioStoragePath;
+    // Prefer CBR playback file (accurate browser seeking) over original upload
+    const storagePath = conversation.playbackAudioPath || conversation.audioStoragePath;
     if (!storagePath) return null;
 
     // Check cache first


### PR DESCRIPTION
## Summary
- Pipeline re-encodes full audio to CBR 128kbps MP3 and uploads as `*_playback.mp3`
- UI prefers `playbackAudioPath` over `audioStoragePath` for audio playback
- Falls back to original for older conversations without playback file

## Root cause
Browser MP3 seeking uses byte-offset estimation: `byte = (time/duration) * filesize`. This is only accurate for CBR (constant bit rate) files. VBR (variable bit rate) MP3 files produce non-linear errors — clicking 0:23 works fine, clicking 0:27 jumps to 0:34. Sequential playback is unaffected because the decoder counts samples.

## Test plan
- [x] TypeScript compilation passes
- [x] Tests pass
- [ ] Upload test conversation, verify click-to-seek accuracy at 0:23, 0:27, 10:00+, 40:00+