### PR TITLE
fix(pipeline): skip playback trigger + raise Gemini temperature to 0.3

### DIFF
--- a/functions/src/gemini3Pipeline.ts
+++ b/functions/src/gemini3Pipeline.ts
@@ -822,7 +822,7 @@ export async function processWithGemini3Flash(
           ],
         }],
         config: {
-          temperature: 0.1,
+          temperature: 0.3,
           maxOutputTokens: 65536,
           // Let the model reason about speaker identity before committing.
           // 4096 tokens is enough for "Speaker 2 sounds like the person

--- a/functions/src/transcribe.ts
+++ b/functions/src/transcribe.ts
@@ -175,6 +175,12 @@ export const transcribeAudio = onObjectFinalized(
       return;
     }
 
+    // Skip playback files created by the pipeline (CBR re-encode for browser seeking)
+    if (filePath.includes('_playback')) {
+      console.debug('[Transcribe] Skipping playback file:', filePath);
+      return;
+    }
+
     // Parse path: audio/{userId}/{conversationId}.{ext}
     const pathParts = filePath.split('/');
     if (pathParts.length !== 3) {


### PR DESCRIPTION
## Summary
- Storage trigger now skips `*_playback.mp3` files (fixes "conversation missing userId" warning)
- Gemini temperature raised from 0.1 to 0.3 for better speaker voice differentiation

## Test plan
- [x] TypeScript + tests pass
- [ ] Upload test conversation, compare diarization quality vs previous runs
- [ ] Verify no more "missing userId" warnings in logs