### PR TITLE
fix(diarization): truncated transcript context + word trimming

### DIFF
--- a/functions/src/alignment.ts
+++ b/functions/src/alignment.ts
@@ -1464,8 +1464,11 @@ async function getWhisperxTimestamps(
               for (const w of segObj.words) {
                 if (typeof w === 'object' && w !== null) {
                   const wordObj = w as Record<string, unknown>;
+                  const wordText = typeof wordObj.word === 'string' ? wordObj.word.trim() : '';
+                  // Skip empty words (WhisperX sometimes emits whitespace-only entries)
+                  if (!wordText) continue;
                   words.push({
-                    word: typeof wordObj.word === 'string' ? wordObj.word : '',
+                    word: wordText,
                     start: typeof wordObj.start === 'number' ? wordObj.start : 0.0,
                     end: typeof wordObj.end === 'number' ? wordObj.end : 0.0,
                     index: wordIdx,

--- a/functions/src/gemini3Pipeline.ts
+++ b/functions/src/gemini3Pipeline.ts
@@ -357,6 +357,26 @@ export function parseGeminiJson(text: string): GeminiPipelineResult {
 // =============================================================================
 
 // =============================================================================
+// =============================================================================
+// Transcript truncation for diarization context
+// =============================================================================
+// Full transcripts (40K+ chars) cause fetch failures when combined with audio.
+// Truncating to first N + last M chars captures speaker introductions and names
+// without overwhelming the request. The ellipsis helps Gemini understand it's partial.
+function truncateForDiarization(
+  text: string | undefined,
+  headChars: number,
+  tailChars: number
+): string | undefined {
+  if (!text) return undefined;
+  const totalLimit = headChars + tailChars;
+  if (text.length <= totalLimit) return text;
+
+  const head = text.slice(0, headChars);
+  const tail = text.slice(-tailChars);
+  return `${head}\n\n[... transcript truncated for context — ${text.length - totalLimit} chars omitted ...]\n\n${tail}`;
+}
+
 // Call 1: Diarization — who spoke when
 // =============================================================================
 // The PoC showed that asking Gemini to GENERATE transcript text hurts diarization.
@@ -872,10 +892,13 @@ export async function processWithGemini3Flash(
     // Gets the full output budget — no competition with content extraction.
     // -----------------------------------------------------------------------
     const diarStart = Date.now();
-    // Diarization: audio-only. Transcript context causes failures even with
-    // gemini-3-flash-preview — the 41K chars overwhelm the audio+text combo.
-    // Content extraction still gets transcript context (works there).
-    const diarResponse = await callGemini(buildDiarizationPrompt(), DIARIZATION_SCHEMA, 'diarization', 4096);
+    // Truncate transcript for diarization context — full 41K chars causes fetch
+    // failures, but first 8K + last 2K captures intros/names without overload.
+    const truncatedTranscript = truncateForDiarization(transcriptText, 8000, 2000);
+    if (truncatedTranscript && transcriptText) {
+      log.info(`Diarization context: ${truncatedTranscript.length} chars (truncated from ${transcriptText.length})`, ctx);
+    }
+    const diarResponse = await callGemini(buildDiarizationPrompt(truncatedTranscript), DIARIZATION_SCHEMA, 'diarization', 4096);
     const diarDuration = Date.now() - diarStart;
     const diarUsage = diarResponse.usageMetadata;
 

--- a/functions/src/gemini3Pipeline.ts
+++ b/functions/src/gemini3Pipeline.ts
@@ -872,9 +872,10 @@ export async function processWithGemini3Flash(
     // Gets the full output budget — no competition with content extraction.
     // -----------------------------------------------------------------------
     const diarStart = Date.now();
-    // Diarization with transcript context: gemini-3-flash-preview handles the
-    // full transcript without the timeout issues that plagued 2.5-flash.
-    const diarResponse = await callGemini(buildDiarizationPrompt(transcriptText), DIARIZATION_SCHEMA, 'diarization', 4096);
+    // Diarization: audio-only. Transcript context causes failures even with
+    // gemini-3-flash-preview — the 41K chars overwhelm the audio+text combo.
+    // Content extraction still gets transcript context (works there).
+    const diarResponse = await callGemini(buildDiarizationPrompt(), DIARIZATION_SCHEMA, 'diarization', 4096);
     const diarDuration = Date.now() - diarStart;
     const diarUsage = diarResponse.usageMetadata;
 


### PR DESCRIPTION
## Summary
- **Truncated transcript context** — Send first 8K + last 2K chars to diarization instead of nothing (full 41K caused fetch failures). Captures speaker name introductions without overloading the request.
- **WhisperX word trimming** — Words sometimes have leading spaces; now trimmed to prevent double spaces in exports.
- **Hotfix** — Disabled full transcript context that was causing fetch failures.

## Why
The 46% speaker accuracy on the 6-speaker commercial analytics benchmark is partly due to Gemini not having transcript context (speaker names like "Adam and Sam, JJ and Chris" help identify voices). This adds truncated context as a middle ground.

## Test plan
- [ ] Deploy
- [ ] Reprocess c_1775840907923 (commercial analytics)
- [ ] Run benchmark against ground truth
- [ ] Verify no double spaces in export