### PR TITLE
fix(gemini): correct model ID to gemini-2.5-pro

### DIFF
--- a/functions/src/gemini3Pipeline.ts
+++ b/functions/src/gemini3Pipeline.ts
@@ -148,7 +148,7 @@ export class GeminiPipelineError extends Error {
 // Configuration
 // =============================================================================
 
-const DEFAULT_MODEL = 'gemini-2.5-pro-preview-05-06';
+const DEFAULT_MODEL = 'gemini-2.5-pro';
 const MAX_PROCESSING_WAIT_ATTEMPTS = 60; // 60 * 2s = 2 minutes max wait
 const PROCESSING_POLL_INTERVAL_MS = 2000;
 


### PR DESCRIPTION
Model ID was wrong — preview suffix not valid for generateContent.