### PR TITLE
fix(gemini): increase SDK timeout — 5min was too short for flash + transcript

### DIFF
--- a/functions/src/gemini3Pipeline.ts
+++ b/functions/src/gemini3Pipeline.ts
@@ -771,7 +771,7 @@ export async function processWithGemini3Flash(
 
     ai = new GoogleGenAI({
       apiKey,
-      httpOptions: { timeout: 300_000 }, // 5 minute budget — hybrid orchestrator enforces this limit
+      httpOptions: { timeout: 600_000 }, // 10 min per Gemini call — orchestrator's 900s budget is the real ceiling
     });
 
     // Step 1: Download audio from Storage


### PR DESCRIPTION
## Summary
Both gemini-2.5-pro and gemini-2.5-flash timed out with DEADLINE_EXCEEDED after exactly 5 minutes — that's our SDK `httpOptions.timeout: 300_000`, not a Google-side timeout. 

The 82.5MB WAV + 41K chars transcript context + thinking budget is too much for a 5-minute SDK timeout. Increased to 10 minutes — the orchestrator's 900s pipeline timeout is the real safety net.

## Test plan
- [ ] Upload test conversation, verify no timeout