### PR TITLE
feat: gemini-2.5-pro + hallucination filter + progress bar fix

### DIFF
--- a/functions/src/gemini3Pipeline.ts
+++ b/functions/src/gemini3Pipeline.ts
@@ -148,7 +148,7 @@ export class GeminiPipelineError extends Error {
 // Configuration
 // =============================================================================
 
-const DEFAULT_MODEL = 'gemini-3-flash-preview';
+const DEFAULT_MODEL = 'gemini-2.5-pro-preview-05-06';
 const MAX_PROCESSING_WAIT_ATTEMPTS = 60; // 60 * 2s = 2 minutes max wait
 const PROCESSING_POLL_INTERVAL_MS = 2000;
 

--- a/functions/src/speakerAssignment.ts
+++ b/functions/src/speakerAssignment.ts
@@ -37,11 +37,44 @@ function overlapMs(wordStartMs: number, wordEndMs: number, seg: GeminiSegment): 
  * Unit note: Word.start/end are seconds (float). GeminiSegment times are ms.
  * Convert words to ms before any comparison — don't get clever and skip it.
  */
+/**
+ * Filter out WhisperX hallucination loops. When the model hits noisy audio
+ * it sometimes gets stuck repeating the same word ("uh, uh, uh, uh...")
+ * dozens of times. Collapse runs of 3+ identical words down to 1.
+ */
+function deduplicateHallucinatedWords(words: Word[]): Word[] {
+  if (words.length < 3) return words;
+
+  const result: Word[] = [words[0]];
+  let runLength = 1;
+
+  for (let i = 1; i < words.length; i++) {
+    const same = words[i].word.trim().toLowerCase() === words[i - 1].word.trim().toLowerCase();
+    if (same) {
+      runLength++;
+      // Keep the first 2 of any run, drop the rest
+      if (runLength <= 2) result.push(words[i]);
+    } else {
+      runLength = 1;
+      result.push(words[i]);
+    }
+  }
+
+  const dropped = words.length - result.length;
+  if (dropped > 0) {
+    console.log(`[SpeakerAssignment] Filtered ${dropped} hallucinated repeat words`);
+  }
+  return result;
+}
+
 export function assignSpeakersToWords(words: Word[], segments: GeminiSegment[]): AlignedSegment[] {
   // Nothing to do — bail early to keep the rest of the logic simple.
   if (words.length === 0 || segments.length === 0) {
     return [];
   }
+
+  // Phase 0: strip WhisperX hallucination loops before any processing.
+  words = deduplicateHallucinatedWords(words);
 
   // Phase 1: assign each word a speaker label.
   const wordSpeakers: string[] = words.map((word) => {


### PR DESCRIPTION
## Summary
- Switch model from `gemini-3-flash-preview` to `gemini-2.5-pro-preview-05-06` for better diarization
- Filter WhisperX hallucination loops (3+ consecutive identical words collapsed to max 2)
- Fix progress bar percentages for WhisperX-first pipeline order (15%→55%→85%→95%→100%)

## Test plan
- [ ] Upload test conversation, compare diarization quality with 2.5 Pro
- [ ] Verify no more "uh, uh, uh..." walls of text
- [ ] Verify progress bar advances smoothly