### PR TITLE
fix(gemini): switch to gemini-2.5-flash — Pro times out on large audio

### DIFF
--- a/functions/src/gemini3Pipeline.ts
+++ b/functions/src/gemini3Pipeline.ts
@@ -148,7 +148,7 @@ export class GeminiPipelineError extends Error {
 // Configuration
 // =============================================================================
 
-const DEFAULT_MODEL = 'gemini-2.5-pro';
+const DEFAULT_MODEL = 'gemini-2.5-flash';
 const MAX_PROCESSING_WAIT_ATTEMPTS = 60; // 60 * 2s = 2 minutes max wait
 const PROCESSING_POLL_INTERVAL_MS = 2000;
 


### PR DESCRIPTION
## Summary
gemini-2.5-pro timed out (DEADLINE_EXCEEDED / 504) after 5 minutes on 82.5MB WAV + 41K chars transcript. Switching to gemini-2.5-flash which the old pipeline used successfully and handles large inputs better.

## Test plan
- [ ] Upload test conversation, verify no timeout
- [ ] Compare diarization quality with flash + transcript context